### PR TITLE
fix(react): prevent WeekPicker from mutating RangePicker.Calendar

### DIFF
--- a/.changeset/fix-rangepicker-mutation.md
+++ b/.changeset/fix-rangepicker-mutation.md
@@ -1,0 +1,13 @@
+---
+'@kalyx/react': patch
+---
+
+fix(react): prevent WeekPicker from mutating RangePicker.Calendar
+
+`WeekPicker` previously called `Object.assign(RangePickerRoot, { ..., Calendar: WeekPickerCalendar })`, which mutates the shared `RangePickerRoot` function object. Because `RangePicker.Calendar` is attached to the same object (via the earlier `Object.assign` in `RangePicker/index.ts`), importing `WeekPicker` would overwrite `RangePicker.Calendar` with `WeekPickerCalendar`.
+
+Users of `RangePicker` would then see week-selection behavior (single click commits a full week and closes the popover) instead of the documented two-click range flow — even without importing `WeekPicker` directly, because both pickers share the module graph.
+
+Added an internal `WeekPickerRoot` wrapper that the `Object.assign` target now uses, preserving `RangePickerRoot.Calendar` intact.
+
+Caught by the `RangePicker › select range in start-date -> end-date order` Playwright test; all existing behavior is restored.

--- a/packages/react/src/components/WeekPicker/Root.tsx
+++ b/packages/react/src/components/WeekPicker/Root.tsx
@@ -1,0 +1,16 @@
+import { RangePickerRoot } from '../RangePicker/Root.js';
+import type { RangePickerRootProps } from '../RangePicker/Root.js';
+
+/** Props for WeekPicker.Root — reuses RangePicker.Root. */
+export type WeekPickerRootProps = RangePickerRootProps;
+
+/**
+ * WeekPicker.Root — thin wrapper over RangePicker.Root.
+ *
+ * The wrapper is necessary (rather than aliasing `RangePickerRoot` directly) because
+ * `Object.assign` on the exported root mutates the target. Without a distinct identity here,
+ * `WeekPicker.Calendar` would leak onto `RangePicker.Calendar`.
+ */
+export function WeekPickerRoot(props: WeekPickerRootProps) {
+  return <RangePickerRoot {...props} />;
+}

--- a/packages/react/src/components/WeekPicker/index.ts
+++ b/packages/react/src/components/WeekPicker/index.ts
@@ -1,15 +1,12 @@
-import { RangePickerRoot } from '../RangePicker/Root.js';
+import { WeekPickerRoot } from './Root.js';
 import { RangePickerInput } from '../RangePicker/Input.js';
 import { RangePickerPopover } from '../RangePicker/Popover.js';
 import { WeekPickerCalendar } from './Calendar.js';
 
-import type { RangePickerRootProps } from '../RangePicker/Root.js';
+import type { WeekPickerRootProps } from './Root.js';
 import type { RangePickerInputProps } from '../RangePicker/Input.js';
 import type { RangePickerPopoverProps } from '../RangePicker/Popover.js';
 import type { WeekPickerCalendarProps, WeekPickerCalendarClassNames } from './Calendar.js';
-
-/** Props for WeekPicker.Root — reuses RangePicker.Root. */
-type WeekPickerRootPropsType = RangePickerRootProps;
 
 /**
  * WeekPicker — Headless week selector. Value is a `DateRange` spanning the entire week (start
@@ -30,14 +27,14 @@ type WeekPickerRootPropsType = RangePickerRootProps;
  * </WeekPicker>
  * ```
  */
-export const WeekPicker = Object.assign(RangePickerRoot, {
+export const WeekPicker = Object.assign(WeekPickerRoot, {
   Input: RangePickerInput,
   Popover: RangePickerPopover,
   Calendar: WeekPickerCalendar,
 });
 
 export type {
-  WeekPickerRootPropsType as WeekPickerRootProps,
+  WeekPickerRootProps,
   RangePickerInputProps as WeekPickerInputProps,
   RangePickerPopoverProps as WeekPickerPopoverProps,
   WeekPickerCalendarProps,


### PR DESCRIPTION
## Summary

Fixes a regression introduced in the v1-rc-preparation batch (PR #11). `WeekPicker` was mutating the shared `RangePickerRoot` function object, causing `RangePicker.Calendar` to be replaced by `WeekPickerCalendar` — so `RangePicker` would exhibit week-selection behavior (single click commits a full week and closes the popover) instead of its two-click range flow.

## Root cause

`WeekPicker/index.ts` used `Object.assign(RangePickerRoot, {...})` with `Calendar: WeekPickerCalendar`. Since `Object.assign` mutates its first argument and `RangePicker` exports the same `RangePickerRoot` function object (with its own `.Calendar` set by the earlier `Object.assign` in `RangePicker/index.ts`), the WeekPicker assignment overwrote `RangePicker.Calendar` at module evaluation time.

MonthPicker and YearPicker don't hit this because they wrap `DatePickerRoot` in their own thin `MonthPickerRoot` / `YearPickerRoot` functions before running `Object.assign` — so the mutation targets the local wrapper, not the shared root.

## Fix

Added `WeekPicker/Root.tsx` with a `WeekPickerRoot` wrapper function (same pattern as MonthPicker/YearPicker) and retargeted the `Object.assign` in `WeekPicker/index.ts`. `RangePickerRoot` is no longer mutated.

## Why unit tests didn't catch it

Each Vitest describe block imports components freshly — the Object.assign side effect was present in unit tests too, but since `RangePicker.test.tsx` runs in an isolated module scope and the tests exercise the *composed* picker surface, the mutation happened before the assertions and no test asserted that `RangePicker.Calendar !== WeekPicker.Calendar`. The Playwright E2E test in `e2e-and-docs.yml` (`RangePicker › select range in start-date -> end-date order`) caught it because it exercises the real-world click flow against a fully bundled app.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:run` — 368 passed
- [x] `pnpm build`
- [x] `pnpm check-bundle` — 11.40KB gzip (no regression)
- [x] `npx playwright test --project=chromium` — **18/18 passed** (the previously-failing `select range in start-date -> end-date order` now passes in 301ms)

## Effect on the open release PR (#12)

This changeset is marked `patch` on `@kalyx/react`. Once merged, the release workflow will update PR #12 to include it — the version target becomes `1.0.0-rc.0` with this fix bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)