### PR TITLE
docs(rc): v1.0 RC announcement — badges, banner, release notes

### DIFF
--- a/.github/RC_SOCIAL_DRAFT.md
+++ b/.github/RC_SOCIAL_DRAFT.md
@@ -1,0 +1,33 @@
+# v1.0.0-rc.0 Social Copy Drafts
+
+> Do NOT post these automatically. Review and publish manually.
+
+---
+
+## X / Twitter (280 chars)
+
+Kalyx v1.0-rc is out — the headless React DatePicker that ships complete. Single / range / time / month / year / week pickers, ISO 8601 UTC, IANA timezone, 11.4KB gzip.
+
+`pnpm add @kalyx/react@next`
+
+Feedback welcome → https://github.com/jiji-hoon96/kalyx/issues
+
+---
+
+## LinkedIn
+
+After months of composition-first API work, Kalyx v1.0 is in release candidate. One library covers Date, Range, Time, DateTime, Month, Year, Week pickers — zero CSS, SSR-safe, IANA timezone. Bundle stays under 12KB gzipped.
+
+Try the RC: `pnpm add @kalyx/react@next`
+
+Issues & feedback: https://github.com/jiji-hoon96/kalyx/issues (tag `v1-rc`).
+
+---
+
+## Korean (X / Twitter)
+
+Kalyx v1.0-rc 출시! Headless React DatePicker — Date/Range/Time/Month/Year/Week 올인원. CSS 없이 11.4KB gzip, SSR 안전, IANA 타임존.
+
+`pnpm add @kalyx/react@next`
+
+피드백 환영 → https://github.com/jiji-hoon96/kalyx/issues (v1-rc 라벨)

--- a/.github/RELEASE_NOTES_RC.md
+++ b/.github/RELEASE_NOTES_RC.md
@@ -1,0 +1,31 @@
+# v1.0.0-rc.0 — First Release Candidate
+
+This is the first RC for Kalyx v1.0. The public API is frozen; we're collecting feedback before cutting the stable release.
+
+## What's in
+
+- **MonthPicker / YearPicker / WeekPicker** — three new top-level components sharing the same composition + adapter contract
+- **Presets API** — `DatePicker.Presets` + `DatePicker.Preset` (today / tomorrow / startOfMonth / custom ISO)
+- **Event callbacks** — `onOpenChange`, `onCalendarNavigate` on all picker roots
+- **WeekPicker mutation fix** — WeekPicker no longer mutates the shared calendar config
+- **IANA timezone** — DST-safe `displayTimezone` on Date/DateTime/Range pickers
+- **API freeze** — public API surface is now stable; any breaking change requires a major bump
+
+## Bundle
+
+- ESM: **11.39 KB** gzip (target: ≤ 12 KB)
+- CJS: **11.40 KB** gzip
+
+## Install
+
+```bash
+pnpm add @kalyx/react@next   # 1.0.0-rc.0
+```
+
+## Feedback
+
+RC issues welcome at https://github.com/jiji-hoon96/kalyx/issues — tag them `v1-rc`.
+
+## Full changelog
+
+See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) and [packages/core/CHANGELOG.md](./packages/core/CHANGELOG.md).

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,8 @@
 [문서](https://kalyx-docs.vercel.app/ko) · [English Docs](https://kalyx-docs.vercel.app) · [npm](https://www.npmjs.com/package/@kalyx/react) · [GitHub](https://github.com/jiji-hoon96/kalyx)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-9.73KB-brightgreen)](#번들-크기)
+[![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
+[![Bundle](https://img.shields.io/badge/gzip-11.39KB-brightgreen)](#번들-크기)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -25,6 +26,9 @@ Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브�
 ```bash
 pnpm add @kalyx/react
 ```
+
+> **v1.0 릴리즈 후보(RC)를 사용해 보세요!**
+> `pnpm add @kalyx/react@next` — 이슈는 [`v1-rc`](https://github.com/jiji-hoon96/kalyx/issues?q=label%3Av1-rc) 라벨로 등록해 주세요.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -49,7 +53,7 @@ bundlephobia 기준 (2026년 4월). 각주는 표 아래를 참조.
 | react-datepicker | 9.1 | 44 KB | ❌ (CSS 필수) | ✅ | ⚠️ prop | ⚠️ 결합형 | ✅ 분리형 | `Date` | ⚠️ |
 | Ark UI | 5.36 | 265 KB² | ✅ | ✅ | ❌ (제거됨) | ❌ | ✅ | `Date` | ⚠️ |
 | React Aria | 1.17 | 247 KB² | ✅ | ✅ | ✅ | ✅ | ✅ | `CalendarDate` | ✅ |
-| **Kalyx** | 0.3 | **9.73 KB** | ✅ | ✅ | ✅ 전용 | ✅ 전용 | ✅ 전용 | ISO 8601 UTC | ✅ `displayTimezone` |
+| **Kalyx** | 1.0.0-rc.0 | **11.39 KB** | ✅ | ✅ | ✅ 전용 | ✅ 전용 | ✅ 전용 | ISO 8601 UTC | ✅ `displayTimezone` |
 
 1. react-day-picker는 캘린더 그리드만 제공 — Kalyx와 동일한 스콥을 맞추려면 Input·Popover·TimePicker를 직접 조합해야 함. 2.4 KB는 기본 엔트리 기준.
 2. `@ark-ui/react`와 `react-aria-components`는 40+ 컴포넌트를 포함한 모노리스 패키지 — 트리셰이킹 시 더 작아지지만 `@internationalized/date` 등 생태계를 통째로 끌어들임.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 [Docs](https://kalyx-docs.vercel.app) · [한국어 문서](https://kalyx-docs.vercel.app/ko) · [npm](https://www.npmjs.com/package/@kalyx/react) · [GitHub](https://github.com/jiji-hoon96/kalyx)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-9.73KB-brightgreen)](#bundle-size)
+[![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
+[![Bundle](https://img.shields.io/badge/gzip-11.39KB-brightgreen)](#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -25,6 +26,9 @@ Kalyx is a headless React DatePicker library that ships **complete**. One compos
 ```bash
 pnpm add @kalyx/react
 ```
+
+> **Trying the v1.0 release candidate?**
+> `pnpm add @kalyx/react@next` — please report issues with the [`v1-rc`](https://github.com/jiji-hoon96/kalyx/issues?q=label%3Av1-rc) label.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -45,8 +49,8 @@ Numbers come from bundlephobia (April 2026). See [notes below the table](#footno
 
 | | Kalyx | react-datepicker | react-day-picker | Ark UI | React Aria |
 |---|---|---|---|---|---|
-| Version measured | 0.3.0 | 9.1.0 | 9.14.0 | 5.36.1 | 1.17.0 |
-| Bundle (min+gzip) | **9.73 KB** | 44 KB | 2.4 KB¹ | 265 KB² | 247 KB² |
+| Version measured | 1.0.0-rc.0 | 9.1.0 | 9.14.0 | 5.36.1 | 1.17.0 |
+| Bundle (min+gzip) | **11.39 KB** | 44 KB | 2.4 KB¹ | 265 KB² | 247 KB² |
 | DatePicker | ✅ | ✅ | ✅ | ✅ | ✅ |
 | RangePicker | ✅ dedicated | ✅ two-picker pattern | ✅ `mode="range"` | ✅ | ✅ |
 | TimePicker | ✅ dedicated | ⚠️ `showTimeSelect` prop | ❌ | ❌ (removed) | ✅ |

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -86,6 +86,14 @@ const config: Config = {
   ],
 
   themeConfig: {
+    announcementBar: {
+      id: 'v1-rc',
+      content:
+        'Kalyx v1.0 RC is out — try <code>pnpm add @kalyx/react@next</code> and share feedback on <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/issues">GitHub</a>.',
+      backgroundColor: '#5b4fe1',
+      textColor: '#ffffff',
+      isCloseable: true,
+    },
     image: 'img/social-card.jpeg',
     colorMode: {
       respectPrefersColorScheme: true,


### PR DESCRIPTION
## Summary

- README.md / README.ko.md: RC 배지 추가, 번들 크기 11.39KB 반영, "Try the RC" 블록, 비교표 버전 갱신
- docs-site: `announcementBar` 추가 (보라색 배너, 닫기 가능)
- `.github/RELEASE_NOTES_RC.md`: GitHub Release 본문 템플릿 (이미 적용 완료)
- `.github/RC_SOCIAL_DRAFT.md`: X/LinkedIn/한국어 소셜 카피 초안 (수동 게시용)
- `v1-rc` GitHub 라벨 생성 완료

## Checklist

- [x] `v1-rc` label created
- [x] GitHub Release notes updated (`@kalyx/react@1.0.0-rc.0`, `@kalyx/core@1.0.0-rc.0`)
- [x] Bundle size verified: 11.39KB gzip (≤12KB)
- [x] No code changes — docs only

## Test plan

- [ ] Verify RC badge renders on README
- [ ] Verify `pnpm --filter docs-site start` shows purple announcement bar
- [ ] Confirm social draft in `.github/RC_SOCIAL_DRAFT.md` before manual posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * v1.0.0-rc.0 릴리스 노트 및 소셜 미디어 배포 콘텐츠 추가
  * RC 버전 설치 안내(`@kalyx/react@next`) 및 이슈 보고 지침 추가
  * 번들 크기 정보 업데이트(9.73KB → 11.39KB)
  * 한국어 README 및 영문 README에 RC 버전 배지 추가

* **새 기능**
  * 문서 사이트에 RC 버전 공지 배너 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->