### PR TITLE
fix(popover): preserve Floating UI styles + brand favicon

### DIFF
--- a/.changeset/popover-style-merge.md
+++ b/.changeset/popover-style-merge.md
@@ -1,0 +1,9 @@
+---
+'@kalyx/react': patch
+---
+
+Fix popover styling regression that broke documentation live previews.
+
+- `DatePicker.Popover` and `RangePicker.Popover` now merge user-provided `style` props *under* Floating UI's positioning instead of being overwritten by it. Previously, passing `style={{...}}` to a Popover stripped away `position: absolute`, `top`, `left`, and `transform`, causing the popover to render as a static block at full container width.
+- The popover is now hidden until Floating UI computes its position, eliminating an unpositioned first-frame flash on every open.
+- The shared `usePopover` hook also wires the floating element's reference synchronously in the ref callback, so positioning is resolved before paint in most cases.

--- a/apps/docs-site/docs/getting-started/quick-start.mdx
+++ b/apps/docs-site/docs/getting-started/quick-start.mdx
@@ -17,30 +17,28 @@ function LiveExample() {
   const [date, setDate] = React.useState(null);
   return (
     <DatePicker value={date} onChange={setDate}>
-      <DatePicker.Input
-        placeholder="YYYY-MM-DD"
-        style={{ padding: '0.5rem', border: '1px solid #ddd', borderRadius: 6 }}
-      />
-      <DatePicker.Trigger style={{ marginLeft: 4 }} />
-      <DatePicker.Popover
-        style={{
-          marginTop: 4,
-          padding: 12,
-          border: '1px solid #ddd',
-          borderRadius: 8,
-          background: 'white',
-          boxShadow: '0 4px 14px rgba(0,0,0,0.08)',
-        }}
-      >
+      <div className="kx-live-row">
+        <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
+        <DatePicker.Trigger className="kx-live-trigger" aria-label="Open calendar" />
+      </div>
+      <DatePicker.Popover className="kx-live-popover">
         <DatePicker.Calendar
           classNames={{
+            header: 'kx-live-header',
+            title: 'kx-live-title',
+            navButton: 'kx-live-nav',
+            grid: 'kx-live-grid',
+            gridCell: 'kx-live-cell',
+            weekdayHeader: 'kx-live-weekday',
             day: 'live-day',
             daySelected: 'live-day-selected',
             dayToday: 'live-day-today',
+            dayDisabled: 'kx-live-disabled',
+            dayOutsideMonth: 'kx-live-outside',
           }}
         />
       </DatePicker.Popover>
-      <div style={{ marginTop: 12, fontSize: 13, color: '#555' }}>
+      <div className="kx-live-value">
         Selected: <code>{date ?? 'null'}</code>
       </div>
     </DatePicker>

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'Kalyx',
   tagline: 'The headless DatePicker, finally complete',
-  favicon: 'img/favicon.ico',
+  favicon: 'img/kalyx-mascot.png',
 
   future: {
     v4: true,

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -609,3 +609,96 @@ describe('DatePicker — SSR safety', () => {
     }).not.toThrow();
   });
 });
+
+describe('DatePicker.Popover — style merging', () => {
+  it('preserves Floating UI positioning when user passes a style prop', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value={null} onChange={vi.fn()}>
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover style={{ padding: 99, background: 'red' }}>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const dialog = screen.getByRole('dialog');
+
+    // User-provided styles still apply...
+    expect(dialog.style.padding).toBe('99px');
+    expect(dialog.style.background).toBe('red');
+    // ...but Floating UI positioning is never overwritten.
+    expect(dialog.style.position).toBe('absolute');
+  });
+
+  it('still positions when no style prop is provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value={null} onChange={vi.fn()}>
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('dialog').style.position).toBe('absolute');
+  });
+
+  it('passes through className without affecting positioning', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value={null} onChange={vi.fn()}>
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover className="my-popover">
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('my-popover');
+    expect(dialog.style.position).toBe('absolute');
+  });
+
+  it('user style cannot overwrite position even when explicitly attempted', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value={null} onChange={vi.fn()}>
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover style={{ position: 'fixed', top: 9999, left: 9999 }}>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const dialog = screen.getByRole('dialog');
+    // floatingStyles wins — user's `position: fixed` and bogus offsets are discarded.
+    expect(dialog.style.position).toBe('absolute');
+    expect(dialog.style.top).not.toBe('9999px');
+    expect(dialog.style.left).not.toBe('9999px');
+  });
+
+  it('becomes visible once Floating UI has positioned (no permanent first-frame hide)', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value={null} onChange={vi.fn()}>
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const dialog = screen.getByRole('dialog');
+    // After Floating UI finishes positioning the visibility guard releases — the
+    // popover must not stay permanently hidden. (Empty string or 'visible' both
+    // mean "no inline visibility override".)
+    expect(['', 'visible']).toContain(dialog.style.visibility);
+  });
+});

--- a/packages/react/src/components/DatePicker/Popover.tsx
+++ b/packages/react/src/components/DatePicker/Popover.tsx
@@ -10,13 +10,15 @@ export function DatePickerPopover({ children, ...props }: DatePickerPopoverProps
   const ctx = useDatePickerContext('DatePicker.Popover');
   const calendarId = `${ctx.pickerId}-calendar`;
 
-  const { floatingStyles, setFloatingRef } = usePopover({
+  const { floatingStyles, setFloatingRef, isPositioned } = usePopover({
     isOpen: ctx.isOpen,
     close: ctx.close,
     referenceRef: ctx.referenceRef,
   });
 
   if (!ctx.isOpen) return null;
+
+  const { style: userStyle, ...rest } = props;
 
   return (
     <div
@@ -25,8 +27,12 @@ export function DatePickerPopover({ children, ...props }: DatePickerPopoverProps
       role="dialog"
       aria-label={ctx.labels.popoverLabel}
       aria-modal="false"
-      style={floatingStyles}
-      {...props}
+      {...rest}
+      style={{
+        ...userStyle,
+        ...floatingStyles,
+        visibility: isPositioned ? undefined : 'hidden',
+      }}
     >
       {children}
     </div>

--- a/packages/react/src/components/RangePicker/Popover.tsx
+++ b/packages/react/src/components/RangePicker/Popover.tsx
@@ -10,13 +10,15 @@ export function RangePickerPopover({ children, ...props }: RangePickerPopoverPro
   const ctx = useRangePickerContext('RangePicker.Popover');
   const calendarId = `${ctx.pickerId}-calendar`;
 
-  const { floatingStyles, setFloatingRef } = usePopover({
+  const { floatingStyles, setFloatingRef, isPositioned } = usePopover({
     isOpen: ctx.isOpen,
     close: ctx.close,
     referenceRef: ctx.referenceRef,
   });
 
   if (!ctx.isOpen) return null;
+
+  const { style: userStyle, ...rest } = props;
 
   return (
     <div
@@ -25,8 +27,12 @@ export function RangePickerPopover({ children, ...props }: RangePickerPopoverPro
       role="dialog"
       aria-label={ctx.labels.popoverLabel}
       aria-modal="false"
-      style={floatingStyles}
-      {...props}
+      {...rest}
+      style={{
+        ...userStyle,
+        ...floatingStyles,
+        visibility: isPositioned ? undefined : 'hidden',
+      }}
     >
       {children}
     </div>

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -562,3 +562,25 @@ describe('RangePicker — SSR safety', () => {
     }).not.toThrow();
   });
 });
+
+describe('RangePicker.Popover — style merging', () => {
+  it('preserves Floating UI positioning when user passes a style prop', async () => {
+    const user = userEvent.setup();
+    render(
+      <RangePicker value={EMPTY} onChange={vi.fn()}>
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover style={{ padding: 77, background: 'blue' }}>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    const dialog = screen.getByRole('dialog');
+
+    expect(dialog.style.padding).toBe('77px');
+    expect(dialog.style.background).toBe('blue');
+    expect(dialog.style.position).toBe('absolute');
+  });
+});

--- a/packages/react/src/hooks/usePopover.ts
+++ b/packages/react/src/hooks/usePopover.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useFloating, autoUpdate, offset, flip, shift } from '@floating-ui/react';
 import type { Placement } from '@floating-ui/react';
 
@@ -25,14 +25,16 @@ export function usePopover({
   const floatingRef = useRef<HTMLDivElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  const { refs, floatingStyles } = useFloating({
+  const { refs, floatingStyles, isPositioned } = useFloating({
     open: isOpen,
     placement,
     middleware: [offset(4), flip(), shift({ padding: 8 })],
     whileElementsMounted: autoUpdate,
   });
 
-  // Wire the context's referenceRef into Floating UI
+  // Wire the context's referenceRef into Floating UI as a fallback for cases
+  // where the popover mounts before reference is updated. The ref callback in
+  // setFloatingRef below handles the common synchronous case.
   useEffect(() => {
     if (referenceRef.current) {
       refs.setReference(referenceRef.current);
@@ -92,10 +94,20 @@ export function usePopover({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, close]);
 
-  const setFloatingRef = (node: HTMLDivElement | null) => {
-    floatingRef.current = node;
-    refs.setFloating(node);
-  };
+  // Set floating + reference together when the popover mounts. The reference
+  // is already attached via Input/Trigger's ref callback by the time the
+  // popover renders, so calling setReference here means Floating UI has both
+  // elements before paint — eliminating the unpositioned first-frame flash.
+  const setFloatingRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      floatingRef.current = node;
+      refs.setFloating(node);
+      if (node && referenceRef.current) {
+        refs.setReference(referenceRef.current);
+      }
+    },
+    [refs, referenceRef],
+  );
 
-  return { floatingStyles, setFloatingRef };
+  return { floatingStyles, setFloatingRef, isPositioned };
 }


### PR DESCRIPTION
## Summary

- 라이브러리 버그 수정: `DatePicker.Popover` / `RangePicker.Popover`가 사용자 `style` prop을 받으면 Floating UI의 `position`/`top`/`left`/`transform`이 전부 덮여 popover가 정적 블록으로 떨어지던 문제. Quick Start 라이브 데모를 통째로 깨고 있었음.
- 첫 프레임 깜빡임 제거: `isPositioned`로 popover를 숨겨 위치 계산 전 풀-너비로 깜빡이는 현상을 차단.
- 동기 reference 등록: `setFloatingRef` ref 콜백에서 `setReference`를 함께 호출해 paint 전에 두 요소가 모두 Floating UI에 등록되도록.
- 문서 메타: Docusaurus 기본 favicon(3,626 bytes 그린 다이노)을 `kalyx-mascot.png`로 교체.
- Quick Start LiveExample: 다른 데모들과 일관되게 `kx-live-*` className 패턴으로 정리.

## 영향 범위

`DatePicker.Popover`, `RangePicker.Popover` 두 파일만 수정했지만 alias 재사용으로 6개 컴포넌트가 동시에 fix됨.

| 컴포넌트 | Popover 출처 |
|---|---|
| `DatePicker.Popover` | DatePicker (직접) |
| `RangePicker.Popover` | RangePicker (직접) |
| `DateTimePicker.Popover` | DatePickerPopover (alias) |
| `MonthPicker.Popover` | DatePickerPopover (alias) |
| `YearPicker.Popover` | DatePickerPopover (alias) |
| `WeekPicker.Popover` | RangePickerPopover (alias) |

## Test plan

- [x] `pnpm typecheck` × 3회 (incremental + clean cache + incremental) 모두 통과
- [x] `pnpm test:run` × 5회 — **374/374 pass** flaky 없이 일관
- [x] `pnpm lint` 0 violations
- [x] `pnpm -r build` 전체 통과 (core, react, docs, docs-site)
- [x] `pnpm check-bundle` gzip **11.43KB** ≤ 12KB
- [x] `pnpm check-tree-shaking` 9 시나리오 정상
- [x] Docs-site 빌드 산출물 `index.html`에 `<link rel=icon href=/img/kalyx-mascot.png>` 확인
- [x] 회귀 테스트 5건 신규: style 병합, position 보존, className pass-through, position override 저항, visibility 해제 (DatePicker 4 + RangePicker 1)

## Changeset

`@kalyx/react` patch — `.changeset/popover-style-merge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* DatePicker 및 RangePicker 팝오버의 스타일 병합 문제 해결 - 사용자 정의 스타일이 Floating UI의 위치 지정 스타일과 올바르게 병합됩니다.
* 팝오버의 초기 깜빡임 현상 제거

## 문서
* 라이브 예제의 스타일링 개선 - 클래스 기반 접근 방식으로 업데이트
* 파비콘 변경 (새로운 마스코트 아이콘 적용)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->