### PR TITLE
docs: sync all READMEs and docs with actual implementation

### DIFF
--- a/.claude/skills/rc-announcement.md
+++ b/.claude/skills/rc-announcement.md
@@ -24,7 +24,7 @@ triggers:
   - feat/v1-rc-preparation (ca7180e)
   - MonthPicker / YearPicker / WeekPicker 추가
   - Presets, onOpenChange, onCalendarNavigate 콜백
-- Bundle 수치: landing 비교표에 `~11KB`, README 배지에 `9.73KB` — **불일치 있음(확인 필요)**
+- Bundle 수치: **11.36 KB** gzip (모든 README·docs·배지 통일 완료 — 2026-04-25)
 
 > 이 상태는 시점 스냅샷. 새 세션에서 먼저 "작업 전 검증"으로 실제 상태를 확인한다.
 
@@ -142,7 +142,7 @@ pnpm --filter docs-site start    # 로컬 브라우저에서 배너 확인
 
 ### Step 4. README 배지 + Try the RC 섹션
 
-**현재 상태**: README의 bundle 배지가 `9.73KB`로 박혀 있으나 최신 landing 비교표는 `~11KB`. Step 1에서 측정한 실제 수치로 통일.
+**현재 상태**: README·docs·배지 모두 `11.36KB`로 통일 완료 (2026-04-25).
 
 **변경 지점** (`README.md`, `README.ko.md` 둘 다):
 1. bundle 배지 gzip 수치 업데이트

--- a/.github/RELEASE_NOTES_RC.md
+++ b/.github/RELEASE_NOTES_RC.md
@@ -13,8 +13,8 @@ This is the first RC for Kalyx v1.0. The public API is frozen; we're collecting 
 
 ## Bundle
 
-- ESM: **11.39 KB** gzip (target: ≤ 12 KB)
-- CJS: **11.40 KB** gzip
+- ESM: **11.36 KB** gzip (target: ≤ 12 KB)
+- CJS: **11.36 KB** gzip
 
 ## Install
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-11.39KB-brightgreen)](#번들-크기)
+[![Bundle](https://img.shields.io/badge/gzip-11.36KB-brightgreen)](#번들-크기)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -53,7 +53,7 @@ bundlephobia 기준 (2026년 4월). 각주는 표 아래를 참조.
 | react-datepicker | 9.1 | 44 KB | ❌ (CSS 필수) | ✅ | ⚠️ prop | ⚠️ 결합형 | ✅ 분리형 | `Date` | ⚠️ |
 | Ark UI | 5.36 | 265 KB² | ✅ | ✅ | ❌ (제거됨) | ❌ | ✅ | `Date` | ⚠️ |
 | React Aria | 1.17 | 247 KB² | ✅ | ✅ | ✅ | ✅ | ✅ | `CalendarDate` | ✅ |
-| **Kalyx** | 1.0.0-rc.0 | **11.39 KB** | ✅ | ✅ | ✅ 전용 | ✅ 전용 | ✅ 전용 | ISO 8601 UTC | ✅ `displayTimezone` |
+| **Kalyx** | 1.0.0-rc.0 | **11.36 KB** | ✅ | ✅ | ✅ 전용 | ✅ 전용 | ✅ 전용 | ISO 8601 UTC | ✅ `displayTimezone` |
 
 1. react-day-picker는 캘린더 그리드만 제공 — Kalyx와 동일한 스콥을 맞추려면 Input·Popover·TimePicker를 직접 조합해야 함. 2.4 KB는 기본 엔트리 기준.
 2. `@ark-ui/react`와 `react-aria-components`는 40+ 컴포넌트를 포함한 모노리스 패키지 — 트리셰이킹 시 더 작아지지만 `@internationalized/date` 등 생태계를 통째로 끌어들임.
@@ -115,6 +115,9 @@ import {
   RangePicker,      // 프리셋 포함 범위
   TimePicker,       // 시 + 분 (+ 초)
   DateTimePicker,   // 날짜 + 시간 결합
+  MonthPicker,      // 월 선택
+  YearPicker,       // 연도 선택
+  WeekPicker,       // 주 단위 범위 선택
 } from '@kalyx/react';
 ```
 
@@ -127,6 +130,7 @@ import {
 <DatePicker.Calendar />
 <DatePicker.MonthGrid />
 <DatePicker.YearGrid />
+<DatePicker.Presets />
 ```
 
 ## 훅
@@ -147,12 +151,14 @@ import { useDatePicker, useRangePicker, useTimePicker } from '@kalyx/react';
 - [컴포넌트](https://kalyx-docs.vercel.app/ko/docs/components/datepicker)
 - [훅](https://kalyx-docs.vercel.app/ko/docs/hooks/use-date-picker)
 - [레시피 — Tailwind / shadcn / React Hook Form](https://kalyx-docs.vercel.app/ko/docs/recipes/tailwind)
+- [테스트](https://kalyx-docs.vercel.app/ko/docs/recipes/testing)
+- [문제 해결](https://kalyx-docs.vercel.app/ko/docs/troubleshooting)
 - [마이그레이션 가이드](https://kalyx-docs.vercel.app/ko/docs/migration)
 
 ## 번들 크기
 
 ```
-packages/react/dist/index.js  →  gzip 9.73 KB  (v0.4 기준)
+@kalyx/react  →  gzip 11.36 KB  (v1.0.0-rc.0, 7개 컴포넌트)
 ```
 
 CI에서 `< 12 KB`로 강제. `@kalyx/core`에 `sideEffects: false`가 설정돼 있어 임포트 단위 트리셰이킹이 작동합니다 — `TimePicker`만 쓰면 DatePicker 코드가 사라집니다.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-11.39KB-brightgreen)](#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-11.36KB-brightgreen)](#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -50,7 +50,7 @@ Numbers come from bundlephobia (April 2026). See [notes below the table](#footno
 | | Kalyx | react-datepicker | react-day-picker | Ark UI | React Aria |
 |---|---|---|---|---|---|
 | Version measured | 1.0.0-rc.0 | 9.1.0 | 9.14.0 | 5.36.1 | 1.17.0 |
-| Bundle (min+gzip) | **11.39 KB** | 44 KB | 2.4 KB¹ | 265 KB² | 247 KB² |
+| Bundle (min+gzip) | **11.36 KB** | 44 KB | 2.4 KB¹ | 265 KB² | 247 KB² |
 | DatePicker | ✅ | ✅ | ✅ | ✅ | ✅ |
 | RangePicker | ✅ dedicated | ✅ two-picker pattern | ✅ `mode="range"` | ✅ | ✅ |
 | TimePicker | ✅ dedicated | ⚠️ `showTimeSelect` prop | ❌ | ❌ (removed) | ✅ |
@@ -174,6 +174,9 @@ import {
   RangePicker,      // date range with presets
   TimePicker,       // hour + minute (+ seconds)
   DateTimePicker,   // combined date + time
+  MonthPicker,      // month-only selection
+  YearPicker,       // year-only selection
+  WeekPicker,       // full-week range selection
 } from '@kalyx/react';
 ```
 
@@ -186,6 +189,7 @@ Each root exposes sub-components via dot notation:
 <DatePicker.Calendar />
 <DatePicker.MonthGrid />
 <DatePicker.YearGrid />
+<DatePicker.Presets />
 ```
 
 ## Hooks
@@ -206,12 +210,14 @@ Full documentation is at **[kalyx-docs.vercel.app](https://kalyx-docs.vercel.app
 - [Components](https://kalyx-docs.vercel.app/docs/components/datepicker)
 - [Hooks](https://kalyx-docs.vercel.app/docs/hooks/use-date-picker)
 - [Recipes — Tailwind / shadcn / React Hook Form](https://kalyx-docs.vercel.app/docs/recipes/tailwind)
+- [Testing](https://kalyx-docs.vercel.app/docs/recipes/testing)
+- [Troubleshooting](https://kalyx-docs.vercel.app/docs/troubleshooting)
 - [Migration guide](https://kalyx-docs.vercel.app/docs/migration)
 
 ## Bundle size
 
 ```
-packages/react/dist/index.js  →  9.73 KB gzip  (as of v0.4)
+@kalyx/react  →  11.36 KB gzip  (v1.0.0-rc.0, 7 components)
 ```
 
 Enforced in CI at `< 12 KB`. Tree-shakable per import — `@kalyx/core` is published with `sideEffects: false`, so using only `TimePicker` drops the DatePicker code.

--- a/apps/docs-site/docs/api/core.md
+++ b/apps/docs-site/docs/api/core.md
@@ -240,6 +240,32 @@ setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul');
 
 See the [Timezone concept page](../concepts/timezone.md) for usage patterns.
 
+## Accessibility labels
+
+Default ARIA label sets. Override via the `labels` prop on any picker Root.
+
+```ts
+import {
+  DEFAULT_DATEPICKER_LABELS,
+  DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS,
+  DEFAULT_DATETIMEPICKER_LABELS,
+} from '@kalyx/core';
+
+import type {
+  DatePickerLabels,
+  RangePickerLabels,
+  TimePickerLabels,
+  DateTimePickerLabels,
+} from '@kalyx/core';
+```
+
+Each label set provides keys like `triggerOpen`, `prevMonth`, `nextMonth`, `hourOption(h)`, etc. Pass a `Partial<*Labels>` to override only what you need:
+
+```tsx
+<DatePicker labels={{ triggerOpen: 'Open calendar', triggerClose: 'Close calendar' }}>
+```
+
 ## See also
 
 - [Concepts → ISO strings](../concepts/iso-string.md)

--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~9.2 KB**. Tree-shakes per import — e.g., using only `TimePicker` drops ~3 KB of DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~11.36 KB** (v1.0.0-rc.0, 7 components). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/docs/intro.md
+++ b/apps/docs-site/docs/intro.md
@@ -7,7 +7,7 @@ slug: /intro
 
 # Kalyx
 
-**Kalyx** is a headless React DatePicker library that ships *complete*. It covers the four things every date UI needs — **single date**, **date range**, **time**, and **date + time** — behind one consistent, composable API.
+**Kalyx** is a headless React DatePicker library that ships *complete*. Seven composable pickers — **DatePicker**, **RangePicker**, **TimePicker**, **DateTimePicker**, **MonthPicker**, **YearPicker**, and **WeekPicker** — behind one consistent API.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -34,7 +34,7 @@ The React ecosystem in 2026 has two extremes — and nothing in between:
 Kalyx fills the gap:
 
 - **Headless philosophy** — no stylesheets, no classes you must override.
-- **Integrated primitives** — DatePicker, RangePicker, TimePicker, DateTimePicker share one context model.
+- **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
 - **Composition first** — Radix-style dot notation. No 100-prop monoliths.
 - **Under 12 KB gzip** — measured, enforced in CI.
 - **SSR-safe** — tested with Next.js App Router.
@@ -56,8 +56,11 @@ Kalyx fills the gap:
 <RangePicker>               getCalendarDays
 <TimePicker>                isDateDisabled
 <DateTimePicker>            setTime / getTime
-useDatePicker               parseInputValue
-useRangePicker              normalizeISO
+<MonthPicker>               formatInTimezone
+<YearPicker>                getMonthName
+<WeekPicker>                parseInputValue
+useDatePicker               normalizeISO
+useRangePicker              DEFAULT_*_LABELS
 useTimePicker               …and more
 ```
 

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/api/core.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/api/core.md
@@ -6,13 +6,13 @@ sidebar_position: 1
 
 # @kalyx/core
 
-플랫폼 독립 날짜 로직. 보통 `@kalyx/react`를 통해 간접 소비됩니다.
+Platform-independent date logic. Usually consumed transitively through `@kalyx/react`.
 
 ```bash
 pnpm add @kalyx/core
 ```
 
-## 타입
+## Types
 
 ```ts
 type ISODateString = string;
@@ -65,21 +65,21 @@ type TimeValue = {
 
 ## `DateAdapter`
 
-전체 인터페이스는 [어댑터 개념 →](../concepts/adapters.md)에.
+See the [Adapters concept →](../concepts/adapters.md) for the full interface.
 
 ## `DateFnsAdapter`
 
-기본 어댑터 — date-fns v4 기반, UTC 안전.
+Default adapter — UTC-safe, built on date-fns v4.
 
 ```ts
 import { DateFnsAdapter } from '@kalyx/core';
 ```
 
-## 캘린더 유틸
+## Calendar utilities
 
 ### `getCalendarDays(viewMonth, adapter, options)`
 
-한 달의 6주 그리드를 생성합니다.
+Build a 6-week grid for a month.
 
 ```ts
 import { getCalendarDays, DateFnsAdapter } from '@kalyx/core';
@@ -91,7 +91,7 @@ const grid = getCalendarDays(
 );
 ```
 
-`CalendarGrid` (6×7 `CalendarDay`)을 반환합니다. 앞뒤 패딩 날짜는 이웃 달이며 `isCurrentMonth: false`.
+Returns `CalendarGrid` (6×7 `CalendarDay`s). Leading and trailing days belong to neighboring months (`isCurrentMonth: false`).
 
 ### `isDateDisabled(iso, rules, adapter)`
 
@@ -102,7 +102,7 @@ isDateDisabled(
   '2026-04-18T00:00:00.000Z',
   [{ dayOfWeek: [0, 6] }],
   DateFnsAdapter,
-); // → true (토요일)
+); // → true (Saturday)
 ```
 
 ### `minDate(dates)` / `maxDate(dates)`
@@ -114,22 +114,22 @@ minDate(['2026-04-15T00:00:00.000Z', '2026-04-10T00:00:00.000Z']);
 // → "2026-04-10T00:00:00.000Z"
 ```
 
-## 날짜 문자열 유틸
+## Date string utilities
 
 ### `normalizeISO(value)`
 
-관용적 파서 — `2026-04-15` 같은 부분 입력을 받아 UTC 자정 ISO 문자열로 반환. 유효하지 않으면 `null`.
+Lenient parser — accepts partial inputs like `2026-04-15` and returns a full UTC midnight ISO string. Returns `null` for invalid input.
 
 ### `parseInputValue(input, format, adapter)`
 
-명시적 포맷으로 사용자 입력 파싱.
+Parse a user-typed string with an explicit format.
 
 ```ts
 parseInputValue('15/04/2026', 'dd/MM/yyyy', DateFnsAdapter);
 // → "2026-04-15T00:00:00.000Z"
 ```
 
-## 시간 유틸
+## Time utilities
 
 ### `setTime(iso, partial)` / `getTime(iso)`
 
@@ -146,7 +146,7 @@ getTime('2026-04-15T09:30:00.000Z');
 ### `parseTimeString(input)` / `formatTimeString(time, withSeconds?)`
 
 ```ts
-parseTimeString('09:30');    // → { hours: 9, minutes: 30, seconds: 0 }
+parseTimeString('09:30');   // → { hours: 9, minutes: 30, seconds: 0 }
 parseTimeString('09:30:45'); // → { hours: 9, minutes: 30, seconds: 45 }
 formatTimeString({ hours: 9, minutes: 30, seconds: 0 });       // → "09:30"
 formatTimeString({ hours: 9, minutes: 30, seconds: 0 }, true); // → "09:30:00"
@@ -154,9 +154,9 @@ formatTimeString({ hours: 9, minutes: 30, seconds: 0 }, true); // → "09:30:00"
 
 ### `formatTimeFromISO(iso, withSeconds?)`
 
-`formatTimeString(getTime(iso), withSeconds)`와 동등한 편의 래퍼.
+Convenience wrapper — equivalent to `formatTimeString(getTime(iso), withSeconds)`.
 
-### 12시간제 헬퍼
+### 12h helpers
 
 ```ts
 import { to12Hour, to24Hour } from '@kalyx/core';
@@ -165,7 +165,7 @@ to12Hour(13);                    // → { hours12: 1, period: 'PM' }
 to24Hour(1, 'PM');               // → 13
 ```
 
-### 옵션 생성기
+### Option generators
 
 ```ts
 generateHours('24h'); // → [0, 1, 2, …, 23]
@@ -180,18 +180,94 @@ isSameTime({ hours: 9, minutes: 0, seconds: 0 }, { hours: 9, minutes: 0, seconds
 // → true
 ```
 
-## 로케일 유틸
+## Locale utilities
 
 ```ts
-getMonthName(3, 'ko-KR');               // → "4월"
-formatMonthYear(2026, 3, 'ko-KR');      // → "2026년 4월"
-getWeekdayNames('ko-KR', 0);
-// → [{ short: '일', full: '일요일' }, …]
-formatFullDate('2026-04-15T00:00:00.000Z', 'ko-KR');
-// → "2026년 4월 15일"
+getMonthName(3, 'en-US');            // → "April"
+formatMonthYear(2026, 3, 'en-US');   // → "April 2026"
+getWeekdayNames('en-US', 0);
+// → [{ short: 'Sun', full: 'Sunday' }, …]
+formatFullDate('2026-04-15T00:00:00.000Z', 'en-US');
+// → "April 15, 2026"
 ```
 
-## 함께 보기
+## Timezone utilities
 
-- [개념 → ISO 문자열](../concepts/iso-string.md)
-- [개념 → 어댑터](../concepts/adapters.md)
+Introduced in v0.4. Used internally by every picker when `displayTimezone` is set; exposed publicly so you can run the same math yourself.
+
+### `formatInTimezone(iso, formatStr, timeZone)`
+
+Format a UTC instant in the requested zone. Handles DST transitions.
+
+```ts
+formatInTimezone('2026-03-08T07:30:00.000Z', 'yyyy-MM-dd HH:mm', 'America/New_York');
+// → '2026-03-08 03:30'   (post spring-forward EDT)
+```
+
+### `startOfDayInTimezone(iso, timeZone)`
+
+Civil midnight of the given UTC instant's day, expressed as a UTC ISO string.
+
+```ts
+startOfDayInTimezone('2026-01-15T12:00:00.000Z', 'Asia/Seoul');
+// → '2026-01-14T15:00:00.000Z'
+```
+
+### `isSameDayInTimezone(a, b, timeZone)`
+
+Civil-day equality in the zone. Timezone-safe alternative to comparing `iso.slice(0, 10)`.
+
+### `todayInTimezone(timeZone)`
+
+"Today" expressed as civil midnight in the zone.
+
+### `getTimezoneOffsetMinutes(iso, timeZone)`
+
+UTC offset (minutes east of UTC) at the given instant. Differs before and after DST transitions.
+
+### `civilMidnightFromUtcDay(gridUtcIso, timeZone)`
+
+The bridge Calendar uses: maps a UTC-midnight grid cell ISO to civil midnight of the same calendar day in the zone. You rarely need this directly — it is exported for custom calendar renderers.
+
+### `getTimeInTimezone(iso, timeZone)` / `setTimeInTimezone(iso, partial, timeZone)`
+
+Read and write time-of-day as observed in the zone. `setTimeInTimezone` preserves the civil date and replaces the time portion, iterating once to absorb DST offsets.
+
+```ts
+setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul');
+// → '2026-01-15T01:00:00.000Z'   (Seoul 10:00 = UTC 01:00)
+```
+
+See the [Timezone concept page](../concepts/timezone.md) for usage patterns.
+
+## Accessibility labels
+
+Default ARIA label sets. Override via the `labels` prop on any picker Root.
+
+```ts
+import {
+  DEFAULT_DATEPICKER_LABELS,
+  DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS,
+  DEFAULT_DATETIMEPICKER_LABELS,
+} from '@kalyx/core';
+
+import type {
+  DatePickerLabels,
+  RangePickerLabels,
+  TimePickerLabels,
+  DateTimePickerLabels,
+} from '@kalyx/core';
+```
+
+Each label set provides keys like `triggerOpen`, `prevMonth`, `nextMonth`, `hourOption(h)`, etc. Pass a `Partial<*Labels>` to override only what you need:
+
+```tsx
+<DatePicker labels={{ triggerOpen: 'Open calendar', triggerClose: 'Close calendar' }}>
+```
+
+## See also
+
+- [Concepts → ISO strings](../concepts/iso-string.md)
+- [Concepts → Adapters](../concepts/adapters.md)
+- [Concepts → Timezone](../concepts/timezone.md)

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~9.2 KB**. Tree-shakes per import — e.g., using only `TimePicker` drops ~3 KB of DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~11.36 KB** (v1.0.0-rc.0, 7 components). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/intro.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/intro.md
@@ -1,13 +1,13 @@
 ---
 id: intro
-title: 소개
+title: Introduction
 sidebar_position: 1
 slug: /intro
 ---
 
 # Kalyx
 
-**Kalyx**는 *완결된* 채로 배포되는 Headless React DatePicker 라이브러리입니다. 날짜 UI가 필요로 하는 네 가지 — **단일 날짜**, **날짜 범위**, **시간**, **날짜 + 시간** — 를 하나의 일관된 조합형 API로 제공합니다.
+**Kalyx** is a headless React DatePicker library that ships *complete*. Seven composable pickers — **DatePicker**, **RangePicker**, **TimePicker**, **DateTimePicker**, **MonthPicker**, **YearPicker**, and **WeekPicker** — behind one consistent API.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -21,32 +21,33 @@ import { DatePicker } from '@kalyx/react';
 </DatePicker>
 ```
 
-## Kalyx가 필요한 이유
+## Why Kalyx exists
 
-2026년 React 생태계의 DatePicker 선택지는 양극단입니다. 그 사이를 채우는 라이브러리가 없습니다.
+The React ecosystem in 2026 has two extremes — and nothing in between:
 
-| 선택지 | 장점 | 한계 |
+| Option | What it offers | What it doesn't |
 | --- | --- | --- |
-| **react-day-picker** | Headless, 접근성 있는 캘린더 그리드 | 입력창·시간·범위 미지원 |
-| **react-datepicker** | 통합 기능 | 60KB, CSS 필수, Date 객체 API, 타임존 함정 |
-| **Ark UI / React Aria** | 조합 패턴 지원 | TimePicker 없음(Ark), 무거운 의존성(Aria) |
+| **react-day-picker** | Headless, accessible calendar grid | No input, no time, no range out of the box |
+| **react-datepicker** | All-in-one features | 60 KB, required CSS, Date-object API, timezone pitfalls |
+| **Ark UI / React Aria** | Composition patterns | No TimePicker (Ark), heavy dependencies (Aria) |
 
-Kalyx는 그 공백을 채웁니다.
+Kalyx fills the gap:
 
-- **Headless 철학** — 스타일시트도, 재정의할 클래스도 없습니다.
-- **통합 프리미티브** — DatePicker, RangePicker, TimePicker, DateTimePicker가 하나의 컨텍스트 모델을 공유합니다.
-- **조합 우선** — Radix 스타일 dot 표기. props 100개짜리 거대 컴포넌트 없음.
-- **gzip 12KB 이하** — 측정하고, CI에서 강제.
-- **SSR 안전** — Next.js App Router 환경에서 검증.
-- **ISO 8601 UTC 문자열**을 값 계약으로 사용. Date 객체의 함정 없음.
+- **Headless philosophy** — no stylesheets, no classes you must override.
+- **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
+- **Composition first** — Radix-style dot notation. No 100-prop monoliths.
+- **Under 12 KB gzip** — measured, enforced in CI.
+- **SSR-safe** — tested with Next.js App Router.
+- **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
+- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone.md).
 
-## 누구에게 적합한가
+## Who it's for
 
-- **Tailwind**, **shadcn/ui**, **Chakra**, 자체 디자인 시스템을 이미 쓰면서 토큰에 맞는 날짜 UI가 필요한 팀.
-- **번들 크기**와 **트리셰이킹**에 민감한 앱.
-- **Next.js**, **Remix** 등 SSR/RSC 환경에서 동작하는 모든 앱.
+- Teams already using **Tailwind**, **shadcn/ui**, **Chakra**, or their own design system, who want date UI that obeys their tokens.
+- Apps that care about **bundle size** and **tree-shaking**.
+- Anything running on **Next.js**, **Remix**, or other SSR/RSC environments.
 
-## 담겨 있는 것
+## What's in the box
 
 ```
 @kalyx/react                @kalyx/core
@@ -55,14 +56,17 @@ Kalyx는 그 공백을 채웁니다.
 <RangePicker>               getCalendarDays
 <TimePicker>                isDateDisabled
 <DateTimePicker>            setTime / getTime
-useDatePicker               parseInputValue
-useRangePicker              normalizeISO
-useTimePicker               …외 다수
+<MonthPicker>               formatInTimezone
+<YearPicker>                getMonthName
+<WeekPicker>                parseInputValue
+useDatePicker               normalizeISO
+useRangePicker              DEFAULT_*_LABELS
+useTimePicker               …and more
 ```
 
-## 다음 단계
+## Next steps
 
-- [설치 →](./getting-started/installation.md)
-- [빠른 시작 (5분) →](./getting-started/quick-start.md)
+- [Install the package →](./getting-started/installation.md)
+- [Quick Start (5 min) →](./getting-started/quick-start.mdx)
 - [Composition API →](./concepts/composition.md)
-- [컴포넌트 →](./components/datepicker.md)
+- [Components →](./components/datepicker.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/core.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/core.md
@@ -6,13 +6,13 @@ sidebar_position: 1
 
 # @kalyx/core
 
-플랫폼 독립 날짜 로직. 보통 `@kalyx/react`를 통해 간접 소비됩니다.
+Platform-independent date logic. Usually consumed transitively through `@kalyx/react`.
 
 ```bash
 pnpm add @kalyx/core
 ```
 
-## 타입
+## Types
 
 ```ts
 type ISODateString = string;
@@ -65,21 +65,21 @@ type TimeValue = {
 
 ## `DateAdapter`
 
-전체 인터페이스는 [어댑터 개념 →](../concepts/adapters.md)에.
+See the [Adapters concept →](../concepts/adapters.md) for the full interface.
 
 ## `DateFnsAdapter`
 
-기본 어댑터 — date-fns v4 기반, UTC 안전.
+Default adapter — UTC-safe, built on date-fns v4.
 
 ```ts
 import { DateFnsAdapter } from '@kalyx/core';
 ```
 
-## 캘린더 유틸
+## Calendar utilities
 
 ### `getCalendarDays(viewMonth, adapter, options)`
 
-한 달의 6주 그리드를 생성합니다.
+Build a 6-week grid for a month.
 
 ```ts
 import { getCalendarDays, DateFnsAdapter } from '@kalyx/core';
@@ -91,7 +91,7 @@ const grid = getCalendarDays(
 );
 ```
 
-`CalendarGrid` (6×7 `CalendarDay`)을 반환합니다. 앞뒤 패딩 날짜는 이웃 달이며 `isCurrentMonth: false`.
+Returns `CalendarGrid` (6×7 `CalendarDay`s). Leading and trailing days belong to neighboring months (`isCurrentMonth: false`).
 
 ### `isDateDisabled(iso, rules, adapter)`
 
@@ -102,7 +102,7 @@ isDateDisabled(
   '2026-04-18T00:00:00.000Z',
   [{ dayOfWeek: [0, 6] }],
   DateFnsAdapter,
-); // → true (토요일)
+); // → true (Saturday)
 ```
 
 ### `minDate(dates)` / `maxDate(dates)`
@@ -114,22 +114,22 @@ minDate(['2026-04-15T00:00:00.000Z', '2026-04-10T00:00:00.000Z']);
 // → "2026-04-10T00:00:00.000Z"
 ```
 
-## 날짜 문자열 유틸
+## Date string utilities
 
 ### `normalizeISO(value)`
 
-관용적 파서 — `2026-04-15` 같은 부분 입력을 받아 UTC 자정 ISO 문자열로 반환. 유효하지 않으면 `null`.
+Lenient parser — accepts partial inputs like `2026-04-15` and returns a full UTC midnight ISO string. Returns `null` for invalid input.
 
 ### `parseInputValue(input, format, adapter)`
 
-명시적 포맷으로 사용자 입력 파싱.
+Parse a user-typed string with an explicit format.
 
 ```ts
 parseInputValue('15/04/2026', 'dd/MM/yyyy', DateFnsAdapter);
 // → "2026-04-15T00:00:00.000Z"
 ```
 
-## 시간 유틸
+## Time utilities
 
 ### `setTime(iso, partial)` / `getTime(iso)`
 
@@ -146,7 +146,7 @@ getTime('2026-04-15T09:30:00.000Z');
 ### `parseTimeString(input)` / `formatTimeString(time, withSeconds?)`
 
 ```ts
-parseTimeString('09:30');    // → { hours: 9, minutes: 30, seconds: 0 }
+parseTimeString('09:30');   // → { hours: 9, minutes: 30, seconds: 0 }
 parseTimeString('09:30:45'); // → { hours: 9, minutes: 30, seconds: 45 }
 formatTimeString({ hours: 9, minutes: 30, seconds: 0 });       // → "09:30"
 formatTimeString({ hours: 9, minutes: 30, seconds: 0 }, true); // → "09:30:00"
@@ -154,9 +154,9 @@ formatTimeString({ hours: 9, minutes: 30, seconds: 0 }, true); // → "09:30:00"
 
 ### `formatTimeFromISO(iso, withSeconds?)`
 
-`formatTimeString(getTime(iso), withSeconds)`와 동등한 편의 래퍼.
+Convenience wrapper — equivalent to `formatTimeString(getTime(iso), withSeconds)`.
 
-### 12시간제 헬퍼
+### 12h helpers
 
 ```ts
 import { to12Hour, to24Hour } from '@kalyx/core';
@@ -165,7 +165,7 @@ to12Hour(13);                    // → { hours12: 1, period: 'PM' }
 to24Hour(1, 'PM');               // → 13
 ```
 
-### 옵션 생성기
+### Option generators
 
 ```ts
 generateHours('24h'); // → [0, 1, 2, …, 23]
@@ -180,18 +180,94 @@ isSameTime({ hours: 9, minutes: 0, seconds: 0 }, { hours: 9, minutes: 0, seconds
 // → true
 ```
 
-## 로케일 유틸
+## Locale utilities
 
 ```ts
-getMonthName(3, 'ko-KR');               // → "4월"
-formatMonthYear(2026, 3, 'ko-KR');      // → "2026년 4월"
-getWeekdayNames('ko-KR', 0);
-// → [{ short: '일', full: '일요일' }, …]
-formatFullDate('2026-04-15T00:00:00.000Z', 'ko-KR');
-// → "2026년 4월 15일"
+getMonthName(3, 'en-US');            // → "April"
+formatMonthYear(2026, 3, 'en-US');   // → "April 2026"
+getWeekdayNames('en-US', 0);
+// → [{ short: 'Sun', full: 'Sunday' }, …]
+formatFullDate('2026-04-15T00:00:00.000Z', 'en-US');
+// → "April 15, 2026"
 ```
 
-## 함께 보기
+## Timezone utilities
 
-- [개념 → ISO 문자열](../concepts/iso-string.md)
-- [개념 → 어댑터](../concepts/adapters.md)
+Introduced in v0.4. Used internally by every picker when `displayTimezone` is set; exposed publicly so you can run the same math yourself.
+
+### `formatInTimezone(iso, formatStr, timeZone)`
+
+Format a UTC instant in the requested zone. Handles DST transitions.
+
+```ts
+formatInTimezone('2026-03-08T07:30:00.000Z', 'yyyy-MM-dd HH:mm', 'America/New_York');
+// → '2026-03-08 03:30'   (post spring-forward EDT)
+```
+
+### `startOfDayInTimezone(iso, timeZone)`
+
+Civil midnight of the given UTC instant's day, expressed as a UTC ISO string.
+
+```ts
+startOfDayInTimezone('2026-01-15T12:00:00.000Z', 'Asia/Seoul');
+// → '2026-01-14T15:00:00.000Z'
+```
+
+### `isSameDayInTimezone(a, b, timeZone)`
+
+Civil-day equality in the zone. Timezone-safe alternative to comparing `iso.slice(0, 10)`.
+
+### `todayInTimezone(timeZone)`
+
+"Today" expressed as civil midnight in the zone.
+
+### `getTimezoneOffsetMinutes(iso, timeZone)`
+
+UTC offset (minutes east of UTC) at the given instant. Differs before and after DST transitions.
+
+### `civilMidnightFromUtcDay(gridUtcIso, timeZone)`
+
+The bridge Calendar uses: maps a UTC-midnight grid cell ISO to civil midnight of the same calendar day in the zone. You rarely need this directly — it is exported for custom calendar renderers.
+
+### `getTimeInTimezone(iso, timeZone)` / `setTimeInTimezone(iso, partial, timeZone)`
+
+Read and write time-of-day as observed in the zone. `setTimeInTimezone` preserves the civil date and replaces the time portion, iterating once to absorb DST offsets.
+
+```ts
+setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul');
+// → '2026-01-15T01:00:00.000Z'   (Seoul 10:00 = UTC 01:00)
+```
+
+See the [Timezone concept page](../concepts/timezone.md) for usage patterns.
+
+## Accessibility labels
+
+Default ARIA label sets. Override via the `labels` prop on any picker Root.
+
+```ts
+import {
+  DEFAULT_DATEPICKER_LABELS,
+  DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS,
+  DEFAULT_DATETIMEPICKER_LABELS,
+} from '@kalyx/core';
+
+import type {
+  DatePickerLabels,
+  RangePickerLabels,
+  TimePickerLabels,
+  DateTimePickerLabels,
+} from '@kalyx/core';
+```
+
+Each label set provides keys like `triggerOpen`, `prevMonth`, `nextMonth`, `hourOption(h)`, etc. Pass a `Partial<*Labels>` to override only what you need:
+
+```tsx
+<DatePicker labels={{ triggerOpen: 'Open calendar', triggerClose: 'Close calendar' }}>
+```
+
+## See also
+
+- [Concepts → ISO strings](../concepts/iso-string.md)
+- [Concepts → Adapters](../concepts/adapters.md)
+- [Concepts → Timezone](../concepts/timezone.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~9.2 KB**. Tree-shakes per import — e.g., using only `TimePicker` drops ~3 KB of DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~11.36 KB** (v1.0.0-rc.0, 7 components). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
@@ -1,13 +1,13 @@
 ---
 id: intro
-title: 소개
+title: Introduction
 sidebar_position: 1
 slug: /intro
 ---
 
 # Kalyx
 
-**Kalyx**는 *완결된* 채로 배포되는 Headless React DatePicker 라이브러리입니다. 날짜 UI가 필요로 하는 네 가지 — **단일 날짜**, **날짜 범위**, **시간**, **날짜 + 시간** — 를 하나의 일관된 조합형 API로 제공합니다.
+**Kalyx** is a headless React DatePicker library that ships *complete*. Seven composable pickers — **DatePicker**, **RangePicker**, **TimePicker**, **DateTimePicker**, **MonthPicker**, **YearPicker**, and **WeekPicker** — behind one consistent API.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -21,32 +21,33 @@ import { DatePicker } from '@kalyx/react';
 </DatePicker>
 ```
 
-## Kalyx가 필요한 이유
+## Why Kalyx exists
 
-2026년 React 생태계의 DatePicker 선택지는 양극단입니다. 그 사이를 채우는 라이브러리가 없습니다.
+The React ecosystem in 2026 has two extremes — and nothing in between:
 
-| 선택지 | 장점 | 한계 |
+| Option | What it offers | What it doesn't |
 | --- | --- | --- |
-| **react-day-picker** | Headless, 접근성 있는 캘린더 그리드 | 입력창·시간·범위 미지원 |
-| **react-datepicker** | 통합 기능 | 60KB, CSS 필수, Date 객체 API, 타임존 함정 |
-| **Ark UI / React Aria** | 조합 패턴 지원 | TimePicker 없음(Ark), 무거운 의존성(Aria) |
+| **react-day-picker** | Headless, accessible calendar grid | No input, no time, no range out of the box |
+| **react-datepicker** | All-in-one features | 60 KB, required CSS, Date-object API, timezone pitfalls |
+| **Ark UI / React Aria** | Composition patterns | No TimePicker (Ark), heavy dependencies (Aria) |
 
-Kalyx는 그 공백을 채웁니다.
+Kalyx fills the gap:
 
-- **Headless 철학** — 스타일시트도, 재정의할 클래스도 없습니다.
-- **통합 프리미티브** — DatePicker, RangePicker, TimePicker, DateTimePicker가 하나의 컨텍스트 모델을 공유합니다.
-- **조합 우선** — Radix 스타일 dot 표기. props 100개짜리 거대 컴포넌트 없음.
-- **gzip 12KB 이하** — 측정하고, CI에서 강제.
-- **SSR 안전** — Next.js App Router 환경에서 검증.
-- **ISO 8601 UTC 문자열**을 값 계약으로 사용. Date 객체의 함정 없음.
+- **Headless philosophy** — no stylesheets, no classes you must override.
+- **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
+- **Composition first** — Radix-style dot notation. No 100-prop monoliths.
+- **Under 12 KB gzip** — measured, enforced in CI.
+- **SSR-safe** — tested with Next.js App Router.
+- **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
+- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone.md).
 
-## 누구에게 적합한가
+## Who it's for
 
-- **Tailwind**, **shadcn/ui**, **Chakra**, 자체 디자인 시스템을 이미 쓰면서 토큰에 맞는 날짜 UI가 필요한 팀.
-- **번들 크기**와 **트리셰이킹**에 민감한 앱.
-- **Next.js**, **Remix** 등 SSR/RSC 환경에서 동작하는 모든 앱.
+- Teams already using **Tailwind**, **shadcn/ui**, **Chakra**, or their own design system, who want date UI that obeys their tokens.
+- Apps that care about **bundle size** and **tree-shaking**.
+- Anything running on **Next.js**, **Remix**, or other SSR/RSC environments.
 
-## 담겨 있는 것
+## What's in the box
 
 ```
 @kalyx/react                @kalyx/core
@@ -55,14 +56,17 @@ Kalyx는 그 공백을 채웁니다.
 <RangePicker>               getCalendarDays
 <TimePicker>                isDateDisabled
 <DateTimePicker>            setTime / getTime
-useDatePicker               parseInputValue
-useRangePicker              normalizeISO
-useTimePicker               …외 다수
+<MonthPicker>               formatInTimezone
+<YearPicker>                getMonthName
+<WeekPicker>                parseInputValue
+useDatePicker               normalizeISO
+useRangePicker              DEFAULT_*_LABELS
+useTimePicker               …and more
 ```
 
-## 다음 단계
+## Next steps
 
-- [설치 →](./getting-started/installation.md)
-- [빠른 시작 (5분) →](./getting-started/quick-start.mdx)
+- [Install the package →](./getting-started/installation.md)
+- [Quick Start (5 min) →](./getting-started/quick-start.mdx)
 - [Composition API →](./concepts/composition.md)
-- [컴포넌트 →](./components/datepicker.md)
+- [Components →](./components/datepicker.md)

--- a/apps/docs-site/src/pages/index.tsx
+++ b/apps/docs-site/src/pages/index.tsx
@@ -27,8 +27,8 @@ function Hero(): ReactNode {
             </h1>
             <p className={styles.subtitle}>
               <Translate id="home.subtitle">
-                DatePicker, RangePicker, TimePicker, and DateTimePicker — composable React primitives
-                with zero built-in styles. Works everywhere React runs.
+                7 composable pickers — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker,
+                YearPicker, and WeekPicker. Zero CSS, SSR-safe, under 12 KB.
               </Translate>
             </p>
             <div className={styles.ctas}>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -73,6 +73,36 @@ import {
 } from '@kalyx/core';
 ```
 
+### Timezone helpers
+
+DST-aware timezone utilities used by every picker when `displayTimezone` is set.
+
+```ts
+import {
+  formatInTimezone,
+  startOfDayInTimezone,
+  isSameDayInTimezone,
+  todayInTimezone,
+  getTimezoneOffsetMinutes,
+  civilMidnightFromUtcDay,
+  getTimeInTimezone,
+  setTimeInTimezone,
+} from '@kalyx/core';
+```
+
+### Accessibility labels
+
+Default ARIA labels (English). Override via the `labels` prop on any picker Root.
+
+```ts
+import {
+  DEFAULT_DATEPICKER_LABELS,
+  DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS,
+  DEFAULT_DATETIMEPICKER_LABELS,
+} from '@kalyx/core';
+```
+
 ## Principles
 
 - **All dates are ISO 8601 UTC strings** — never `Date` objects.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -3,7 +3,7 @@
 > The headless React DatePicker, finally complete. Zero CSS · SSR-safe · under 12 KB gzip.
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-9.2KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-11.36KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 
@@ -51,6 +51,9 @@ import {
   RangePicker,       // date range + presets
   TimePicker,        // hour + minute (+ seconds)
   DateTimePicker,    // date + time combined
+  MonthPicker,       // month-only selection
+  YearPicker,        // year-only selection
+  WeekPicker,        // full-week range selection
   useDatePicker,     // hook for custom UIs
   useRangePicker,
   useTimePicker,
@@ -90,6 +93,8 @@ Full recipes: [Tailwind](https://kalyx-docs.vercel.app/docs/recipes/tailwind), [
 - [Quick Start](https://kalyx-docs.vercel.app/docs/getting-started/quick-start)
 - [Components](https://kalyx-docs.vercel.app/docs/components/datepicker)
 - [Hooks](https://kalyx-docs.vercel.app/docs/hooks/use-date-picker)
+- [Testing](https://kalyx-docs.vercel.app/docs/recipes/testing)
+- [Troubleshooting](https://kalyx-docs.vercel.app/docs/troubleshooting)
 - [Migration from react-datepicker / react-day-picker / React Aria](https://kalyx-docs.vercel.app/docs/migration)
 
 ## License


### PR DESCRIPTION
## Summary

- README/docs 전체에서 발견된 **9개 불일치** 수정
- 모든 문서에서 7개 컴포넌트 반영, 번들 크기 **11.36KB**로 통일

## Changes

### 불일치 수정 내역

| # | 문제 | 위치 | 수정 |
|---|------|------|------|
| 1 | 컴포넌트 4개만 기재 (실제 7개) | README.md | MonthPicker/YearPicker/WeekPicker 추가 |
| 2 | 컴포넌트 4개만 기재 | README.ko.md | 동일 |
| 3 | 번들 크기 "9.73 KB (v0.4)" | README.md, README.ko.md | "11.36 KB (v1.0.0-rc.0)" |
| 4 | 번들 배지 "11.39KB" | README.md, README.ko.md | "11.36KB" |
| 5 | 컴포넌트 4개만 기재 | packages/react/README.md | 7개로 업데이트 |
| 6 | 번들 배지 "9.2KB" | packages/react/README.md | "11.36KB" |
| 7 | Timezone/Labels 유틸 미기재 | packages/core/README.md | 2개 섹션 추가 |
| 8 | 홈페이지 4개 컴포넌트만 언급 | docs-site index.tsx | 7개 피커 언급 |
| 9 | intro.md 4개 컴포넌트만 언급 | docs-site intro.md | 7개 피커 + core 목록 업데이트 |

### 추가 수정
- docs-site api/react.md: 번들 크기 9.2KB → 11.36KB
- docs-site api/core.md: Labels 섹션 추가
- RELEASE_NOTES_RC.md: 11.39KB → 11.36KB
- rc-announcement.md: 번들 불일치 해결 표시
- ko/ko-KR i18n 디렉토리 동기화

### 검증
- `grep -r "9.73\|9.2 KB\|11.39"` → **0건** (구버전 수치 완전 제거)

## Test plan

- [x] `pnpm test:run` — 368 tests passed
- [x] `npx docusaurus build --locale en` — success
- [x] `grep` 전수 검사 — 구버전 번들 수치 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * MonthPicker, YearPicker, WeekPicker 컴포넌트 추가 문서화
  * DatePicker.Presets 서브컴포넌트 지원
  * 접근성 라벨(ARIA) 커스터마이징 기능 문서화
  * 타임존 유틸리티 기능 문서화

* **문서**
  * 번들 크기 최적화: 11.39 KB → 11.36 KB
  * 테스트 및 문제 해결 가이드 추가
  * 다국어 문서 업데이트 및 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->