### PR TITLE
feat: v0.4 — full displayTimezone support across all pickers

### DIFF
--- a/.changeset/core-sideeffects.md
+++ b/.changeset/core-sideeffects.md
@@ -1,0 +1,5 @@
+---
+"@kalyx/core": patch
+---
+
+perf: mark `@kalyx/core` as `sideEffects: false` so downstream bundlers can tree-shake unused exports. Safe because the package is purely functional (no module-level side effects).

--- a/.changeset/timezone-v04.md
+++ b/.changeset/timezone-v04.md
@@ -1,0 +1,18 @@
+---
+"@kalyx/core": minor
+"@kalyx/react": minor
+---
+
+feat: full `displayTimezone` support across all pickers (v0.4)
+
+All four pickers (`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`) and their corresponding hooks (`useDatePicker`, `useRangePicker`, `useTimePicker`) now accept a `displayTimezone` prop/option.
+
+When set, the value stored via `onChange` is the **civil midnight of the selected day in the target timezone** (in UTC-ISO form), eliminating the classic "day off by one" bug that affects picker libraries bound to `new Date()`. Input formatting, calendar highlighting, and the time-of-day controls all follow the display timezone — including DST-aware offsets for zones like `America/New_York` and `Europe/London`.
+
+`DateFnsAdapter` now honors the `timezone` argument on `format`, `isSameDay`, `startOfDay`, and `today` (previously declared-but-ignored). Core also exposes new helpers:
+
+- `civilMidnightFromUtcDay(iso, tz)`
+- `getTimeInTimezone(iso, tz)`
+- `setTimeInTimezone(iso, partial, tz)`
+
+No breaking changes — omitting `displayTimezone` keeps the existing UTC semantics.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,4 @@
 - [ ] Bundle size checked (`pnpm check-bundle` ≤ 12KB)
 - [ ] Changeset added (if public API changed)
 - [ ] New public APIs have JSDoc comments
+- [ ] If the change touches date/time math, `displayTimezone` behavior verified (format, onChange, DST-safe)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -83,6 +83,9 @@ jobs:
     name: Bundle Size (≤12KB gzip)
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: dist 다운로드

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ apps/
 
 - **TypeScript strict** — `any` is forbidden (`@typescript-eslint/no-explicit-any: error`).
 - **ISO 8601 UTC strings** — All date values are `string` (e.g., `"2026-01-15T00:00:00.000Z"`). Never use native `Date` objects as component values.
+- **Timezone awareness** — For display-zone-specific behavior, route through the `displayTimezone` prop (v0.4+) or `@kalyx/core` helpers (`civilMidnightFromUtcDay`, `getTimeInTimezone`, `setTimeInTimezone`). Avoid ad-hoc `new Date()` math in features.
 - **Composition API** — Sub-components via Dot Notation (`DatePicker.Input`, `DatePicker.Calendar`), not props explosion.
 - **SSR safe** — No `window`/`document` outside `useEffect`. Use `useId()` for IDs.
 - **Headless** — Zero CSS. Styling is done via `classNames` prop and `data-*` attributes.

--- a/README.ko.md
+++ b/README.ko.md
@@ -56,6 +56,7 @@ import { DatePicker } from '@kalyx/react';
 - **Headless** — Tailwind, shadcn/ui, Chakra, 어떤 CSS와도 짝 지을 수 있음.
 - **SSR 안전** — Next.js App Router에서 검증. `useId` 기반 안정 ID.
 - **ISO 8601 UTC 문자열** — `Date` 객체의 함정 없음.
+- **타임존 인지** — v0.4부터 `displayTimezone` prop으로 IANA 타임존과 DST를 안전하게 처리. UTC 저장 계약은 그대로.
 - **접근성** — WAI-ARIA, 풀 키보드, axe 자동 통과.
 - **트리셰이킹** — 렌더하는 만큼만 비용.
 - **TypeScript 우선** — strict, `any` 없음.

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 [문서](https://kalyx-docs.vercel.app/ko) · [English Docs](https://kalyx-docs.vercel.app) · [npm](https://www.npmjs.com/package/@kalyx/react) · [GitHub](https://github.com/jiji-hoon96/kalyx)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-9.2KB-brightgreen)](#번들-크기)
+[![Bundle](https://img.shields.io/badge/gzip-9.73KB-brightgreen)](#번들-크기)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -41,13 +41,18 @@ import { DatePicker } from '@kalyx/react';
 
 2026년 React 생태계는 양극단만 있습니다 — Kalyx가 그 공백을 채웁니다.
 
-| 라이브러리 | Headless | Input | TimePicker | RangePicker | SSR | 번들 (gzip) |
-| --- | --- | --- | --- | --- | --- | --- |
-| react-day-picker | ✅ | ❌ | ❌ | ✅ | ✅ | ~22 KB |
-| react-datepicker | ❌ (CSS 필수) | ✅ | ✅ | ✅ | △ | ~60 KB |
-| Ark UI | ✅ | ✅ | ❌ (제거됨) | ✅ | ✅ | 큼 |
-| React Aria | ✅ | ✅ | ✅ | ✅ | ✅ | 큼 |
-| **Kalyx** | ✅ | ✅ | ✅ | ✅ | ✅ | **~9 KB** |
+bundlephobia 기준 (2026년 4월). 각주는 표 아래를 참조.
+
+| 라이브러리 | 버전 | 번들 (min+gzip) | Headless | Input | TimePicker | DateTimePicker | RangePicker | 값 계약 | Timezone |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| react-day-picker | 9.14 | 2.4 KB¹ | ✅ | ❌ BYO | ❌ | ❌ | ✅ | `Date` | ⚠️ |
+| react-datepicker | 9.1 | 44 KB | ❌ (CSS 필수) | ✅ | ⚠️ prop | ⚠️ 결합형 | ✅ 분리형 | `Date` | ⚠️ |
+| Ark UI | 5.36 | 265 KB² | ✅ | ✅ | ❌ (제거됨) | ❌ | ✅ | `Date` | ⚠️ |
+| React Aria | 1.17 | 247 KB² | ✅ | ✅ | ✅ | ✅ | ✅ | `CalendarDate` | ✅ |
+| **Kalyx** | 0.3 | **9.73 KB** | ✅ | ✅ | ✅ 전용 | ✅ 전용 | ✅ 전용 | ISO 8601 UTC | ✅ `displayTimezone` |
+
+1. react-day-picker는 캘린더 그리드만 제공 — Kalyx와 동일한 스콥을 맞추려면 Input·Popover·TimePicker를 직접 조합해야 함. 2.4 KB는 기본 엔트리 기준.
+2. `@ark-ui/react`와 `react-aria-components`는 40+ 컴포넌트를 포함한 모노리스 패키지 — 트리셰이킹 시 더 작아지지만 `@internationalized/date` 등 생태계를 통째로 끌어들임.
 
 ## 특징
 
@@ -143,10 +148,10 @@ import { useDatePicker, useRangePicker, useTimePicker } from '@kalyx/react';
 ## 번들 크기
 
 ```
-packages/react/dist/index.js  →  gzip 9.2 KB
+packages/react/dist/index.js  →  gzip 9.73 KB  (v0.4 기준)
 ```
 
-CI에서 `< 12 KB`로 강제. 임포트 단위 트리셰이킹 — `TimePicker`만 쓰면 DatePicker 코드가 사라집니다.
+CI에서 `< 12 KB`로 강제. `@kalyx/core`에 `sideEffects: false`가 설정돼 있어 임포트 단위 트리셰이킹이 작동합니다 — `TimePicker`만 쓰면 DatePicker 코드가 사라집니다.
 
 ## 지원 환경
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [Docs](https://kalyx-docs.vercel.app) · [한국어 문서](https://kalyx-docs.vercel.app/ko) · [npm](https://www.npmjs.com/package/@kalyx/react) · [GitHub](https://github.com/jiji-hoon96/kalyx)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-9.2KB-brightgreen)](#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-9.73KB-brightgreen)](#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -41,20 +41,30 @@ import { DatePicker } from '@kalyx/react';
 
 The React ecosystem in 2026 has two extremes — Kalyx fills the gap.
 
+Numbers come from bundlephobia (April 2026). See [notes below the table](#footnotes).
+
 | | Kalyx | react-datepicker | react-day-picker | Ark UI | React Aria |
 |---|---|---|---|---|---|
-| Bundle (gzip) | **9.4 KB** | ~40-60 KB | ~22 KB | ~45 KB (full) | Large |
-| Headless (Zero CSS) | ✅ | ❌ CSS required | ✅ | ✅ | ✅ |
+| Version measured | 0.3.0 | 9.1.0 | 9.14.0 | 5.36.1 | 1.17.0 |
+| Bundle (min+gzip) | **9.73 KB** | 44 KB | 2.4 KB¹ | 265 KB² | 247 KB² |
 | DatePicker | ✅ | ✅ | ✅ | ✅ | ✅ |
-| RangePicker | ✅ | ✅ | ✅ | ✅ | ✅ |
-| TimePicker | ✅ | ✅ | ❌ | ❌ (removed) | ✅ |
-| DateTimePicker | ✅ | ✅ | ❌ | ❌ | ✅ |
-| Composition API | ✅ | ❌ 100+ props | ❌ | ✅ | ✅ |
+| RangePicker | ✅ dedicated | ✅ two-picker pattern | ✅ `mode="range"` | ✅ | ✅ |
+| TimePicker | ✅ dedicated | ⚠️ `showTimeSelect` prop | ❌ | ❌ (removed) | ✅ |
+| DateTimePicker | ✅ dedicated | ⚠️ combined picker | ❌ | ❌ | ✅ |
+| Text Input included | ✅ | ✅ | ❌ BYO | ✅ | ✅ |
+| Headless (Zero CSS) | ✅ | ❌ CSS required | ✅ | ✅ | ✅ |
+| Composition API | ✅ dot notation | ❌ 100+ props | ✅ | ✅ | ✅ |
 | SSR Safe | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 | TypeScript Strict | ✅ | ⚠️ | ✅ | ✅ | ✅ |
+| Value contract | ISO 8601 UTC string | `Date` object | `Date` object | `Date` object | `CalendarDate` (internationalized/date) |
 | date-fns compatible | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Timezone-aware (IANA, DST) | ✅ `displayTimezone` | ⚠️ native `Date` pitfalls | ❌ | ⚠️ partial | ✅ `@internationalized/date` |
+| Timezone-aware (IANA, DST) | ✅ `displayTimezone` | ⚠️ native `Date` pitfalls | ⚠️ via adapter | ⚠️ partial | ✅ `@internationalized/date` |
 | React 19+ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+#### Footnotes
+
+1. react-day-picker ships only a calendar grid — no Input, no TimePicker, no DateTimePicker. Matching Kalyx's feature surface means composing it with your own input, popover, and time components. The 2.4 KB figure is the default entry point.
+2. `@ark-ui/react` and `react-aria-components` are full component monoliths covering 40+ patterns. Both are tree-shakeable, so an app that only imports DatePicker will ship substantially less — but also inherits a multi-package ecosystem (`@internationalized/date`, Ark's state-chart engine). Kalyx targets the "I want a DatePicker, not a framework" use case.
 
 ## Features
 
@@ -197,10 +207,10 @@ Full documentation is at **[kalyx-docs.vercel.app](https://kalyx-docs.vercel.app
 ## Bundle size
 
 ```
-packages/react/dist/index.js  →  9.2 KB gzip
+packages/react/dist/index.js  →  9.73 KB gzip  (as of v0.4)
 ```
 
-Enforced in CI at `< 12 KB`. Tree-shakable per import — using only `TimePicker` drops the DatePicker code.
+Enforced in CI at `< 12 KB`. Tree-shakable per import — `@kalyx/core` is published with `sideEffects: false`, so using only `TimePicker` drops the DatePicker code.
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The React ecosystem in 2026 has two extremes — Kalyx fills the gap.
 | SSR Safe | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 | TypeScript Strict | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 | date-fns compatible | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Timezone-aware (IANA, DST) | ✅ `displayTimezone` | ⚠️ native `Date` pitfalls | ❌ | ⚠️ partial | ✅ `@internationalized/date` |
 | React 19+ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Features
@@ -62,6 +63,7 @@ The React ecosystem in 2026 has two extremes — Kalyx fills the gap.
 - **Headless** — pair with Tailwind, shadcn/ui, Chakra, or any CSS.
 - **SSR-safe** — verified on Next.js App Router. `useId` for stable IDs.
 - **ISO 8601 UTC strings** — no `Date` object footguns.
+- **Timezone-aware** — opt-in `displayTimezone` prop handles IANA zones and DST without changing the UTC storage contract.
 - **Accessible** — WAI-ARIA, full keyboard, passes axe out of the box.
 - **Tree-shakable** — pay only for what you render.
 - **TypeScript first** — strict types, zero `any`.

--- a/apps/docs-site/docs/api/core.md
+++ b/apps/docs-site/docs/api/core.md
@@ -191,7 +191,57 @@ formatFullDate('2026-04-15T00:00:00.000Z', 'en-US');
 // → "April 15, 2026"
 ```
 
+## Timezone utilities
+
+Introduced in v0.4. Used internally by every picker when `displayTimezone` is set; exposed publicly so you can run the same math yourself.
+
+### `formatInTimezone(iso, formatStr, timeZone)`
+
+Format a UTC instant in the requested zone. Handles DST transitions.
+
+```ts
+formatInTimezone('2026-03-08T07:30:00.000Z', 'yyyy-MM-dd HH:mm', 'America/New_York');
+// → '2026-03-08 03:30'   (post spring-forward EDT)
+```
+
+### `startOfDayInTimezone(iso, timeZone)`
+
+Civil midnight of the given UTC instant's day, expressed as a UTC ISO string.
+
+```ts
+startOfDayInTimezone('2026-01-15T12:00:00.000Z', 'Asia/Seoul');
+// → '2026-01-14T15:00:00.000Z'
+```
+
+### `isSameDayInTimezone(a, b, timeZone)`
+
+Civil-day equality in the zone. Timezone-safe alternative to comparing `iso.slice(0, 10)`.
+
+### `todayInTimezone(timeZone)`
+
+"Today" expressed as civil midnight in the zone.
+
+### `getTimezoneOffsetMinutes(iso, timeZone)`
+
+UTC offset (minutes east of UTC) at the given instant. Differs before and after DST transitions.
+
+### `civilMidnightFromUtcDay(gridUtcIso, timeZone)`
+
+The bridge Calendar uses: maps a UTC-midnight grid cell ISO to civil midnight of the same calendar day in the zone. You rarely need this directly — it is exported for custom calendar renderers.
+
+### `getTimeInTimezone(iso, timeZone)` / `setTimeInTimezone(iso, partial, timeZone)`
+
+Read and write time-of-day as observed in the zone. `setTimeInTimezone` preserves the civil date and replaces the time portion, iterating once to absorb DST offsets.
+
+```ts
+setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul');
+// → '2026-01-15T01:00:00.000Z'   (Seoul 10:00 = UTC 01:00)
+```
+
+See the [Timezone concept page](../concepts/timezone.md) for usage patterns.
+
 ## See also
 
 - [Concepts → ISO strings](../concepts/iso-string.md)
 - [Concepts → Adapters](../concepts/adapters.md)
+- [Concepts → Timezone](../concepts/timezone.md)

--- a/apps/docs-site/docs/components/datepicker.md
+++ b/apps/docs-site/docs/components/datepicker.md
@@ -114,6 +114,7 @@ Holds state and provides context to sub-components. Controlled when `value` is p
 | `weekStartsOn` | `0 \| 1` | `0` | `0` = Sunday, `1` = Monday. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | date-fns format string. |
 | `locale` | `string` | `'en-US'` | BCP 47 locale tag. |
+| `displayTimezone` | `string` | — | IANA zone (e.g., `"Asia/Seoul"`). When set, Input formats in this zone, Calendar highlights match civil days, and `onChange` emits civil midnight in this zone. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom date adapter. |
 | `children` | `ReactNode` | — | Sub-components. |
 

--- a/apps/docs-site/docs/components/datepicker.md
+++ b/apps/docs-site/docs/components/datepicker.md
@@ -116,6 +116,7 @@ Holds state and provides context to sub-components. Controlled when `value` is p
 | `locale` | `string` | `'en-US'` | BCP 47 locale tag. |
 | `displayTimezone` | `string` | — | IANA zone (e.g., `"Asia/Seoul"`). When set, Input formats in this zone, Calendar highlights match civil days, and `onChange` emits civil midnight in this zone. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom date adapter. |
+| `labels` | `Partial<DatePickerLabels>` | — | Override ARIA labels (defaults to English). Keys: `triggerOpen`, `triggerClose`, `popoverLabel`, `prevMonth`, `nextMonth`, `prevYear`, `nextYear`, `prevDecade`, `nextDecade`. |
 | `children` | `ReactNode` | — | Sub-components. |
 
 ### `DisabledRule`

--- a/apps/docs-site/docs/components/datetimepicker.md
+++ b/apps/docs-site/docs/components/datetimepicker.md
@@ -102,6 +102,7 @@ function BasicDateTime() {
 | `locale` | `string` | `'en-US'` | BCP 47 locale. |
 | `displayTimezone` | `string` | — | IANA zone. Calendar highlights by civil day in this zone, TimePicker reads/writes time-of-day in this zone, and `onChange` emits the UTC instant that corresponds to the zone-local date+time. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
+| `labels` | `Partial<DateTimePickerLabels>` | — | Override ARIA labels. Union of DatePicker + TimePicker label keys, plus `dateTimeInput`. |
 | `children` | `ReactNode` | — | Sub-components. |
 
 ## Sub-components

--- a/apps/docs-site/docs/components/datetimepicker.md
+++ b/apps/docs-site/docs/components/datetimepicker.md
@@ -100,6 +100,7 @@ function BasicDateTime() {
 | `weekStartsOn` | `0 \| 1` | `0` | Week start. |
 | `displayFormat` | `string` | `'yyyy-MM-dd HH:mm'` | date-fns format. |
 | `locale` | `string` | `'en-US'` | BCP 47 locale. |
+| `displayTimezone` | `string` | — | IANA zone. Calendar highlights by civil day in this zone, TimePicker reads/writes time-of-day in this zone, and `onChange` emits the UTC instant that corresponds to the zone-local date+time. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
 | `children` | `ReactNode` | — | Sub-components. |
 

--- a/apps/docs-site/docs/components/rangepicker.md
+++ b/apps/docs-site/docs/components/rangepicker.md
@@ -88,6 +88,7 @@ function BasicRange() {
 | `locale` | `string` | `'en-US'` | BCP 47 locale. |
 | `displayTimezone` | `string` | — | IANA zone. When set, `start`/`end` are civil midnight of the clicked day in this zone. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
+| `labels` | `Partial<RangePickerLabels>` | — | Override ARIA labels. Adds `startInput`, `endInput`, `presetsGroup` on top of DatePicker's label keys. |
 | `children` | `ReactNode` | — | Sub-components. |
 
 ### `DateRange`

--- a/apps/docs-site/docs/components/rangepicker.md
+++ b/apps/docs-site/docs/components/rangepicker.md
@@ -86,6 +86,7 @@ function BasicRange() {
 | `weekStartsOn` | `0 \| 1` | `0` | Week start. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | Format string. |
 | `locale` | `string` | `'en-US'` | BCP 47 locale. |
+| `displayTimezone` | `string` | — | IANA zone. When set, `start`/`end` are civil midnight of the clicked day in this zone. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
 | `children` | `ReactNode` | — | Sub-components. |
 

--- a/apps/docs-site/docs/components/timepicker.md
+++ b/apps/docs-site/docs/components/timepicker.md
@@ -77,6 +77,7 @@ function Basic24h() {
 | `displayTimezone` | `string` | — | IANA zone. When set, the hour/minute controls read and write time as observed in this zone (DST-aware). See [Timezone](../concepts/timezone.md). |
 | `disabled` | `boolean` | `false` | Disable the whole picker. |
 | `readOnly` | `boolean` | `false` | Prevent changes. |
+| `labels` | `Partial<TimePickerLabels>` | — | Override ARIA labels. Keys: `timeInput`, `hourList`, `minuteList`, `amPmToggle`, `hourOption(h)`, `minuteOption(m)`. |
 | `children` | `ReactNode` | — | Sub-components. |
 
 ## `<TimePicker.Input>`

--- a/apps/docs-site/docs/components/timepicker.md
+++ b/apps/docs-site/docs/components/timepicker.md
@@ -74,6 +74,7 @@ function Basic24h() {
 | `format` | `'12h' \| '24h'` | `'24h'` | Time format. |
 | `step` | `number` | `1` | Minute granularity (e.g. `5`, `15`, `30`). |
 | `withSeconds` | `boolean` | `false` | Show seconds in display + input. |
+| `displayTimezone` | `string` | — | IANA zone. When set, the hour/minute controls read and write time as observed in this zone (DST-aware). See [Timezone](../concepts/timezone.md). |
 | `disabled` | `boolean` | `false` | Disable the whole picker. |
 | `readOnly` | `boolean` | `false` | Prevent changes. |
 | `children` | `ReactNode` | — | Sub-components. |

--- a/apps/docs-site/docs/concepts/iso-string.md
+++ b/apps/docs-site/docs/concepts/iso-string.md
@@ -87,9 +87,10 @@ parseInputValue('15/04/2026', 'dd/MM/yyyy', DateFnsAdapter); // → ISO or null
 
 `TimePicker` and `DateTimePicker` also return ISO strings. The date part of a pure `TimePicker` value is a stable placeholder — consume only the time fields (`getTime(iso)` in `@kalyx/core` helps).
 
-Full IANA time-zone display (e.g., rendering "2026-04-15T00:00:00Z" as `"2026-04-15 09:00 KST"`) lands in v0.4. Until then, treat display formatting as your application's responsibility.
+For IANA time-zone-aware display and input — rendering `"2026-04-15T00:00:00Z"` as `"2026-04-15 09:00 KST"`, or making a calendar click emit the civil midnight of that day in the user's zone — use the `displayTimezone` prop introduced in v0.4. See the dedicated [Timezone concept page](./timezone.md).
 
 ## Next
 
+- [Timezone (displayTimezone) →](./timezone.md)
 - [Adapters →](./adapters.md)
 - [SSR safety →](./ssr.md)

--- a/apps/docs-site/docs/concepts/timezone.md
+++ b/apps/docs-site/docs/concepts/timezone.md
@@ -1,0 +1,123 @@
+---
+id: timezone
+title: Timezone (displayTimezone)
+sidebar_position: 3
+---
+
+# Timezone support
+
+All four pickers (`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`) accept a `displayTimezone` prop. When set, Kalyx interprets the user's input and the displayed value as *civil time in that IANA zone* while continuing to emit the plain UTC-ISO strings you already store.
+
+This is Kalyx's structural answer to [react-datepicker #1018](https://github.com/Hacker0x01/react-datepicker/issues/1018) — the "day off by one" bug that has haunted timezone-sensitive apps for a decade.
+
+## The problem in one snippet
+
+Without a deliberate zone, picking "April 15" in Seoul stores April 14:
+
+```ts
+const picked = new Date(2026, 3, 15); // UTC+9 → "2026-04-14T15:00:00.000Z"
+await save(picked.toISOString());     // server stores April 14
+```
+
+With `displayTimezone`, the same click always stores the same *civil* day:
+
+```tsx
+<DatePicker displayTimezone="Asia/Seoul" onChange={save}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+// click "April 15" → onChange("2026-04-14T15:00:00.000Z")
+// which represents Seoul April 15 00:00 exactly
+```
+
+The ISO string is still UTC — but it is the UTC instant that equals civil midnight in the display zone, not civil midnight in the server's runtime zone.
+
+## When to use it
+
+| Situation | Recommendation |
+| --- | --- |
+| Calendar dates for logs, birthdays, anniversaries (single civil day) | Set `displayTimezone` to the user's zone. |
+| Booking slots where a server renders for multiple regions | Store in UTC, render with the customer's `displayTimezone`. |
+| Times of day in a single region | Set `displayTimezone` once on the root. |
+| All users in one zone (e.g., a Korean-only product) | Setting `displayTimezone="Asia/Seoul"` makes timezone behavior explicit and safe against server runtime drift. |
+| Never leaves UTC (analytics, audit trails) | Leave it unset — Kalyx's default semantics are UTC. |
+
+## Component-level behavior
+
+```tsx
+<DatePicker displayTimezone="Asia/Seoul" value={iso} onChange={setIso}>
+  <DatePicker.Input />           {/* formats `iso` as seen in Seoul */}
+  <DatePicker.Popover>
+    <DatePicker.Calendar />      {/* highlights today/selected by civil Seoul day */}
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+| Surface | Effect |
+| --- | --- |
+| `DatePicker.Input` / `RangePicker.Input` / `DateTimePicker.Input` | `format` runs in `displayTimezone`. |
+| `Calendar` | `today` and `isSelected` comparisons use civil-day equality in the zone. |
+| `onChange` on calendar click | The stored ISO represents civil midnight of the clicked day *in the zone*. |
+| `TimePicker.HourList` / `MinuteList` | Read and write time-of-day as observed in the zone (DST-aware). |
+
+## DST handling
+
+Kalyx delegates to `Intl.DateTimeFormat` for offset lookups, so transitions are handled correctly for all IANA zones.
+
+```ts
+// Spring forward 2026-03-08 in America/New_York: 02:00 EST → 03:00 EDT
+startOfDayInTimezone('2026-03-08T12:00:00.000Z', 'America/New_York');
+// → '2026-03-08T05:00:00.000Z'  (EST — midnight is still pre-transition)
+
+startOfDayInTimezone('2026-03-09T12:00:00.000Z', 'America/New_York');
+// → '2026-03-09T04:00:00.000Z'  (EDT — full day in daylight time)
+```
+
+## Low-level helpers
+
+Import from `@kalyx/core` when you need to do the same math in your own code:
+
+```ts
+import {
+  civilMidnightFromUtcDay,  // Calendar-cell UTC iso → civil midnight ISO in tz
+  getTimeInTimezone,         // UTC iso → { hours, minutes, seconds } as seen in tz
+  setTimeInTimezone,         // UTC iso + TimeValue → UTC iso with new time in tz
+  formatInTimezone,
+  startOfDayInTimezone,
+  isSameDayInTimezone,
+  todayInTimezone,
+  getTimezoneOffsetMinutes,
+} from '@kalyx/core';
+```
+
+## Migrating from no-timezone code
+
+1. Decide on the display zone (user preference, account setting, or server-known region).
+2. Add `displayTimezone={userZone}` on the root. Nothing else changes in the call site.
+3. Run existing tests — they keep passing because the contract (`value`, `onChange` with UTC ISO strings) is unchanged; only the *content* of those strings now has a single, unambiguous meaning.
+
+```diff
+  <DatePicker
+    value={iso}
+    onChange={setIso}
++   displayTimezone={user.timezone ?? 'UTC'}
+  >
+    <DatePicker.Input />
+    <DatePicker.Popover>
+      <DatePicker.Calendar />
+    </DatePicker.Popover>
+  </DatePicker>
+```
+
+## Gotchas
+
+- **Omitting the prop keeps UTC semantics.** Existing code continues to work.
+- **Adapter contract unchanged.** Custom adapters implementing the `DateAdapter` interface should honor the `timezone?: string` parameter on `format`, `isSameDay`, `startOfDay`, and `today`. The built-in `DateFnsAdapter` already does.
+- **IANA zone only.** Offsets like `"+09:00"` are not supported — use `"Asia/Seoul"`.
+
+## Next
+
+- [Adapters →](./adapters.md)
+- [ISO 8601 UTC strings →](./iso-string.md)

--- a/apps/docs-site/docs/hooks/use-date-picker.md
+++ b/apps/docs-site/docs/hooks/use-date-picker.md
@@ -28,6 +28,7 @@ function useDatePicker(options?: UseDatePickerOptions): UseDatePickerReturn;
 | `disabled` | `DisabledRule[]` | `[]` | Disable rules. |
 | `weekStartsOn` | `0 \| 1` | `0` | Week start. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
+| `displayTimezone` | `string` | — | IANA zone. When set, `selectDate` stores civil-midnight-in-tz and today/selected highlighting uses civil-day comparison. See [Timezone](../concepts/timezone.md). |
 
 ### Return
 

--- a/apps/docs-site/docs/hooks/use-range-picker.md
+++ b/apps/docs-site/docs/hooks/use-range-picker.md
@@ -28,6 +28,7 @@ function useRangePicker(options?: UseRangePickerOptions): UseRangePickerReturn;
 | `disabled` | `DisabledRule[]` | `[]` | Disable rules. |
 | `weekStartsOn` | `0 \| 1` | `0` | Week start. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
+| `displayTimezone` | `string` | — | IANA zone. Same semantics as [`useDatePicker#displayTimezone`](./use-date-picker.md); applies to both `start` and `end`. |
 
 ### Return (delta over `useDatePicker`)
 

--- a/apps/docs-site/docs/hooks/use-time-picker.md
+++ b/apps/docs-site/docs/hooks/use-time-picker.md
@@ -28,6 +28,7 @@ function useTimePicker(options?: UseTimePickerOptions): UseTimePickerReturn;
 | `format` | `'12h' \| '24h'` | `'24h'` | Time format. |
 | `step` | `number` | `1` | Minute granularity. |
 | `withSeconds` | `boolean` | `false` | Include seconds. |
+| `displayTimezone` | `string` | — | IANA zone. When set, `currentTime` / `setHour` / `setMinute` read and write time-of-day as observed in this zone (DST-aware). See [Timezone](../concepts/timezone.md). |
 
 ### Return
 

--- a/apps/docs-site/docs/intro.md
+++ b/apps/docs-site/docs/intro.md
@@ -39,6 +39,7 @@ Kalyx fills the gap:
 - **Under 12 KB gzip** — measured, enforced in CI.
 - **SSR-safe** — tested with Next.js App Router.
 - **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
+- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone.md).
 
 ## Who it's for
 

--- a/apps/docs-site/docs/migration.md
+++ b/apps/docs-site/docs/migration.md
@@ -117,6 +117,47 @@ const toISO = (cal: CalendarDate | null): ISODateString | null =>
   cal ? new Date(Date.UTC(cal.year, cal.month - 1, cal.day)).toISOString() : null;
 ```
 
+## v0.3 → v0.4 — adding `displayTimezone`
+
+v0.4 introduces `displayTimezone` on all four pickers (plus the matching hooks). No breaking changes — omitting the prop keeps v0.3 semantics. Adopt it when the user's displayed zone differs from the server runtime, or when you want an explicit barrier against "day off by one" bugs.
+
+### Before (v0.3, implicit UTC / runtime local)
+
+```tsx
+<DatePicker value={iso} onChange={setIso}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+### After (v0.4)
+
+```tsx
+<DatePicker
+  value={iso}
+  onChange={setIso}
+  displayTimezone={user.timezone ?? 'UTC'}
+>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+The ISO contract does not change. What *does* change with the prop set:
+
+- The `Input` formats the value in `displayTimezone`.
+- The `Calendar` highlights today / selected by civil-day equality in the zone.
+- `onChange` on a calendar click now emits the civil midnight of the clicked day *in the zone* (not UTC midnight of the clicked cell).
+- `TimePicker` / `DateTimePicker` hour+minute controls read and write time-of-day as observed in the zone, DST-aware.
+
+Custom `DateAdapter` implementations should honor the `timezone?: string` argument on `format`, `isSameDay`, `startOfDay`, and `today` — the built-in `DateFnsAdapter` already does.
+
+See the [Timezone concept page](./concepts/timezone.md) for the full story.
+
 ## General checklist
 
 When migrating:

--- a/apps/docs-site/sidebars.ts
+++ b/apps/docs-site/sidebars.ts
@@ -18,6 +18,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'concepts/composition',
         'concepts/iso-string',
+        'concepts/timezone',
         'concepts/ssr',
         'concepts/adapters',
         'concepts/accessibility',

--- a/apps/docs-site/src/pages/playground.mdx
+++ b/apps/docs-site/src/pages/playground.mdx
@@ -226,6 +226,60 @@ function PlaygroundDateTime() {
 }
 ```
 
+## displayTimezone — pick the same civil day across zones
+
+Switch the timezone radio and watch the emitted ISO change while the *civil day you clicked* stays the same. This is Kalyx's structural answer to the "day off by one" bug (react-datepicker #1018).
+
+```jsx live
+function PlaygroundTimezone() {
+  const [date, setDate] = React.useState('2026-01-15T00:00:00.000Z');
+  const [tz, setTz] = React.useState('Asia/Seoul');
+  const zones = ['UTC', 'Asia/Seoul', 'America/New_York', 'Europe/London'];
+  return (
+    <div>
+      <div className="kx-live-row" style={{ marginBottom: 10, flexWrap: 'wrap' }}>
+        {zones.map((z) => (
+          <label key={z} style={{ fontSize: 13, marginRight: 12 }}>
+            <input
+              type="radio"
+              checked={tz === z}
+              onChange={() => setTz(z)}
+            />{' '}
+            {z}
+          </label>
+        ))}
+      </div>
+      <DatePicker value={date} onChange={setDate} displayTimezone={tz}>
+        <DatePicker.Input className="kx-live-input" />
+        <DatePicker.Popover className="kx-live-popover">
+          <DatePicker.Calendar
+            classNames={{
+              header: 'kx-live-header',
+              title: 'kx-live-title',
+              navButton: 'kx-live-nav',
+              grid: 'kx-live-grid',
+              gridCell: 'kx-live-cell',
+              weekdayHeader: 'kx-live-weekday',
+              day: 'live-day',
+              daySelected: 'live-day-selected',
+              dayToday: 'live-day-today',
+              dayOutsideMonth: 'kx-live-outside',
+            }}
+          />
+        </DatePicker.Popover>
+      </DatePicker>
+      <div className="kx-live-value" style={{ marginTop: 10 }}>
+        Emitted ISO (UTC): <code>{date ?? 'null'}</code>
+        <br />
+        <em style={{ fontSize: 12 }}>
+          The instant represents civil midnight of the clicked day in <code>{tz}</code>.
+        </em>
+      </div>
+    </div>
+  );
+}
+```
+
 ## Mix and match
 
 The scope includes `React`, `DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`, `useDatePicker`, `useRangePicker`, `useTimePicker`, and `DateFnsAdapter`. Start typing — the editor is yours.

--- a/apps/docs/app/datepicker/demo.tsx
+++ b/apps/docs/app/datepicker/demo.tsx
@@ -56,6 +56,43 @@ export function DatePickerWithNavDemo() {
 	);
 }
 
+export function DatePickerTimezoneDemo() {
+	const [date, setDate] = useState<string | null>(null);
+	const [tz, setTz] = useState('Asia/Seoul');
+	const zones = ['UTC', 'Asia/Seoul', 'America/New_York', 'Europe/London'];
+
+	return (
+		<>
+			<div style={{ marginBottom: 12, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+				{zones.map((z) => (
+					<label key={z} style={{ fontSize: 13 }}>
+						<input
+							type="radio"
+							name="tz"
+							checked={tz === z}
+							onChange={() => setTz(z)}
+							data-testid={`tz-${z}`}
+						/>{' '}
+						{z}
+					</label>
+				))}
+			</div>
+			<DatePicker value={date} onChange={setDate} displayTimezone={tz}>
+				<DatePicker.Input className="kalyx-input" placeholder="날짜 선택" />
+				<DatePicker.Popover>
+					<DatePicker.Calendar />
+				</DatePicker.Popover>
+			</DatePicker>
+			<div className="demo-result">
+				<strong>displayTimezone:</strong> <code>{tz}</code>
+				<br />
+				<strong>저장 ISO (UTC):</strong>{' '}
+				<code data-testid="tz-emitted-iso">{date ?? '(없음)'}</code>
+			</div>
+		</>
+	);
+}
+
 export function DatePickerLocaleDemo() {
 	const [date, setDate] = useState<string | null>(null);
 	const [locale, setLocale] = useState('en-US');

--- a/apps/docs/app/datepicker/page.tsx
+++ b/apps/docs/app/datepicker/page.tsx
@@ -1,4 +1,4 @@
-import { DatePickerDemo, DatePickerWithNavDemo, DatePickerLocaleDemo } from './demo';
+import { DatePickerDemo, DatePickerWithNavDemo, DatePickerLocaleDemo, DatePickerTimezoneDemo } from './demo';
 
 export default function DatePickerPage() {
 	return (
@@ -18,6 +18,16 @@ export default function DatePickerPage() {
 			</p>
 			<div className="demo">
 				<DatePickerWithNavDemo />
+			</div>
+
+			<h2>Timezone (displayTimezone)</h2>
+			<p>
+				<code>displayTimezone</code> prop으로 IANA 타임존을 지정하면, 같은 시민 날짜를
+				클릭해도 타임존에 맞는 UTC 자정이 저장된다. 서버에서 구동해도 동일한 결과를
+				보장한다 (react-datepicker #1018 방지).
+			</p>
+			<div className="demo" data-testid="timezone-demo">
+				<DatePickerTimezoneDemo />
 			</div>
 
 			<h2>다국어 (Locale)</h2>

--- a/e2e/timezone.e2e.ts
+++ b/e2e/timezone.e2e.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * End-to-end coverage for `displayTimezone` across SSR, hydration, and user interaction.
+ * Mirrors the React-level unit tests in packages/react/src/components/__tests__/displayTimezone.test.tsx
+ * but exercises the full Next.js → hydration → click path on real browsers.
+ *
+ * The demo page under /datepicker includes a Timezone section with radio inputs for
+ * UTC, Asia/Seoul, America/New_York, Europe/London. A `data-testid="tz-emitted-iso"` holds
+ * the emitted ISO so assertions don't depend on locale-sensitive input formatting.
+ */
+
+test.describe('DatePicker — displayTimezone', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/datepicker');
+	});
+
+	test('SSR + hydration: timezone demo renders without errors', async ({ page }) => {
+		const consoleErrors: string[] = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') consoleErrors.push(msg.text());
+		});
+
+		const demo = page.getByTestId('timezone-demo');
+		await expect(demo).toBeVisible();
+		await expect(demo.getByRole('combobox')).toBeVisible();
+
+		const hydrationErrors = consoleErrors.filter(
+			(msg) => msg.includes('Hydration') || msg.includes('hydrat'),
+		);
+		expect(hydrationErrors).toHaveLength(0);
+	});
+
+	test('Asia/Seoul: clicking a day emits civil-midnight-in-zone (UTC-9h)', async ({ page }) => {
+		const demo = page.getByTestId('timezone-demo');
+		// Default selection is Asia/Seoul (first option with checked=true)
+		await demo.getByTestId('tz-Asia/Seoul').check();
+
+		await demo.getByRole('combobox').click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+
+		// Click the 15th (first non-outside-month 15)
+		await dialog
+			.locator('button:not([data-outside-month])')
+			.filter({ hasText: /^15$/ })
+			.click();
+
+		// Emitted ISO should end with "T15:00:00.000Z" — that is civil-midnight in KST (UTC+9)
+		// represented as the UTC instant of the previous day at 15:00.
+		const emitted = demo.getByTestId('tz-emitted-iso');
+		await expect(emitted).toContainText('T15:00:00.000Z');
+	});
+
+	test('America/New_York: civil-midnight-in-zone (UTC+5h during EST)', async ({ page }) => {
+		const demo = page.getByTestId('timezone-demo');
+		await demo.getByTestId('tz-America/New_York').check();
+
+		await demo.getByRole('combobox').click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+
+		await dialog
+			.locator('button:not([data-outside-month])')
+			.filter({ hasText: /^15$/ })
+			.click();
+
+		// New York civil midnight during EST (UTC-5) = UTC 05:00 the same day (non-DST months)
+		// During EDT (UTC-4) it would be 04:00. Accept either by checking the pattern.
+		const emitted = demo.getByTestId('tz-emitted-iso');
+		await expect(emitted).toContainText(/T0[45]:00:00\.000Z/);
+	});
+
+	test('UTC: clicking a day emits UTC midnight unchanged', async ({ page }) => {
+		const demo = page.getByTestId('timezone-demo');
+		await demo.getByTestId('tz-UTC').check();
+
+		await demo.getByRole('combobox').click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+
+		await dialog
+			.locator('button:not([data-outside-month])')
+			.filter({ hasText: /^15$/ })
+			.click();
+
+		// UTC path: midnight stays at T00:00:00.000Z.
+		const emitted = demo.getByTestId('tz-emitted-iso');
+		await expect(emitted).toContainText('T00:00:00.000Z');
+	});
+
+	test('switching the zone re-interprets the display without losing the picked UTC instant', async ({
+		page,
+	}) => {
+		const demo = page.getByTestId('timezone-demo');
+		await demo.getByTestId('tz-Asia/Seoul').check();
+
+		await demo.getByRole('combobox').click();
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+
+		await dialog
+			.locator('button:not([data-outside-month])')
+			.filter({ hasText: /^15$/ })
+			.click();
+
+		const emitted = demo.getByTestId('tz-emitted-iso');
+		const firstEmission = await emitted.textContent();
+		expect(firstEmission).toContain('T15:00:00.000Z');
+
+		// Swap the zone: the stored UTC does not change because nothing was clicked again.
+		await demo.getByTestId('tz-UTC').check();
+		await expect(emitted).toHaveText(firstEmission!);
+	});
+});

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -30,6 +30,23 @@ src/
 - 새 유틸 함수는 반드시 `__tests__/`에 테스트 추가
 - `index.ts`에서 내부 구현 export 금지
 
+## 플랫폼 독립성
+
+`@kalyx/core`는 DOM / React / Node 전용 API를 참조하지 않아 React Native / 웹 어디서든 동작한다.
+
+| 검사 항목 | 상태 |
+|---|---|
+| `window` / `document` / `navigator` / `localStorage` | ❌ 미사용 |
+| `process.env` / `require()` | ❌ 미사용 |
+| `react` import | ❌ 미사용 |
+| `new Date()` | ✅ `now()` / `today()` 내부에서만 (의도적) |
+| `Intl.DateTimeFormat` | ✅ 사용 — RN Hermes 0.72+ (React Native 0.71+) 기본 지원. 이전 버전은 `hermes-intl` 또는 폴리필 필요 |
+
+핵심 원칙을 유지하려면:
+- 외부 IO를 여기에 넣지 말 것 (fetch / fs / storage / analytics 등)
+- 브라우저 전용 API에 의존하지 말 것 — React 레이어로 이동시킬 것
+- 새 파일 추가 시 "이 모듈을 Node · 브라우저 · React Native 모두에서 import했을 때 깨지는가?"를 확인
+
 ## 빌드
 
 ```bash

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kalyx/core",
 	"version": "0.3.0",
-	"description": "Kalyx core — platform-agnostic date logic",
+	"description": "Kalyx core — platform-agnostic date logic, IANA timezone helpers, and the DateAdapter contract used by @kalyx/react",
 	"license": "MIT",
 	"author": "jiji-hoon96",
 	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",
@@ -18,6 +18,8 @@
 		"datepicker",
 		"calendar",
 		"timezone",
+		"iana",
+		"dst",
 		"iso8601",
 		"utc",
 		"date-fns"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
 		"date-fns"
 	],
 	"type": "module",
+	"sideEffects": false,
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/packages/core/src/__tests__/date-fns-adapter.test.ts
+++ b/packages/core/src/__tests__/date-fns-adapter.test.ts
@@ -148,4 +148,50 @@ describe('DateFnsAdapter', () => {
       expect(adapter.getDate(adapter.endOfMonth('2026-02-01T00:00:00.000Z'))).toBe(28);
     });
   });
+
+  describe('timezone parameter (displayTimezone)', () => {
+    it('format honours the requested timezone', () => {
+      // 2026-01-15 00:00 UTC = 2026-01-15 09:00 KST
+      expect(
+        adapter.format('2026-01-15T00:00:00.000Z', 'yyyy-MM-dd HH:mm', 'Asia/Seoul'),
+      ).toBe('2026-01-15 09:00');
+      // 2026-01-15 00:00 UTC = 2026-01-14 19:00 EST
+      expect(
+        adapter.format('2026-01-15T00:00:00.000Z', 'yyyy-MM-dd HH:mm', 'America/New_York'),
+      ).toBe('2026-01-14 19:00');
+    });
+
+    it('isSameDay treats instants straddling UTC midnight as one civil day in Asia/Seoul', () => {
+      // 2026-01-15T22:00Z = 2026-01-16 07:00 KST (next day)
+      // 2026-01-15T12:00Z = 2026-01-15 21:00 KST (same day)
+      expect(
+        adapter.isSameDay('2026-01-15T12:00:00.000Z', '2026-01-15T22:00:00.000Z', 'Asia/Seoul'),
+      ).toBe(false);
+      expect(
+        adapter.isSameDay('2026-01-15T00:00:00.000Z', '2026-01-15T14:00:00.000Z', 'Asia/Seoul'),
+      ).toBe(true);
+    });
+
+    it('startOfDay returns civil-midnight in timezone (across DST)', () => {
+      // EST before spring-forward
+      expect(adapter.startOfDay('2026-01-15T12:00:00.000Z', 'America/New_York'))
+        .toBe('2026-01-15T05:00:00.000Z');
+      // EDT after spring-forward
+      expect(adapter.startOfDay('2026-07-15T12:00:00.000Z', 'America/New_York'))
+        .toBe('2026-07-15T04:00:00.000Z');
+    });
+
+    it('today without timezone matches UTC midnight shape', () => {
+      expect(adapter.today()).toMatch(/T00:00:00\.000Z$/);
+    });
+
+    it('omitted timezone falls back to UTC semantics', () => {
+      // No timezone → legacy UTC path
+      expect(adapter.format('2026-01-15T00:00:00.000Z', 'yyyy-MM-dd')).toBe('2026-01-15');
+      expect(
+        adapter.isSameDay('2026-01-15T00:00:00.000Z', '2026-01-15T23:59:59.000Z'),
+      ).toBe(true);
+      expect(adapter.startOfDay('2026-01-15T14:30:00.000Z')).toBe('2026-01-15T00:00:00.000Z');
+    });
+  });
 });

--- a/packages/core/src/__tests__/timezone.test.ts
+++ b/packages/core/src/__tests__/timezone.test.ts
@@ -4,6 +4,9 @@ import {
   startOfDayInTimezone,
   isSameDayInTimezone,
   getTimezoneOffsetMinutes,
+  civilMidnightFromUtcDay,
+  getTimeInTimezone,
+  setTimeInTimezone,
 } from '../utils/timezone.js';
 
 // Known DST transitions used as fixtures.
@@ -178,5 +181,65 @@ describe('getTimezoneOffsetMinutes — spot checks', () => {
   it('Asia/Seoul is +540 year-round (no DST)', () => {
     expect(getTimezoneOffsetMinutes('2026-01-15T12:00:00.000Z', 'Asia/Seoul')).toBe(540);
     expect(getTimezoneOffsetMinutes('2026-07-15T12:00:00.000Z', 'Asia/Seoul')).toBe(540);
+  });
+});
+
+describe('civilMidnightFromUtcDay — calendar-grid cell bridge', () => {
+  it('maps UTC-midnight Jan 15 to Seoul civil midnight (Jan 14 15:00 UTC)', () => {
+    expect(civilMidnightFromUtcDay('2026-01-15T00:00:00.000Z', 'Asia/Seoul'))
+      .toBe('2026-01-14T15:00:00.000Z');
+  });
+
+  it('maps UTC-midnight Jan 15 to New York civil midnight during EST (Jan 15 05:00 UTC)', () => {
+    expect(civilMidnightFromUtcDay('2026-01-15T00:00:00.000Z', 'America/New_York'))
+      .toBe('2026-01-15T05:00:00.000Z');
+  });
+
+  it('keeps the same day on UTC-midnight → UTC', () => {
+    expect(civilMidnightFromUtcDay('2026-06-15T00:00:00.000Z', 'UTC'))
+      .toBe('2026-06-15T00:00:00.000Z');
+  });
+});
+
+describe('getTimeInTimezone', () => {
+  it('reads Seoul wall-clock time from a UTC instant', () => {
+    // 2026-01-15 03:30 UTC = 2026-01-15 12:30 KST
+    expect(getTimeInTimezone('2026-01-15T03:30:00.000Z', 'Asia/Seoul'))
+      .toEqual({ hours: 12, minutes: 30, seconds: 0 });
+  });
+
+  it('reads New York wall-clock time during EDT (UTC-4)', () => {
+    // 2026-07-15 16:00 UTC = 2026-07-15 12:00 EDT
+    expect(getTimeInTimezone('2026-07-15T16:00:00.000Z', 'America/New_York'))
+      .toEqual({ hours: 12, minutes: 0, seconds: 0 });
+  });
+});
+
+describe('setTimeInTimezone', () => {
+  it('replaces only the hour in Asia/Seoul while keeping the civil date', () => {
+    // Starting from 2026-01-15T00:00:00Z (= Seoul Jan 15 09:00) → set hours to 10
+    // Expected: Seoul Jan 15 10:00 = UTC Jan 15 01:00
+    expect(setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul'))
+      .toBe('2026-01-15T01:00:00.000Z');
+  });
+
+  it('updates minutes while preserving the hour and civil date', () => {
+    expect(setTimeInTimezone('2026-01-15T01:00:00.000Z', { minutes: 30 }, 'Asia/Seoul'))
+      .toBe('2026-01-15T01:30:00.000Z');
+  });
+
+  it('set hour across DST in America/New_York (after spring forward)', () => {
+    // Starting at 2026-07-15T16:00Z (= EDT 12:00). Set hour 15.
+    // Target: EDT 15:00 = UTC 19:00
+    expect(setTimeInTimezone('2026-07-15T16:00:00.000Z', { hours: 15 }, 'America/New_York'))
+      .toBe('2026-07-15T19:00:00.000Z');
+  });
+
+  it('round-trips getTimeInTimezone ∘ setTimeInTimezone', () => {
+    const input = '2026-03-15T08:00:00.000Z';
+    const tz = 'Europe/London';
+    const { hours, minutes, seconds } = getTimeInTimezone(input, tz);
+    const round = setTimeInTimezone(input, { hours, minutes, seconds }, tz);
+    expect(round).toBe(input);
   });
 });

--- a/packages/core/src/adapters/date-fns.ts
+++ b/packages/core/src/adapters/date-fns.ts
@@ -8,6 +8,12 @@ import {
   isValid as dfIsValid,
 } from 'date-fns';
 import type { DateAdapter } from '../types.js';
+import {
+  formatInTimezone,
+  isSameDayInTimezone,
+  startOfDayInTimezone,
+  todayInTimezone,
+} from '../utils/timezone.js';
 
 function toDate(iso: string): Date {
   return parseISO(iso);
@@ -77,7 +83,10 @@ export const DateFnsAdapter: DateAdapter = {
     return normalize(value);
   },
 
-  format(iso: string, formatStr: string): string {
+  format(iso: string, formatStr: string, timezone?: string): string {
+    if (timezone) {
+      return formatInTimezone(iso, formatStr, timezone);
+    }
     const d = toDate(iso);
     // Format in UTC to avoid local timezone interference
     const tokens: Record<string, string> = {
@@ -119,8 +128,11 @@ export const DateFnsAdapter: DateAdapter = {
     return dfIsAfter(toDate(a), toDate(b));
   },
 
-  isSameDay(a: string, b: string): boolean {
+  isSameDay(a: string, b: string, timezone?: string): boolean {
     if (!a || !b) return false;
+    if (timezone) {
+      return isSameDayInTimezone(a, b, timezone);
+    }
     const da = toDate(a);
     const db = toDate(b);
     return (
@@ -139,7 +151,10 @@ export const DateFnsAdapter: DateAdapter = {
     );
   },
 
-  startOfDay(iso: string): string {
+  startOfDay(iso: string, timezone?: string): string {
+    if (timezone) {
+      return startOfDayInTimezone(iso, timezone);
+    }
     return toISO(utcStartOfDay(toDate(iso)));
   },
 
@@ -163,7 +178,10 @@ export const DateFnsAdapter: DateAdapter = {
     return new Date().toISOString();
   },
 
-  today(): string {
+  today(timezone?: string): string {
+    if (timezone) {
+      return todayInTimezone(timezone);
+    }
     return toISO(utcStartOfDay(new Date()));
   },
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,9 @@ export {
   isSameDayInTimezone,
   todayInTimezone,
   getTimezoneOffsetMinutes,
+  civilMidnightFromUtcDay,
+  getTimeInTimezone,
+  setTimeInTimezone,
 } from './utils/timezone.js';
 export type {
   DatePickerLabels,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -113,4 +113,10 @@ export interface CalendarOptions {
   range?: DateRange | null;
   /** Currently hovered date (for RangePicker preview) */
   rangeHover?: ISODateString | null;
+  /**
+   * IANA timezone. When set, `isSameDay` comparisons for today/selected/range flags are
+   * evaluated in this zone — required when the picker stores values in display-tz civil
+   * midnight form while the grid iterates in UTC.
+   */
+  timezone?: string;
 }

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -41,16 +41,17 @@ export function getCalendarDays(
     disabled = [],
     range,
     rangeHover,
+    timezone,
   } = options;
 
-  const todayISO = today ?? adapter.today();
+  const todayISO = today ?? adapter.today(timezone);
   const monthStart = adapter.startOfMonth(monthISO);
 
   // Start of grid: start of the week containing the first day of the month
   const gridStart = adapter.startOfWeek(monthStart, weekStartsOn);
 
   // Normalize for range computation (ensures start <= end)
-  const normalizedRange = normalizeRangeForDisplay(range, rangeHover, adapter);
+  const normalizedRange = normalizeRangeForDisplay(range, rangeHover, adapter, timezone);
 
   const weeks: CalendarGrid = [];
   let current = gridStart;
@@ -61,12 +62,12 @@ export function getCalendarDays(
 
     for (let day = 0; day < 7; day++) {
       const isCurrentMonth = adapter.isSameMonth(current, monthISO);
-      const isTodayDate = adapter.isSameDay(current, todayISO);
-      const isSelected_ = selected ? adapter.isSameDay(current, selected) : false;
-      const isFocused_ = focusedDate ? adapter.isSameDay(current, focusedDate) : false;
+      const isTodayDate = adapter.isSameDay(current, todayISO, timezone);
+      const isSelected_ = selected ? adapter.isSameDay(current, selected, timezone) : false;
+      const isFocused_ = focusedDate ? adapter.isSameDay(current, focusedDate, timezone) : false;
       const isDisabled_ = isDateDisabled(current, disabled, adapter);
 
-      const rangeFlags = computeRangeFlags(current, normalizedRange, adapter);
+      const rangeFlags = computeRangeFlags(current, normalizedRange, adapter, timezone);
 
       days.push({
         isoString: current,
@@ -101,6 +102,7 @@ function normalizeRangeForDisplay(
   range: DateRange | null | undefined,
   hover: ISODateString | null | undefined,
   adapter: DateAdapter,
+  _timezone?: string,
 ): { start: ISODateString | null; end: ISODateString | null } {
   if (!range) return { start: null, end: null };
 
@@ -140,6 +142,7 @@ function computeRangeFlags(
   iso: ISODateString,
   range: { start: ISODateString | null; end: ISODateString | null },
   adapter: DateAdapter,
+  timezone?: string,
 ): RangeFlags {
   const { start, end } = range;
 
@@ -147,13 +150,13 @@ function computeRangeFlags(
     return { isRangeStart: false, isRangeEnd: false, isInRange: false };
   }
 
-  const isRangeStart = adapter.isSameDay(iso, start);
+  const isRangeStart = adapter.isSameDay(iso, start, timezone);
 
   if (!end) {
     return { isRangeStart, isRangeEnd: false, isInRange: false };
   }
 
-  const isRangeEnd = adapter.isSameDay(iso, end);
+  const isRangeEnd = adapter.isSameDay(iso, end, timezone);
   const isInRange =
     !isRangeStart &&
     !isRangeEnd &&

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -150,3 +150,81 @@ export function isSameDayInTimezone(
 export function todayInTimezone(timeZone: string): ISODateString {
   return startOfDayInTimezone(new Date().toISOString(), timeZone);
 }
+
+/**
+ * Converts a UTC-midnight ISO (as produced by the default calendar grid iteration) into the
+ * civil midnight of the same calendar day in `timeZone`.
+ *
+ * This is the bridge used by DatePicker/RangePicker when `displayTimezone` is set: the grid
+ * iterates in UTC, so a cell's `isoString` is `YYYY-MM-DDT00:00:00.000Z`. When the user clicks
+ * that cell we want to emit an ISO representing the same civil day's midnight in the display
+ * timezone. A probe at noon UTC is used so the target civil day is unambiguous across any zone.
+ *
+ * @example
+ * civilMidnightFromUtcDay('2026-01-15T00:00:00.000Z', 'Asia/Seoul');
+ * // → '2026-01-14T15:00:00.000Z'  (Seoul Jan 15 00:00 = UTC Jan 14 15:00)
+ */
+export function civilMidnightFromUtcDay(
+  gridUtcIso: ISODateString,
+  timeZone: string,
+): ISODateString {
+  const utc = parseISO(gridUtcIso);
+  const probe = new Date(Date.UTC(
+    utc.getUTCFullYear(),
+    utc.getUTCMonth(),
+    utc.getUTCDate(),
+    12, 0, 0,
+  )).toISOString();
+  return startOfDayInTimezone(probe, timeZone);
+}
+
+/**
+ * Extracts the time-of-day (hours / minutes / seconds) of a UTC instant as observed in
+ * `timeZone`. The result differs from reading UTC hours when the zone has a non-zero offset.
+ *
+ * @example
+ * getTimeInTimezone('2026-01-15T00:00:00.000Z', 'Asia/Seoul');
+ * // → { hours: 9, minutes: 0, seconds: 0 }  (Seoul is UTC+9)
+ */
+export function getTimeInTimezone(
+  iso: ISODateString,
+  timeZone: string,
+): { hours: number; minutes: number; seconds: number } {
+  const p = partsInTimezone(parseISO(iso), timeZone);
+  return { hours: p.hour, minutes: p.minute, seconds: p.second };
+}
+
+/**
+ * Returns a new ISO UTC string where the civil date in `timeZone` is preserved and the time
+ * portion is replaced according to `partial` (as observed in that same timezone). Undefined
+ * fields keep their current value.
+ *
+ * Implementation note: the civil target (Y,M,D,H,m,s) is first mapped to a UTC epoch as if
+ * the wall-clock reading lived in UTC; then we subtract the timezone offset at that instant
+ * to recover the real UTC instant. The offset is refined once to absorb DST transitions.
+ *
+ * @example
+ * // In Asia/Seoul (UTC+9): set the hour to 10
+ * setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul');
+ * // → '2026-01-15T01:00:00.000Z'   (Seoul Jan 15 10:00 = UTC 01:00)
+ */
+export function setTimeInTimezone(
+  iso: ISODateString,
+  partial: { hours?: number; minutes?: number; seconds?: number },
+  timeZone: string,
+): ISODateString {
+  const p = partsInTimezone(parseISO(iso), timeZone);
+  const targetHours = partial.hours ?? p.hour;
+  const targetMinutes = partial.minutes ?? p.minute;
+  const targetSeconds = partial.seconds ?? p.second;
+  const civilEpoch = Date.UTC(p.year, p.month - 1, p.day, targetHours, targetMinutes, targetSeconds);
+
+  // First pass: use the offset at the civil-as-UTC probe, correct once to absorb DST.
+  const probe1 = new Date(civilEpoch).toISOString();
+  const offset1 = getTimezoneOffsetMinutes(probe1, timeZone);
+  const realEpoch1 = civilEpoch - offset1 * 60_000;
+  const probe2 = new Date(realEpoch1).toISOString();
+  const offset2 = getTimezoneOffsetMinutes(probe2, timeZone);
+  const realEpoch2 = civilEpoch - offset2 * 60_000;
+  return new Date(realEpoch2).toISOString();
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kalyx/react",
 	"version": "0.3.0",
-	"description": "Headless, SSR-safe React DatePicker",
+	"description": "Headless, SSR-safe React DatePicker / RangePicker / TimePicker / DateTimePicker — ISO 8601 UTC strings, IANA timezone support, under 10 KB gzipped",
 	"license": "MIT",
 	"author": "jiji-hoon96",
 	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",
@@ -16,12 +16,20 @@
 	"keywords": [
 		"react",
 		"datepicker",
+		"daterangepicker",
+		"timepicker",
+		"datetimepicker",
 		"calendar",
 		"headless",
 		"typescript",
 		"tailwind",
 		"accessible",
-		"SSR"
+		"a11y",
+		"SSR",
+		"timezone",
+		"iana",
+		"dst",
+		"date-fns"
 	],
 	"type": "module",
 	"sideEffects": false,

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -53,14 +53,17 @@ export function DatePickerCalendar({ classNames, onTitleClick, ...props }: DateP
   const gridRef = useRef<HTMLTableElement>(null);
   const [announcement, setAnnouncement] = useState('');
 
-  const { adapter, viewMonth, focusedDate, weekStartsOn, disabled, locale } = ctx;
+  const { adapter, viewMonth, focusedDate, weekStartsOn, disabled, locale, displayTimezone } = ctx;
   const weekdays = getWeekdayNames(locale, weekStartsOn);
 
+  // Recompute cell flags with a timezone-aware today/selected matcher when displayTimezone is set.
+  // The grid iteration stays in UTC — only the `isSelected` / `isToday` highlighting shifts.
   const weeks = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,
     selected: ctx.value,
     focusedDate,
     disabled,
+    timezone: displayTimezone,
   });
 
   const year = adapter.getYear(viewMonth);

--- a/packages/react/src/components/DatePicker/Input.tsx
+++ b/packages/react/src/components/DatePicker/Input.tsx
@@ -23,7 +23,7 @@ export const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps
     let formattedValue = '';
     if (ctx.value) {
       try {
-        formattedValue = ctx.adapter.format(ctx.value, displayFormat);
+        formattedValue = ctx.adapter.format(ctx.value, displayFormat, ctx.displayTimezone);
       } catch {
         formattedValue = ctx.value;
       }

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { DateFnsAdapter, DEFAULT_DATEPICKER_LABELS } from '@kalyx/core';
+import { DateFnsAdapter, DEFAULT_DATEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
 import type { DateAdapter, DatePickerLabels, DisabledRule, ISODateString, WeekStartsOn } from '@kalyx/core';
 import { DatePickerContext } from '../../context/DatePickerContext.js';
 import type { DatePickerContextValue } from '../../context/DatePickerContext.js';
@@ -42,6 +42,12 @@ export interface DatePickerRootProps {
   displayFormat?: string;
   /** BCP 47 locale (e.g., "en-US", "ko-KR", "ja-JP") */
   locale?: string;
+  /**
+   * IANA timezone used for display and selection semantics (e.g., "Asia/Seoul").
+   * When set, the Input formats the value in this zone, Calendar highlights the matching civil
+   * day, and selecting a date emits the civil midnight of that day (UTC-ISO form).
+   */
+  displayTimezone?: string;
   /** Date adapter */
   adapter?: DateAdapter;
   /** Override ARIA labels (defaults to English) */
@@ -59,6 +65,7 @@ export function DatePickerRoot({
   weekStartsOn = 0,
   displayFormat = 'yyyy-MM-dd',
   locale = 'en-US',
+  displayTimezone,
   adapter = DateFnsAdapter,
   labels: labelsProp,
   children,
@@ -77,11 +84,11 @@ export function DatePickerRoot({
   const [isOpen, setIsOpen] = useState(false);
 
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue ?? adapter.today(),
+    currentValue ?? adapter.today(displayTimezone),
   );
 
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue ?? adapter.today(),
+    currentValue ?? adapter.today(displayTimezone),
   );
 
   const mergedLabels = useMemo(
@@ -99,25 +106,31 @@ export function DatePickerRoot({
     (iso: ISODateString | null) => {
       if (isDisabled || readOnly) return;
 
+      // The grid emits UTC-midnight ISO strings. When displayTimezone is set, map those to the
+      // civil midnight of the same calendar day in that zone — otherwise "picking Jan 15 in KST"
+      // would save Jan 14 15:00 UTC shifted incorrectly.
+      const normalized =
+        iso && displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
+
       if (!isControlled) {
-        setUncontrolledValue(iso);
+        setUncontrolledValue(normalized);
       }
-      onChange?.(iso);
+      onChange?.(normalized);
 
       // Close the popover after selection
       setIsOpen(false);
     },
-    [isControlled, isDisabled, readOnly, onChange],
+    [isControlled, isDisabled, readOnly, onChange, displayTimezone],
   );
 
   const open = useCallback(() => {
     if (isDisabled || readOnly) return;
     setIsOpen(true);
     // Reset the view to the current value or today when opening
-    const target = currentValue ?? adapter.today();
+    const target = currentValue ?? adapter.today(displayTimezone);
     setViewMonth(target);
     setFocusedDate(target);
-  }, [isDisabled, readOnly, currentValue, adapter]);
+  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -149,6 +162,7 @@ export function DatePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
       pickerId,
@@ -168,6 +182,7 @@ export function DatePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      displayTimezone,
       isDisabled,
       readOnly,
       pickerId,

--- a/packages/react/src/components/DateTimePicker/Input.tsx
+++ b/packages/react/src/components/DateTimePicker/Input.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useCallback } from 'react';
 import type { InputHTMLAttributes } from 'react';
-import { formatTimeString, getTime } from '@kalyx/core';
+import { formatTimeString, getTime, getTimeInTimezone } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
 
 export interface DateTimePickerInputProps
@@ -21,7 +21,11 @@ export const DateTimePickerInput = forwardRef<HTMLInputElement, DateTimePickerIn
     let displayValue = '';
     if (ctx.value) {
       try {
-        displayValue = `${ctx.adapter.format(ctx.value, 'yyyy-MM-dd')} ${formatTimeString(getTime(ctx.value))}`;
+        const datePart = ctx.adapter.format(ctx.value, 'yyyy-MM-dd', ctx.displayTimezone);
+        const time = ctx.displayTimezone
+          ? getTimeInTimezone(ctx.value, ctx.displayTimezone)
+          : getTime(ctx.value);
+        displayValue = `${datePart} ${formatTimeString(time)}`;
       } catch {
         displayValue = ctx.value;
       }

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -6,6 +6,9 @@ import {
   DEFAULT_TIMEPICKER_LABELS,
   getTime,
   setTime as setTimeOnIso,
+  getTimeInTimezone,
+  setTimeInTimezone,
+  civilMidnightFromUtcDay,
 } from '@kalyx/core';
 import type {
   DateAdapter,
@@ -60,6 +63,12 @@ export interface DateTimePickerRootProps {
   displayFormat?: string;
   /** BCP 47 locale */
   locale?: string;
+  /**
+   * IANA timezone used for display (e.g., "Asia/Seoul"). When set, Calendar highlights match
+   * civil days in this zone, TimePicker reads/writes the time in this zone, and the Input
+   * formats the combined date+time in this zone.
+   */
+  displayTimezone?: string;
   /** Date adapter */
   adapter?: DateAdapter;
   /** Override ARIA labels (defaults to English) */
@@ -96,6 +105,7 @@ export function DateTimePickerRoot({
   weekStartsOn = 0,
   displayFormat = 'yyyy-MM-dd HH:mm',
   locale = 'en-US',
+  displayTimezone,
   adapter = DateFnsAdapter,
   labels: labelsProp,
   children,
@@ -120,10 +130,10 @@ export function DateTimePickerRoot({
 
   const [isOpen, setIsOpen] = useState(false);
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue ?? adapter.today(),
+    currentValue ?? adapter.today(displayTimezone),
   );
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue ?? adapter.today(),
+    currentValue ?? adapter.today(displayTimezone),
   );
 
   const isDisabled = typeof disabled === 'boolean' ? disabled : false;
@@ -134,7 +144,10 @@ export function DateTimePickerRoot({
 
   // When value is null, use a fallback for time extraction
   const baseIso = currentValue ?? getDefaultIso();
-  const currentTime: TimeValue = useMemo(() => getTime(baseIso), [baseIso]);
+  const currentTime: TimeValue = useMemo(
+    () => (displayTimezone ? getTimeInTimezone(baseIso, displayTimezone) : getTime(baseIso)),
+    [baseIso, displayTimezone],
+  );
 
   const updateValue = useCallback(
     (next: ISODateString | null) => {
@@ -157,12 +170,22 @@ export function DateTimePickerRoot({
         updateValue(null);
         return;
       }
-      // Preserve the current time portion and apply it to the new date
-      const time = currentValue ? getTime(currentValue) : currentTime;
-      const merged = setTimeOnIso(newDateIso, time);
+      // Map UTC-grid ISO to civil-midnight in display timezone when set
+      const normalizedDate = displayTimezone
+        ? civilMidnightFromUtcDay(newDateIso, displayTimezone)
+        : newDateIso;
+      // Preserve the current time portion (tz-aware when applicable)
+      const time = currentValue
+        ? displayTimezone
+          ? getTimeInTimezone(currentValue, displayTimezone)
+          : getTime(currentValue)
+        : currentTime;
+      const merged = displayTimezone
+        ? setTimeInTimezone(normalizedDate, time, displayTimezone)
+        : setTimeOnIso(normalizedDate, time);
       updateValue(merged);
     },
-    [currentValue, currentTime, updateValue],
+    [currentValue, currentTime, updateValue, displayTimezone],
   );
 
   /**
@@ -170,21 +193,23 @@ export function DateTimePickerRoot({
    */
   const setTime = useCallback(
     (partial: Partial<TimeValue>) => {
-      // If no date yet, start from today at midnight
+      // If no date yet, start from today at midnight (tz-aware)
       const base = currentValue ?? getDefaultIso();
-      const merged = setTimeOnIso(base, partial);
+      const merged = displayTimezone
+        ? setTimeInTimezone(base, partial, displayTimezone)
+        : setTimeOnIso(base, partial);
       updateValue(merged);
     },
-    [currentValue, updateValue],
+    [currentValue, updateValue, displayTimezone],
   );
 
   const open = useCallback(() => {
     if (isDisabled || readOnly) return;
     setIsOpen(true);
-    const target = currentValue ?? adapter.today();
+    const target = currentValue ?? adapter.today(displayTimezone);
     setViewMonth(target);
     setFocusedDate(target);
-  }, [isDisabled, readOnly, currentValue, adapter]);
+  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -214,6 +239,7 @@ export function DateTimePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
       pickerId,
@@ -233,6 +259,7 @@ export function DateTimePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      displayTimezone,
       isDisabled,
       readOnly,
       pickerId,
@@ -248,13 +275,14 @@ export function DateTimePickerRoot({
       format,
       step,
       withSeconds: false,
+      displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
       currentTime,
       pickerId,
       labels: mergedTimeLabels,
     }),
-    [currentValue, setTime, format, step, isDisabled, readOnly, currentTime, pickerId, mergedTimeLabels],
+    [currentValue, setTime, format, step, displayTimezone, isDisabled, readOnly, currentTime, pickerId, mergedTimeLabels],
   );
 
   return (

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -62,6 +62,7 @@ export function RangePickerCalendar({ classNames, ...props }: RangePickerCalenda
     value,
     hoverDate,
     selectingTarget,
+    displayTimezone,
   } = ctx;
 
   const { locale } = ctx;
@@ -73,6 +74,7 @@ export function RangePickerCalendar({ classNames, ...props }: RangePickerCalenda
     disabled,
     range: value,
     rangeHover: hoverDate,
+    timezone: displayTimezone,
   });
 
   const year = adapter.getYear(viewMonth);

--- a/packages/react/src/components/RangePicker/Input.tsx
+++ b/packages/react/src/components/RangePicker/Input.tsx
@@ -28,7 +28,7 @@ export const RangePickerInput = forwardRef<HTMLInputElement, RangePickerInputPro
     let displayValue = '';
     if (value) {
       try {
-        displayValue = ctx.adapter.format(value, displayFormat);
+        displayValue = ctx.adapter.format(value, displayFormat, ctx.displayTimezone);
       } catch {
         displayValue = value;
       }

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { DateFnsAdapter, DEFAULT_RANGEPICKER_LABELS } from '@kalyx/core';
+import { DateFnsAdapter, DEFAULT_RANGEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
 import type {
   DateAdapter,
   DateRange,
@@ -48,6 +48,12 @@ export interface RangePickerRootProps {
   displayFormat?: string;
   /** BCP 47 locale */
   locale?: string;
+  /**
+   * IANA timezone for display (e.g., "Asia/Seoul"). When set, inputs format in this zone,
+   * calendar highlighting uses civil-day comparison in this zone, and selected start/end are
+   * emitted as civil midnight of the clicked day in this zone (UTC-ISO form).
+   */
+  displayTimezone?: string;
   /** Date adapter */
   adapter?: DateAdapter;
   /** Override ARIA labels (defaults to English) */
@@ -65,6 +71,7 @@ export function RangePickerRoot({
   weekStartsOn = 0,
   displayFormat = 'yyyy-MM-dd',
   locale = 'en-US',
+  displayTimezone,
   adapter = DateFnsAdapter,
   labels: labelsProp,
   children,
@@ -88,11 +95,11 @@ export function RangePickerRoot({
   const [hoverDate, setHoverDate] = useState<ISODateString | null>(null);
 
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(),
+    currentValue.start ?? adapter.today(displayTimezone),
   );
 
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(),
+    currentValue.start ?? adapter.today(displayTimezone),
   );
 
   const mergedLabels = useMemo(
@@ -126,8 +133,11 @@ export function RangePickerRoot({
     (iso: ISODateString) => {
       if (isDisabled || readOnly) return;
 
+      // Normalize UTC-grid ISOs to civil-midnight-in-tz before storing (see DatePicker.Root).
+      const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
+
       if (selectingTarget === 'start') {
-        const newRange: DateRange = { start: iso, end: null };
+        const newRange: DateRange = { start: normalized, end: null };
         setRange(newRange);
         setSelectingTarget('end');
         setHoverDate(null);
@@ -135,17 +145,17 @@ export function RangePickerRoot({
         const start = currentValue.start;
         if (!start) {
           // Safety: if start is missing, treat this click as start
-          setRange({ start: iso, end: null });
+          setRange({ start: normalized, end: null });
           setSelectingTarget('end');
           return;
         }
 
         let newRange: DateRange;
-        if (adapter.isBefore(iso, start)) {
+        if (adapter.isBefore(normalized, start)) {
           // Swap if the clicked end is earlier than start
-          newRange = { start: iso, end: start };
+          newRange = { start: normalized, end: start };
         } else {
-          newRange = { start, end: iso };
+          newRange = { start, end: normalized };
         }
 
         setRange(newRange);
@@ -154,20 +164,20 @@ export function RangePickerRoot({
         setIsOpen(false);
       }
     },
-    [isDisabled, readOnly, selectingTarget, currentValue.start, adapter, setRange],
+    [isDisabled, readOnly, selectingTarget, currentValue.start, adapter, setRange, displayTimezone],
   );
 
   const open = useCallback(() => {
     if (isDisabled || readOnly) return;
     setIsOpen(true);
-    const target = currentValue.start ?? adapter.today();
+    const target = currentValue.start ?? adapter.today(displayTimezone);
     setViewMonth(target);
     setFocusedDate(target);
     // If the range is complete, restart; otherwise preserve current state
     if (currentValue.start && currentValue.end) {
       setSelectingTarget('start');
     }
-  }, [isDisabled, readOnly, currentValue, adapter]);
+  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -201,6 +211,7 @@ export function RangePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
       pickerId,
@@ -223,6 +234,7 @@ export function RangePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      displayTimezone,
       isDisabled,
       readOnly,
       pickerId,

--- a/packages/react/src/components/TimePicker/Root.tsx
+++ b/packages/react/src/components/TimePicker/Root.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { DateFnsAdapter, DEFAULT_TIMEPICKER_LABELS, getTime, setTime as setTimeOnIso } from '@kalyx/core';
+import {
+  DateFnsAdapter,
+  DEFAULT_TIMEPICKER_LABELS,
+  getTime,
+  setTime as setTimeOnIso,
+  getTimeInTimezone,
+  setTimeInTimezone,
+} from '@kalyx/core';
 import type { ISODateString, TimePickerLabels, TimeValue } from '@kalyx/core';
 import { TimePickerContext } from '../../context/TimePickerContext.js';
 import type {
@@ -34,6 +41,11 @@ export interface TimePickerRootProps {
   step?: number;
   /** Whether to display seconds */
   withSeconds?: boolean;
+  /**
+   * IANA timezone used to interpret time. When set, the hour/minute controls read and write
+   * the time as observed in this zone.
+   */
+  displayTimezone?: string;
   /** Whether entire picker is disabled */
   disabled?: boolean;
   /** Read-only */
@@ -56,6 +68,7 @@ export function TimePickerRoot({
   format = '24h',
   step = 1,
   withSeconds = false,
+  displayTimezone,
   disabled = false,
   readOnly = false,
   labels: labelsProp,
@@ -76,18 +89,23 @@ export function TimePickerRoot({
 
   // Allow time selection even when value is null -> fallback
   const baseIso = currentValue ?? getDefaultIso();
-  const currentTime = useMemo(() => getTime(baseIso), [baseIso]);
+  const currentTime = useMemo(
+    () => (displayTimezone ? getTimeInTimezone(baseIso, displayTimezone) : getTime(baseIso)),
+    [baseIso, displayTimezone],
+  );
 
   const setTime = useCallback(
     (partial: Partial<TimeValue>) => {
       if (disabled || readOnly) return;
-      const newIso = setTimeOnIso(baseIso, partial);
+      const newIso = displayTimezone
+        ? setTimeInTimezone(baseIso, partial, displayTimezone)
+        : setTimeOnIso(baseIso, partial);
       if (!isControlled) {
         setUncontrolledValue(newIso);
       }
       onChange?.(newIso);
     },
-    [disabled, readOnly, baseIso, isControlled, onChange],
+    [disabled, readOnly, baseIso, isControlled, onChange, displayTimezone],
   );
 
   const contextValue: TimePickerContextValue = useMemo(
@@ -97,13 +115,14 @@ export function TimePickerRoot({
       format,
       step,
       withSeconds,
+      displayTimezone,
       isDisabled: disabled,
       isReadOnly: readOnly,
       currentTime,
       pickerId,
       labels: mergedLabels,
     }),
-    [currentValue, setTime, format, step, withSeconds, disabled, readOnly, currentTime, pickerId, mergedLabels],
+    [currentValue, setTime, format, step, withSeconds, displayTimezone, disabled, readOnly, currentTime, pickerId, mergedLabels],
   );
 
   return (

--- a/packages/react/src/components/__tests__/displayTimezone.test.tsx
+++ b/packages/react/src/components/__tests__/displayTimezone.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Cross-component displayTimezone integration tests.
+ *
+ * The point is to verify that when `displayTimezone` is set on each Root, the public behavior
+ * (onChange ISO emissions, Input formatting) reflects the chosen zone. Core math is exercised
+ * more thoroughly in packages/core/src/__tests__/timezone.test.ts.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DatePicker } from '../DatePicker/index.js';
+import { RangePicker } from '../RangePicker/index.js';
+import { TimePicker } from '../TimePicker/index.js';
+import { DateTimePicker } from '../DateTimePicker/index.js';
+
+describe('DatePicker — displayTimezone', () => {
+  it('emits civil-midnight-in-tz ISO on selection (Asia/Seoul = UTC+9)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DatePicker
+        value="2026-01-15T00:00:00.000Z"
+        displayTimezone="Asia/Seoul"
+        onChange={onChange}
+      >
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    // Click January 15 cell
+    await user.click(screen.getByRole('button', { name: /January 15/ }));
+    // Seoul Jan 15 00:00 = UTC Jan 14 15:00
+    expect(onChange).toHaveBeenCalledWith('2026-01-14T15:00:00.000Z');
+  });
+
+  it('formats the Input using the display timezone', () => {
+    render(
+      <DatePicker
+        value="2026-01-14T15:00:00.000Z"
+        displayTimezone="Asia/Seoul"
+      >
+        <DatePicker.Input aria-label="date" />
+      </DatePicker>,
+    );
+    expect(screen.getByRole('combobox')).toHaveValue('2026-01-15');
+  });
+});
+
+describe('RangePicker — displayTimezone', () => {
+  it('emits civil-midnight-in-tz for start and end', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <RangePicker
+        defaultValue={{ start: '2026-01-05T00:00:00.000Z', end: null }}
+        displayTimezone="Asia/Seoul"
+        onChange={onChange}
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: /January 10/ }));
+    await user.click(screen.getByRole('button', { name: /January 20/ }));
+
+    const last = onChange.mock.calls.at(-1)?.[0];
+    expect(last).toEqual({
+      start: '2026-01-09T15:00:00.000Z',
+      end: '2026-01-19T15:00:00.000Z',
+    });
+  });
+});
+
+describe('TimePicker — displayTimezone', () => {
+  it('reads and writes the time-of-day in the requested timezone', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // Start from UTC 00:00 Jan 15 (= KST 09:00 Jan 15). Pick hour 10 → KST 10:00 = UTC 01:00.
+    render(
+      <TimePicker
+        value="2026-01-15T00:00:00.000Z"
+        displayTimezone="Asia/Seoul"
+        onChange={onChange}
+      >
+        <TimePicker.HourList />
+        <TimePicker.MinuteList />
+      </TimePicker>,
+    );
+    await user.click(screen.getByRole('option', { name: '10 hours' }));
+    expect(onChange).toHaveBeenCalledWith('2026-01-15T01:00:00.000Z');
+  });
+});
+
+describe('DateTimePicker — displayTimezone', () => {
+  it('selecting a day preserves the tz-local time portion', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // Start: UTC 2026-01-14T15:00Z (= Seoul Jan 15 00:00)
+    render(
+      <DateTimePicker
+        value="2026-01-14T15:00:00.000Z"
+        displayTimezone="Asia/Seoul"
+        onChange={onChange}
+      >
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePicker.Calendar />
+          <DateTimePicker.HourList />
+          <DateTimePicker.MinuteList />
+        </DateTimePicker.Popover>
+      </DateTimePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    // Click Jan 20 → Seoul Jan 20 00:00 = UTC Jan 19 15:00
+    await user.click(screen.getByRole('button', { name: /January 20/ }));
+    expect(onChange).toHaveBeenCalledWith('2026-01-19T15:00:00.000Z');
+  });
+});

--- a/packages/react/src/context/DatePickerContext.ts
+++ b/packages/react/src/context/DatePickerContext.ts
@@ -35,6 +35,12 @@ export interface DatePickerContextValue {
   displayFormat: string;
   /** BCP 47 locale (e.g., "en-US", "ko-KR") */
   locale: string;
+  /**
+   * IANA timezone for display (e.g., "Asia/Seoul"). When set, the Input formats the value in
+   * this zone, Calendar highlights the matching civil day, and selecting a date emits the civil
+   * midnight of that day in the zone (UTC-ISO form).
+   */
+  displayTimezone?: string;
   /** Whether entire picker is disabled */
   isDisabled: boolean;
   /** Read-only */

--- a/packages/react/src/context/RangePickerContext.ts
+++ b/packages/react/src/context/RangePickerContext.ts
@@ -47,6 +47,8 @@ export interface RangePickerContextValue {
   displayFormat: string;
   /** BCP 47 locale */
   locale: string;
+  /** IANA timezone for display (see DatePickerContext#displayTimezone) */
+  displayTimezone?: string;
   /** Whether entire picker is disabled */
   isDisabled: boolean;
   /** Read-only */

--- a/packages/react/src/context/TimePickerContext.ts
+++ b/packages/react/src/context/TimePickerContext.ts
@@ -14,6 +14,11 @@ export interface TimePickerContextValue {
   step: number;
   /** Whether to display seconds */
   withSeconds: boolean;
+  /**
+   * IANA timezone for time interpretation. When set, the hour/minute controls read and write
+   * the time as observed in this zone rather than UTC.
+   */
+  displayTimezone?: string;
   /** Whether entire picker is disabled */
   isDisabled: boolean;
   /** Read-only */

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -1,5 +1,5 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { DateFnsAdapter, getCalendarDays } from '@kalyx/core';
+import { DateFnsAdapter, civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
 import type {
   CalendarGrid,
   DateAdapter,
@@ -21,6 +21,8 @@ export interface UseDatePickerOptions {
   weekStartsOn?: WeekStartsOn;
   /** Date adapter */
   adapter?: DateAdapter;
+  /** IANA timezone for display (see DatePickerRoot#displayTimezone) */
+  displayTimezone?: string;
 }
 
 export interface UseDatePickerReturn {
@@ -78,6 +80,7 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
     disabled = [],
     weekStartsOn = 0,
     adapter = DateFnsAdapter,
+    displayTimezone,
   } = options;
 
   const pickerId = useId();
@@ -90,26 +93,32 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [viewMonth, setViewMonth] = useState<ISODateString>(currentValue ?? adapter.today());
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(currentValue ?? adapter.today());
+  const [viewMonth, setViewMonth] = useState<ISODateString>(
+    currentValue ?? adapter.today(displayTimezone),
+  );
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(
+    currentValue ?? adapter.today(displayTimezone),
+  );
 
   const selectDate = useCallback(
     (iso: ISODateString | null) => {
+      const normalized =
+        iso && displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (!isControlled) {
-        setUncontrolledValue(iso);
+        setUncontrolledValue(normalized);
       }
-      onChange?.(iso);
+      onChange?.(normalized);
       setIsOpen(false);
     },
-    [isControlled, onChange],
+    [isControlled, onChange, displayTimezone],
   );
 
   const open = useCallback(() => {
     setIsOpen(true);
-    const target = currentValue ?? adapter.today();
+    const target = currentValue ?? adapter.today(displayTimezone);
     setViewMonth(target);
     setFocusedDate(target);
-  }, [currentValue, adapter]);
+  }, [currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -137,6 +146,7 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
     selected: currentValue,
     focusedDate,
     disabled,
+    timezone: displayTimezone,
   });
 
   return {

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -1,5 +1,5 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { DateFnsAdapter, getCalendarDays } from '@kalyx/core';
+import { DateFnsAdapter, civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
 import type {
   CalendarGrid,
   DateAdapter,
@@ -25,6 +25,8 @@ export interface UseRangePickerOptions {
   weekStartsOn?: WeekStartsOn;
   /** Date adapter */
   adapter?: DateAdapter;
+  /** IANA timezone for display (see RangePickerRoot#displayTimezone) */
+  displayTimezone?: string;
 }
 
 export interface UseRangePickerReturn {
@@ -85,6 +87,7 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
     disabled = [],
     weekStartsOn = 0,
     adapter = DateFnsAdapter,
+    displayTimezone,
   } = options;
 
   const pickerId = useId();
@@ -100,10 +103,10 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
   const [selectingTarget, setSelectingTarget] = useState<RangeSelectingTarget>('start');
   const [hoverDate, setHoverDate] = useState<ISODateString | null>(null);
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(),
+    currentValue.start ?? adapter.today(displayTimezone),
   );
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(),
+    currentValue.start ?? adapter.today(displayTimezone),
   );
 
   const setRange = useCallback(
@@ -118,21 +121,22 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
 
   const selectDate = useCallback(
     (iso: ISODateString) => {
+      const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (selectingTarget === 'start') {
-        setRange({ start: iso, end: null });
+        setRange({ start: normalized, end: null });
         setSelectingTarget('end');
         setHoverDate(null);
       } else {
         const start = currentValue.start;
         if (!start) {
-          setRange({ start: iso, end: null });
+          setRange({ start: normalized, end: null });
           setSelectingTarget('end');
           return;
         }
 
-        const newRange: DateRange = adapter.isBefore(iso, start)
-          ? { start: iso, end: start }
-          : { start, end: iso };
+        const newRange: DateRange = adapter.isBefore(normalized, start)
+          ? { start: normalized, end: start }
+          : { start, end: normalized };
 
         setRange(newRange);
         setSelectingTarget('start');
@@ -140,18 +144,18 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
         setIsOpen(false);
       }
     },
-    [selectingTarget, currentValue.start, adapter, setRange],
+    [selectingTarget, currentValue.start, adapter, setRange, displayTimezone],
   );
 
   const open = useCallback(() => {
     setIsOpen(true);
-    const target = currentValue.start ?? adapter.today();
+    const target = currentValue.start ?? adapter.today(displayTimezone);
     setViewMonth(target);
     setFocusedDate(target);
     if (currentValue.start && currentValue.end) {
       setSelectingTarget('start');
     }
-  }, [currentValue, adapter]);
+  }, [currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -181,6 +185,7 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
     disabled,
     range: currentValue,
     rangeHover: hoverDate,
+    timezone: displayTimezone,
   });
 
   return {

--- a/packages/react/src/hooks/useTimePicker.ts
+++ b/packages/react/src/hooks/useTimePicker.ts
@@ -5,6 +5,8 @@ import {
   generateMinutes,
   getTime,
   setTime as setTimeOnIso,
+  getTimeInTimezone,
+  setTimeInTimezone,
   to12Hour,
   to24Hour,
 } from '@kalyx/core';
@@ -24,6 +26,8 @@ export interface UseTimePickerOptions {
   step?: number;
   /** Whether seconds are shown */
   withSeconds?: boolean;
+  /** IANA timezone for time interpretation (see TimePickerRoot#displayTimezone) */
+  displayTimezone?: string;
 }
 
 export interface UseTimePickerReturn {
@@ -83,6 +87,7 @@ export function useTimePicker(options: UseTimePickerOptions = {}): UseTimePicker
     onChange,
     format = '24h',
     step = 1,
+    displayTimezone,
   } = options;
 
   const pickerId = useId();
@@ -94,17 +99,22 @@ export function useTimePicker(options: UseTimePickerOptions = {}): UseTimePicker
 
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
   const baseIso = currentValue ?? getDefaultIso();
-  const currentTime = useMemo(() => getTime(baseIso), [baseIso]);
+  const currentTime = useMemo(
+    () => (displayTimezone ? getTimeInTimezone(baseIso, displayTimezone) : getTime(baseIso)),
+    [baseIso, displayTimezone],
+  );
 
   const setTime = useCallback(
     (partial: Partial<TimeValue>) => {
-      const newIso = setTimeOnIso(baseIso, partial);
+      const newIso = displayTimezone
+        ? setTimeInTimezone(baseIso, partial, displayTimezone)
+        : setTimeOnIso(baseIso, partial);
       if (!isControlled) {
         setUncontrolledValue(newIso);
       }
       onChange?.(newIso);
     },
-    [baseIso, isControlled, onChange],
+    [baseIso, isControlled, onChange, displayTimezone],
   );
 
   const period = format === '12h' ? to12Hour(currentTime.hours).period : null;


### PR DESCRIPTION
## Summary

- `displayTimezone` prop on all four pickers (`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`) + matching hooks. When set, `onChange` emits civil midnight of the selected day in the target zone — a structural fix for the "day off by one" bug (react-datepicker #1018).
- `DateFnsAdapter` now honors the `timezone` argument on `format` / `isSameDay` / `startOfDay` / `today`. Previously the signature existed but the argument was silently ignored.
- New public helpers in `@kalyx/core`: `civilMidnightFromUtcDay`, `getTimeInTimezone`, `setTimeInTimezone` (plus DST-aware internals already in place).
- `@kalyx/core` is now `sideEffects: false` so downstream bundlers can tree-shake unused exports.
- Documentation overhaul: new `/concepts/timezone` page, displayTimezone threaded through every component / hook / API page, migration guide v0.3 → v0.4 section, updated README + README.ko comparison tables with bundlephobia-verified numbers, richer npm descriptions / keywords, contributor guidance.
- Playground demo + cross-browser Playwright E2E coverage for the timezone flow.

No breaking changes — omitting `displayTimezone` keeps v0.3 UTC semantics.

## Changesets pending

- `.changeset/timezone-v04.md` — `@kalyx/core` minor + `@kalyx/react` minor
- `.changeset/core-sideeffects.md` — `@kalyx/core` patch

The release workflow will create a follow-up "chore: release packages" PR after this merges.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test:run` ✅ 318 tests (14 new: 9 timezone-core, 5 React integration)
- `pnpm build` ✅
- `pnpm check-bundle` ✅ 9.73 KB gzip (< 12 KB target)
- `pnpm test:e2e --project=chromium e2e/timezone.e2e.ts` ✅ 5 / 5 pass

## Test plan

- [ ] CI turns green on all jobs (typecheck, lint, test, build, bundle-size, SSR, cross-browser E2E)
- [ ] Manual sanity: open the `/datepicker` Timezone demo, pick the same civil day in `Asia/Seoul` and `America/New_York`, confirm the emitted ISO differs by the expected offset
- [ ] Docs-site builds cleanly and `/playground` renders the new `displayTimezone` live example
- [ ] After merge: review the auto-generated "chore: release packages" PR before merging it to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 모든 날짜/시간 선택기에 timezone 지원 추가: `displayTimezone` 속성으로 지정된 IANA timezone에서 입력/출력 표시 가능
  * 새로운 timezone 유틸리티 함수 공개

* **Documentation**
  * 새로운 timezone 개념 페이지 및 마이그레이션 가이드 추가
  * 모든 picker 컴포넌트 및 hook 문서에 `displayTimezone` 옵션 설명 추가

* **Tests**
  * E2E 테스트 및 유닛 테스트로 timezone 기능 검증

* **Chores**
  * 번들 사이즈 배지 업데이트 (9.2KB → 9.73KB)
  * 패키지 메타데이터 및 설명 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->