### PR TITLE
docs(i18n): add internationalization guide and v0.2→v0.3 migration

### DIFF
--- a/apps/docs-site/docs/concepts/accessibility.md
+++ b/apps/docs-site/docs/concepts/accessibility.md
@@ -80,6 +80,22 @@ For RangePicker, pair each input:
 <RangePicker.Input id="to" part="end" />
 ```
 
+### Built-in ARIA labels (`labels` prop)
+
+Kalyx auto-applies English ARIA labels to triggers, navigation buttons, and popover dialogs. Override them for other languages via the `labels` prop on any Root component:
+
+```tsx
+<DatePicker
+  labels={{ triggerOpen: '캘린더 열기', prevMonth: '이전 달', nextMonth: '���음 달' }}
+  value={iso}
+  onChange={setIso}
+>
+  {/* ... */}
+</DatePicker>
+```
+
+See the full key reference in the [Internationalization guide →](./internationalization.md).
+
 ## Color contrast
 
 Kalyx ships zero colors. **You own the palette** — which means you also own the contrast. A minimum of WCAG AA (4.5:1 for text, 3:1 for large text and focus indicators) is your responsibility. A few places to double-check:

--- a/apps/docs-site/docs/concepts/internationalization.md
+++ b/apps/docs-site/docs/concepts/internationalization.md
@@ -1,0 +1,155 @@
+---
+id: internationalization
+title: Internationalization (i18n)
+sidebar_position: 6
+---
+
+# Internationalization (i18n)
+
+Kalyx ships English ARIA labels by default. Override them per-component with the `labels` prop — no external i18n library required.
+
+## How it works
+
+Every Root component (`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`) accepts a `labels` prop. Pass a **partial** object — only the keys you override are replaced; the rest keep their English defaults.
+
+```tsx
+<DatePicker
+  value={date}
+  onChange={setDate}
+  labels={{
+    triggerOpen: '캘린더 열기',
+    prevMonth: '이전 달',
+    nextMonth: '다음 달',
+  }}
+>
+  {/* ... */}
+</DatePicker>
+```
+
+## Label keys reference
+
+### DatePicker
+
+| Key | Default (English) | Used by |
+| --- | --- | --- |
+| `triggerOpen` | `"Open calendar"` | Trigger `aria-label` (closed) |
+| `triggerClose` | `"Close calendar"` | Trigger `aria-label` (open) |
+| `popoverLabel` | `"Choose date"` | Popover `aria-label` |
+| `prevMonth` | `"Previous month"` | Calendar nav button |
+| `nextMonth` | `"Next month"` | Calendar nav button |
+| `prevYear` | `"Previous year"` | Calendar nav button |
+| `nextYear` | `"Next year"` | Calendar nav button |
+| `prevDecade` | `"Previous decade"` | YearGrid nav button |
+| `nextDecade` | `"Next decade"` | YearGrid nav button |
+
+### RangePicker (extends DatePicker)
+
+| Key | Default | Used by |
+| --- | --- | --- |
+| `popoverLabel` | `"Choose date range"` | Popover `aria-label` |
+| `startInput` | `"Start date"` | Start input `aria-label` |
+| `endInput` | `"End date"` | End input `aria-label` |
+| `presetsGroup` | `"Date range presets"` | Presets group `aria-label` |
+
+### TimePicker
+
+| Key | Default | Used by |
+| --- | --- | --- |
+| `timeInput` | `"Time"` | Input `aria-label` |
+| `hourList` | `"Hour"` | Hour listbox `aria-label` |
+| `minuteList` | `"Minute"` | Minute listbox `aria-label` |
+| `amPmToggle` | `"AM/PM"` | AM/PM radiogroup `aria-label` |
+| `hourOption(h)` | `` `${h} hours` `` | Hour option `aria-label` |
+| `minuteOption(m)` | `` `${m} minutes` `` | Minute option `aria-label` |
+
+### DateTimePicker (extends DatePicker + TimePicker)
+
+| Key | Default | Used by |
+| --- | --- | --- |
+| `dateTimeInput` | `"Date and time"` | Input `aria-label` |
+
+## Reusable locale presets
+
+Create a shared labels file and import it across your app:
+
+```ts title="lib/kalyx-labels.ts"
+import type { DatePickerLabels, RangePickerLabels, TimePickerLabels } from '@kalyx/core';
+
+export const ko: DatePickerLabels = {
+  triggerOpen: '캘린더 열기',
+  triggerClose: '캘린더 닫기',
+  popoverLabel: '날짜 선택',
+  prevMonth: '이전 달',
+  nextMonth: '다음 달',
+  prevYear: '이전 년',
+  nextYear: '다음 년',
+  prevDecade: '이전 10년',
+  nextDecade: '다음 10년',
+};
+
+export const koRange: RangePickerLabels = {
+  ...ko,
+  popoverLabel: '날짜 범위 선택',
+  startInput: '시작일',
+  endInput: '종료일',
+  presetsGroup: '날짜 범위 프리셋',
+};
+
+export const koTime: TimePickerLabels = {
+  timeInput: '시간',
+  hourList: '시',
+  minuteList: '분',
+  amPmToggle: '오전/오후',
+  hourOption: (h) => `${h}시`,
+  minuteOption: (m) => `${m}분`,
+};
+```
+
+```tsx title="components/BookingPicker.tsx"
+import { ko } from '@/lib/kalyx-labels';
+
+<DatePicker labels={ko} value={date} onChange={setDate}>
+  {/* ... */}
+</DatePicker>
+```
+
+## Japanese example
+
+```ts
+import type { DatePickerLabels } from '@kalyx/core';
+
+export const ja: DatePickerLabels = {
+  triggerOpen: 'カレンダーを開く',
+  triggerClose: 'カレンダーを閉じる',
+  popoverLabel: '日付を選択',
+  prevMonth: '前月',
+  nextMonth: '翌月',
+  prevYear: '前年',
+  nextYear: '翌年',
+  prevDecade: '前の10年',
+  nextDecade: '次の10年',
+};
+```
+
+## Calendar locale (weekday & month names)
+
+Weekday headers and month names use `Intl.DateTimeFormat` under the hood. Pass the `locale` prop (BCP 47 tag) to render them in the target language:
+
+```tsx
+<DatePicker locale="ko-KR" labels={ko} value={date} onChange={setDate}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+- `locale` controls **display formatting** (weekday names, month names in the header).
+- `labels` controls **ARIA attributes** (screen reader text).
+
+Both are independent — you can use `locale="ko-KR"` with English labels, or vice versa.
+
+## Next
+
+- [Accessibility →](./accessibility.md)
+- [Migration guide (v0.2 → v0.3) →](../migration.md#v02--v03--aria-labels-i18n)

--- a/apps/docs-site/docs/migration.md
+++ b/apps/docs-site/docs/migration.md
@@ -117,6 +117,43 @@ const toISO = (cal: CalendarDate | null): ISODateString | null =>
   cal ? new Date(Date.UTC(cal.year, cal.month - 1, cal.day)).toISOString() : null;
 ```
 
+## v0.2 → v0.3 — ARIA labels i18n
+
+v0.3 changes the default ARIA labels from Korean to English. If your app targets Korean users, restore the labels with the `labels` prop.
+
+### Breaking change
+
+All hardcoded Korean aria-labels (`"캘린더 열기"`, `"이전 달"`, etc.) are now English by default.
+
+### Restore Korean labels
+
+```tsx
+<DatePicker
+  value={date}
+  onChange={setDate}
+  labels={{
+    triggerOpen: '캘린더 열기',
+    triggerClose: '캘린더 닫기',
+    popoverLabel: '날짜 선택',
+    prevMonth: '이전 달',
+    nextMonth: '다음 달',
+    prevYear: '이전 년',
+    nextYear: '다음 년',
+    prevDecade: '이전 10년',
+    nextDecade: '다음 10년',
+  }}
+>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+You only need to override the keys you care about — unspecified keys keep the English defaults.
+
+For the full key reference and reusable locale presets, see the [Internationalization guide](./concepts/internationalization.md).
+
 ## v0.3 → v0.4 — adding `displayTimezone`
 
 v0.4 introduces `displayTimezone` on all four pickers (plus the matching hooks). No breaking changes — omitting the prop keeps v0.3 semantics. Adopt it when the user's displayed zone differs from the server runtime, or when you want an explicit barrier against "day off by one" bugs.

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/concepts/accessibility.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/concepts/accessibility.md
@@ -80,6 +80,22 @@ RangePicker에서는 각 입력에 라벨을 붙이세요.
 <RangePicker.Input id="to" part="end" />
 ```
 
+### 내장 ARIA 라벨 (`labels` prop)
+
+Kalyx는 트리거, 네비게이션 버튼, popover 다이얼로그에 영어 ARIA 라벨을 자동 적용합���다. 다른 언어로 오버라이드하려면 Root 컴포넌트에 `labels` prop을 전달하세요:
+
+```tsx
+<DatePicker
+  labels={{ triggerOpen: '캘린더 열기', prevMonth: '이전 달', nextMonth: '다음 달' }}
+  value={iso}
+  onChange={setIso}
+>
+  {/* ... */}
+</DatePicker>
+```
+
+전체 키 레퍼런스는 [다국어 가이드 →](./internationalization.md)를 참고하세요.
+
 ## 색상 대비
 
 Kalyx는 색상을 전혀 제공하지 않습니다. **팔레트를 여러분이 소유**하므로 대비도 여러분의 책임입니다. 최소 WCAG AA (텍스트 4.5:1, 큰 텍스트/포커스 인디케이터 3:1)를 확보해야 합니다. 특히 점검할 지점:

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -1,0 +1,155 @@
+---
+id: internationalization
+title: 다국어 (i18n)
+sidebar_position: 6
+---
+
+# 다국어 (i18n)
+
+Kalyx는 영어 ARIA 라벨을 기본으로 제공합니다. `labels` prop으로 컴포넌트별 오버라이드하세요 — 별도 i18n 라이브러리 불필요.
+
+## 동작 방식
+
+모든 Root 컴포넌트(`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`)가 `labels` prop을 받습니다. **부분 객체**만 넘기면 됩니다 — 오버라이드한 키만 교체되고 나머지는 영어 기본값이 유지됩니다.
+
+```tsx
+<DatePicker
+  value={date}
+  onChange={setDate}
+  labels={{
+    triggerOpen: '캘린더 열기',
+    prevMonth: '이전 달',
+    nextMonth: '다음 달',
+  }}
+>
+  {/* ... */}
+</DatePicker>
+```
+
+## 라벨 키 레퍼런스
+
+### DatePicker
+
+| 키 | 기본값 (영어) | 사용 위치 |
+| --- | --- | --- |
+| `triggerOpen` | `"Open calendar"` | Trigger `aria-label` (닫힘) |
+| `triggerClose` | `"Close calendar"` | Trigger `aria-label` (열림) |
+| `popoverLabel` | `"Choose date"` | Popover `aria-label` |
+| `prevMonth` | `"Previous month"` | Calendar 이전 달 버튼 |
+| `nextMonth` | `"Next month"` | Calendar 다음 달 버튼 |
+| `prevYear` | `"Previous year"` | Calendar 이전 년 버튼 |
+| `nextYear` | `"Next year"` | Calendar 다음 년 버튼 |
+| `prevDecade` | `"Previous decade"` | YearGrid 이전 10년 버튼 |
+| `nextDecade` | `"Next decade"` | YearGrid 다음 10년 버튼 |
+
+### RangePicker (DatePicker 확장)
+
+| 키 | 기본값 | 사용 위치 |
+| --- | --- | --- |
+| `popoverLabel` | `"Choose date range"` | Popover `aria-label` |
+| `startInput` | `"Start date"` | 시작 Input `aria-label` |
+| `endInput` | `"End date"` | 종료 Input `aria-label` |
+| `presetsGroup` | `"Date range presets"` | Presets 그룹 `aria-label` |
+
+### TimePicker
+
+| 키 | 기본값 | 사용 위치 |
+| --- | --- | --- |
+| `timeInput` | `"Time"` | Input `aria-label` |
+| `hourList` | `"Hour"` | 시 목록 `aria-label` |
+| `minuteList` | `"Minute"` | 분 목록 `aria-label` |
+| `amPmToggle` | `"AM/PM"` | AM/PM 라디오그룹 `aria-label` |
+| `hourOption(h)` | `` `${h} hours` `` | 시 옵션 `aria-label` |
+| `minuteOption(m)` | `` `${m} minutes` `` | 분 옵션 `aria-label` |
+
+### DateTimePicker (DatePicker + TimePicker 확장)
+
+| 키 | 기본값 | 사용 위치 |
+| --- | --- | --- |
+| `dateTimeInput` | `"Date and time"` | Input `aria-label` |
+
+## 재사용 가능한 로케일 프리셋
+
+공유 라벨 파일을 만들어 앱 전체에서 import하세요:
+
+```ts title="lib/kalyx-labels.ts"
+import type { DatePickerLabels, RangePickerLabels, TimePickerLabels } from '@kalyx/core';
+
+export const ko: DatePickerLabels = {
+  triggerOpen: '캘린더 열기',
+  triggerClose: '캘린더 닫기',
+  popoverLabel: '날짜 선택',
+  prevMonth: '이전 달',
+  nextMonth: '다음 달',
+  prevYear: '이전 년',
+  nextYear: '다음 년',
+  prevDecade: '이전 10년',
+  nextDecade: '다음 10년',
+};
+
+export const koRange: RangePickerLabels = {
+  ...ko,
+  popoverLabel: '날짜 범위 선택',
+  startInput: '시작일',
+  endInput: '종료일',
+  presetsGroup: '날짜 범위 프리셋',
+};
+
+export const koTime: TimePickerLabels = {
+  timeInput: '시간',
+  hourList: '시',
+  minuteList: '분',
+  amPmToggle: '오전/오후',
+  hourOption: (h) => `${h}시`,
+  minuteOption: (m) => `${m}분`,
+};
+```
+
+```tsx title="components/BookingPicker.tsx"
+import { ko } from '@/lib/kalyx-labels';
+
+<DatePicker labels={ko} value={date} onChange={setDate}>
+  {/* ... */}
+</DatePicker>
+```
+
+## 일본어 예제
+
+```ts
+import type { DatePickerLabels } from '@kalyx/core';
+
+export const ja: DatePickerLabels = {
+  triggerOpen: 'カレンダーを開く',
+  triggerClose: 'カレンダーを閉じる',
+  popoverLabel: '日付を選択',
+  prevMonth: '前月',
+  nextMonth: '翌月',
+  prevYear: '前年',
+  nextYear: '翌年',
+  prevDecade: '前の10年',
+  nextDecade: '次の10年',
+};
+```
+
+## 캘린더 로케일 (요일·월 이름)
+
+요일 헤더와 월 이름은 내부적으로 `Intl.DateTimeFormat`을 사용합니다. `locale` prop (BCP 47 태그)을 넘기면 해당 언어로 렌더됩니다:
+
+```tsx
+<DatePicker locale="ko-KR" labels={ko} value={date} onChange={setDate}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+- `locale`은 **표시 포맷**을 제어합니다 (요일 이름, 헤더의 월 이름).
+- `labels`는 **ARIA 속성**을 제어합니다 (스크린 리더 텍스트).
+
+둘은 독립적입니다 — `locale="ko-KR"`과 영어 라벨을 함께 쓸 수도 있고, 그 반대도 가능합니다.
+
+## 다음
+
+- [접근성 →](./accessibility.md)
+- [마이그레이션 가이드 (v0.2 → v0.3) →](../migration.md#v02--v03--aria-라벨-i18n)

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/migration.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/migration.md
@@ -117,6 +117,82 @@ const toISO = (cal: CalendarDate | null): ISODateString | null =>
   cal ? new Date(Date.UTC(cal.year, cal.month - 1, cal.day)).toISOString() : null;
 ```
 
+## v0.2 → v0.3 — ARIA 라벨 i18n
+
+v0.3에서 기본 ARIA 라벨이 한국어에서 영어로 변경되었습니다. 한국어 사용자라면 `labels` prop으로 복원하세요.
+
+### Breaking change
+
+모든 하드코딩된 한국어 aria-label (`"캘린더 열기"`, `"이전 달"` 등)이 영어 기본값으로 교체됐습니다.
+
+### 한국어 라벨 복원
+
+```tsx
+<DatePicker
+  value={date}
+  onChange={setDate}
+  labels={{
+    triggerOpen: '캘린�� 열기',
+    triggerClose: '캘린더 닫���',
+    popoverLabel: '날짜 선택',
+    prevMonth: '이��� 달',
+    nextMonth: '다음 달',
+    prevYear: '���전 년',
+    nextYear: '다음 년',
+    prevDecade: '이전 10년',
+    nextDecade: '다음 10년',
+  }}
+>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+변경하고 싶은 키만 넘기면 됩니다 — 나머지는 영어 기본값이 유지됩니다.
+
+전체 키 목록과 재사용 가능한 로케일 프리셋은 [다국어 가이드](./concepts/internationalization.md)를 참고하세요.
+
+## v0.3 → v0.4 — `displayTimezone` 추가
+
+v0.4���서 네 가지 Picker(와 대응 Hook)에 `displayTimezone` prop이 추가되었습니다. Breaking change 없음 — prop을 생략하면 v0.3 동작과 동일합니다.
+
+### Before (v0.3)
+
+```tsx
+<DatePicker value={iso} onChange={setIso}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+### After (v0.4)
+
+```tsx
+<DatePicker
+  value={iso}
+  onChange={setIso}
+  displayTimezone={user.timezone ?? 'UTC'}
+>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+ISO 계약은 바뀌지 않습니다. prop을 설정하면:
+
+- `Input`이 `displayTimezone` 기준으로 값을 포맷합니다.
+- `Calendar`가 해당 타임존 기준으로 오늘/선택 날짜를 하이라이트합니다.
+- `onChange`가 해당 타임존의 시민 자정(civil midnight)을 반환합니다.
+- `TimePicker` / `DateTimePicker`의 시/분이 DST를 반영합니다.
+
+자세한 내용은 [타임존 개념 페이지](./concepts/timezone.md)를 참고하세요.
+
 ## 일반 체크리스트
 
 이전 시:

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/accessibility.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/accessibility.md
@@ -80,6 +80,22 @@ RangePicker에서는 각 입력에 라벨을 붙이세요.
 <RangePicker.Input id="to" part="end" />
 ```
 
+### 내장 ARIA 라벨 (`labels` prop)
+
+Kalyx는 트리거, 네비게이션 버튼, popover 다이얼로그에 영어 ARIA 라벨을 자동 적용합���다. 다른 언어로 오버라이드하려면 Root 컴포넌트에 `labels` prop을 전달하세요:
+
+```tsx
+<DatePicker
+  labels={{ triggerOpen: '캘린더 열기', prevMonth: '이전 달', nextMonth: '다음 달' }}
+  value={iso}
+  onChange={setIso}
+>
+  {/* ... */}
+</DatePicker>
+```
+
+전체 키 레퍼런스는 [다국어 가이드 →](./internationalization.md)를 참고하세요.
+
 ## 색상 대비
 
 Kalyx는 색상을 전혀 제공하지 않습니다. **팔레트를 여러분이 소유**하므로 대비도 여러분의 책임입니다. 최소 WCAG AA (텍스트 4.5:1, 큰 텍스트/포커스 인디케이터 3:1)를 확보해야 합니다. 특히 점검할 지점:

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -1,0 +1,155 @@
+---
+id: internationalization
+title: 다국어 (i18n)
+sidebar_position: 6
+---
+
+# 다국어 (i18n)
+
+Kalyx는 영어 ARIA 라벨을 기본으로 제공합니다. `labels` prop으로 컴포넌트별 오버라이드하세요 — 별도 i18n 라이브러리 불필요.
+
+## 동작 방식
+
+모든 Root 컴포넌트(`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`)가 `labels` prop을 받습니다. **부분 객체**만 넘기면 됩니다 — 오버라이드한 키만 교체되고 나머지는 영어 기본값이 유지됩니다.
+
+```tsx
+<DatePicker
+  value={date}
+  onChange={setDate}
+  labels={{
+    triggerOpen: '캘린더 열기',
+    prevMonth: '이전 달',
+    nextMonth: '다음 달',
+  }}
+>
+  {/* ... */}
+</DatePicker>
+```
+
+## 라벨 키 레퍼런스
+
+### DatePicker
+
+| 키 | 기본값 (영어) | 사용 위치 |
+| --- | --- | --- |
+| `triggerOpen` | `"Open calendar"` | Trigger `aria-label` (닫힘) |
+| `triggerClose` | `"Close calendar"` | Trigger `aria-label` (열림) |
+| `popoverLabel` | `"Choose date"` | Popover `aria-label` |
+| `prevMonth` | `"Previous month"` | Calendar 이전 달 버튼 |
+| `nextMonth` | `"Next month"` | Calendar 다음 달 버튼 |
+| `prevYear` | `"Previous year"` | Calendar 이전 년 버튼 |
+| `nextYear` | `"Next year"` | Calendar 다음 년 버튼 |
+| `prevDecade` | `"Previous decade"` | YearGrid 이전 10년 버튼 |
+| `nextDecade` | `"Next decade"` | YearGrid 다음 10년 버튼 |
+
+### RangePicker (DatePicker 확장)
+
+| 키 | 기본값 | 사용 위치 |
+| --- | --- | --- |
+| `popoverLabel` | `"Choose date range"` | Popover `aria-label` |
+| `startInput` | `"Start date"` | 시작 Input `aria-label` |
+| `endInput` | `"End date"` | 종료 Input `aria-label` |
+| `presetsGroup` | `"Date range presets"` | Presets 그룹 `aria-label` |
+
+### TimePicker
+
+| 키 | 기본값 | 사용 위치 |
+| --- | --- | --- |
+| `timeInput` | `"Time"` | Input `aria-label` |
+| `hourList` | `"Hour"` | 시 목록 `aria-label` |
+| `minuteList` | `"Minute"` | 분 목록 `aria-label` |
+| `amPmToggle` | `"AM/PM"` | AM/PM 라디오그룹 `aria-label` |
+| `hourOption(h)` | `` `${h} hours` `` | 시 옵션 `aria-label` |
+| `minuteOption(m)` | `` `${m} minutes` `` | 분 옵션 `aria-label` |
+
+### DateTimePicker (DatePicker + TimePicker 확장)
+
+| 키 | 기본값 | 사용 위치 |
+| --- | --- | --- |
+| `dateTimeInput` | `"Date and time"` | Input `aria-label` |
+
+## 재사용 가능한 로케일 프리셋
+
+공유 라벨 파일을 만들어 앱 전체에서 import하세요:
+
+```ts title="lib/kalyx-labels.ts"
+import type { DatePickerLabels, RangePickerLabels, TimePickerLabels } from '@kalyx/core';
+
+export const ko: DatePickerLabels = {
+  triggerOpen: '캘린더 열기',
+  triggerClose: '캘린더 닫기',
+  popoverLabel: '날짜 선택',
+  prevMonth: '이전 달',
+  nextMonth: '다음 달',
+  prevYear: '이전 년',
+  nextYear: '다음 년',
+  prevDecade: '이전 10년',
+  nextDecade: '다음 10년',
+};
+
+export const koRange: RangePickerLabels = {
+  ...ko,
+  popoverLabel: '날짜 범위 선택',
+  startInput: '시작일',
+  endInput: '종료일',
+  presetsGroup: '날짜 범위 프리셋',
+};
+
+export const koTime: TimePickerLabels = {
+  timeInput: '시간',
+  hourList: '시',
+  minuteList: '분',
+  amPmToggle: '오전/오후',
+  hourOption: (h) => `${h}시`,
+  minuteOption: (m) => `${m}분`,
+};
+```
+
+```tsx title="components/BookingPicker.tsx"
+import { ko } from '@/lib/kalyx-labels';
+
+<DatePicker labels={ko} value={date} onChange={setDate}>
+  {/* ... */}
+</DatePicker>
+```
+
+## 일본어 예제
+
+```ts
+import type { DatePickerLabels } from '@kalyx/core';
+
+export const ja: DatePickerLabels = {
+  triggerOpen: 'カレンダーを開く',
+  triggerClose: 'カレンダーを閉じる',
+  popoverLabel: '日付を選択',
+  prevMonth: '前月',
+  nextMonth: '翌月',
+  prevYear: '前年',
+  nextYear: '翌年',
+  prevDecade: '前の10年',
+  nextDecade: '次の10年',
+};
+```
+
+## 캘린더 로케일 (요일·월 이름)
+
+요일 헤더와 월 이름은 내부적으로 `Intl.DateTimeFormat`을 사용합니다. `locale` prop (BCP 47 태그)을 넘기면 해당 언어로 렌더됩니다:
+
+```tsx
+<DatePicker locale="ko-KR" labels={ko} value={date} onChange={setDate}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+- `locale`은 **표시 포맷**을 제어합니다 (요일 이름, 헤더의 월 이름).
+- `labels`는 **ARIA 속성**을 제어합니다 (스크린 리더 텍스트).
+
+둘은 독립적입니다 — `locale="ko-KR"`과 영어 라벨을 함께 쓸 수도 있고, 그 반대도 가능합니다.
+
+## 다음
+
+- [접근성 →](./accessibility.md)
+- [마이그레이션 가이드 (v0.2 → v0.3) →](../migration.md#v02--v03--aria-라벨-i18n)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/migration.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/migration.md
@@ -117,6 +117,82 @@ const toISO = (cal: CalendarDate | null): ISODateString | null =>
   cal ? new Date(Date.UTC(cal.year, cal.month - 1, cal.day)).toISOString() : null;
 ```
 
+## v0.2 → v0.3 — ARIA 라벨 i18n
+
+v0.3에서 기본 ARIA 라벨이 한국어에서 영어로 변경되었습니다. 한국어 사용자라면 `labels` prop으로 복원하세요.
+
+### Breaking change
+
+모든 하드코딩된 한국어 aria-label (`"캘린더 열기"`, `"이전 달"` 등)이 영어 기본값으로 교체됐습니다.
+
+### 한국어 라벨 복원
+
+```tsx
+<DatePicker
+  value={date}
+  onChange={setDate}
+  labels={{
+    triggerOpen: '캘린�� 열기',
+    triggerClose: '캘린더 닫���',
+    popoverLabel: '날짜 선택',
+    prevMonth: '이��� 달',
+    nextMonth: '다음 달',
+    prevYear: '���전 년',
+    nextYear: '다음 년',
+    prevDecade: '이전 10년',
+    nextDecade: '다음 10년',
+  }}
+>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+변경하고 싶은 키만 넘기면 됩니다 — 나머지는 영어 기본값이 유지됩니다.
+
+전체 키 목록과 재사용 가능한 로케일 프리셋은 [다국어 가이드](./concepts/internationalization.md)를 참고하세요.
+
+## v0.3 → v0.4 — `displayTimezone` 추가
+
+v0.4���서 네 가지 Picker(와 대응 Hook)에 `displayTimezone` prop이 추가되었습니다. Breaking change 없음 — prop을 생략하면 v0.3 동작과 동일합니다.
+
+### Before (v0.3)
+
+```tsx
+<DatePicker value={iso} onChange={setIso}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+### After (v0.4)
+
+```tsx
+<DatePicker
+  value={iso}
+  onChange={setIso}
+  displayTimezone={user.timezone ?? 'UTC'}
+>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+ISO 계약은 바뀌지 않습니다. prop을 설정하면:
+
+- `Input`이 `displayTimezone` 기준으로 값을 포맷합니다.
+- `Calendar`가 해당 타임존 기준으로 오늘/선택 날짜를 하이라이트합니다.
+- `onChange`가 해당 타임존의 시민 자정(civil midnight)을 반환합니다.
+- `TimePicker` / `DateTimePicker`의 시/분이 DST를 반영합니다.
+
+자세한 내용은 [타임존 개념 페이지](./concepts/timezone.md)를 참고하세요.
+
 ## 일반 체크리스트
 
 이전 시:

--- a/apps/docs-site/sidebars.ts
+++ b/apps/docs-site/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
         'concepts/ssr',
         'concepts/adapters',
         'concepts/accessibility',
+        'concepts/internationalization',
       ],
     },
     {


### PR DESCRIPTION
## Summary

- **New page**: `concepts/internationalization.md` — full labels key reference (DatePicker, RangePicker, TimePicker, DateTimePicker), reusable locale presets (Korean, Japanese), `locale` vs `labels` distinction
- **Migration guide**: added v0.2→v0.3 section documenting the ARIA labels breaking change (Korean → English defaults) with restoration example
- **Accessibility docs**: added `labels` prop reference in Screen reader labelling section
- **Korean translations**: all changes synced to `i18n/ko/` and `i18n/ko-KR/`
- **Sidebar**: added `concepts/internationalization` entry

## Test plan

- [x] `pnpm --filter docs-site build` passes (SUCCESS for en and ko)
- [ ] Verify new i18n page renders at `/docs/concepts/internationalization`
- [ ] Verify migration guide shows v0.2→v0.3 section
- [ ] Verify Korean translation at `/ko/docs/concepts/internationalization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)