### PR TITLE
fix(v1.0-rc): resolve P0 release blockers

### DIFF
--- a/.changeset/v1-rc1-blockers.md
+++ b/.changeset/v1-rc1-blockers.md
@@ -1,0 +1,14 @@
+---
+"@kalyx/react": patch
+"@kalyx/core": patch
+---
+
+Resolve v1.0-rc release-blocking defects (P0):
+
+- **`"use client"` directive** — bundle is now marked as a React Server Component client boundary via tsup banner. Next.js App Router consumers no longer have to wrap each import.
+- **Stable `today()`/`now()` initialization** — `viewMonth`/`focusedDate` `useState` calls in `DatePicker`/`RangePicker`/`DateTimePicker` Roots now use lazy initializers, so the adapter isn't called on every render.
+- **`@kalyx/core` version sync** — bumped from `1.0.0-rc.0` to `1.0.0-rc.1` to match `@kalyx/react`.
+- **`@kalyx/core` package contents** — `LICENSE` and `CHANGELOG.md` are now included in the npm tarball (`files` field).
+- **Form auto-submit blocked when calendar open** — pressing Enter inside `DatePicker.Input`/`RangePicker.Input`/`DateTimePicker.Input` while the popover is open no longer submits the surrounding `<form>`.
+- **`aria-haspopup="dialog"` on Trigger** — completes the WAI-ARIA combobox/dialog pattern.
+- **Disabled cells skipped during keyboard navigation** — Calendar arrow keys / PageUp/Down / Home / End now step over disabled days and stop only when no enabled day is reachable.

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jihoon Lee (jiji-hoon96)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kalyx/core",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "Kalyx core — platform-agnostic date logic, IANA timezone helpers, and the DateAdapter contract used by @kalyx/react",
 	"license": "MIT",
 	"author": "jiji-hoon96",
@@ -42,7 +42,9 @@
 		}
 	},
 	"files": [
-		"dist"
+		"dist",
+		"CHANGELOG.md",
+		"LICENSE"
 	],
 	"scripts": {
 		"build": "tsup src/index.ts --format esm,cjs --dts --clean",

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jihoon Lee (jiji-hoon96)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -165,6 +165,28 @@ export function DatePickerCalendar({
 
       if (newFocused) {
         e.preventDefault();
+
+        // WAI-ARIA grid pattern: disabled cells should be skipped during keyboard
+        // navigation. Keep stepping in the original direction until we land on an
+        // enabled day, capped at 42 attempts (one full grid) to avoid infinite loops
+        // when every day in range is disabled.
+        const skipStep =
+          e.key === 'ArrowLeft' ||
+          e.key === 'ArrowUp' ||
+          e.key === 'PageUp' ||
+          e.key === 'Home'
+            ? -1
+            : 1;
+        let attempts = 0;
+        while (isDateDisabled(newFocused, disabled, adapter) && attempts < 42) {
+          newFocused = adapter.addDays(newFocused, skipStep);
+          attempts++;
+        }
+        if (attempts >= 42) {
+          // No reachable enabled date in this direction — leave focus where it was.
+          return;
+        }
+
         ctx.setFocusedDate(newFocused);
 
         // Update the view when focus moves outside the current view month

--- a/packages/react/src/components/DatePicker/Input.tsx
+++ b/packages/react/src/components/DatePicker/Input.tsx
@@ -79,6 +79,12 @@ export const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps
         if (e.key === 'Escape') {
           ctx.close();
         } else if (e.key === 'Enter') {
+          // Block form submission while the calendar is open. Otherwise an Enter
+          // intended to commit a typed date (or simply navigate inside the popover)
+          // bubbles up and submits the surrounding <form>, which surprised users.
+          if (ctx.isOpen) {
+            e.preventDefault();
+          }
           if (inputText !== null) {
             const parsed = parseInputValue(inputText, ctx.adapter);
             if (parsed) {

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -99,12 +99,15 @@ export function DatePickerRoot({
 
   const [isOpen, setIsOpen] = useState(false);
 
+  // Lazy initializers: today() is only computed once per mount instead of on every
+  // render. Avoids redundant Date allocations and makes the SSR/hydration contract
+  // explicit — neither server nor client re-evaluates the fallback after first render.
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue ?? adapter.today(displayTimezone),
+    () => currentValue ?? adapter.today(displayTimezone),
   );
 
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue ?? adapter.today(displayTimezone),
+    () => currentValue ?? adapter.today(displayTimezone),
   );
 
   useChangeEffect(isOpen, onOpenChange);

--- a/packages/react/src/components/DatePicker/Trigger.tsx
+++ b/packages/react/src/components/DatePicker/Trigger.tsx
@@ -35,6 +35,7 @@ export const DatePickerTrigger = forwardRef<HTMLButtonElement, DatePickerTrigger
         tabIndex={0}
         aria-label={ctx.isOpen ? ctx.labels.triggerClose : ctx.labels.triggerOpen}
         aria-expanded={ctx.isOpen}
+        aria-haspopup="dialog"
         aria-controls={ctx.isOpen ? calendarId : undefined}
         disabled={ctx.isDisabled || props.disabled}
         onClick={handleClick}

--- a/packages/react/src/components/DateTimePicker/Input.tsx
+++ b/packages/react/src/components/DateTimePicker/Input.tsx
@@ -44,6 +44,9 @@ export const DateTimePickerInput = forwardRef<HTMLInputElement, DateTimePickerIn
       (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Escape') {
           ctx.close();
+        } else if (e.key === 'Enter' && ctx.isOpen) {
+          // Don't submit the surrounding form when the calendar is open.
+          e.preventDefault();
         } else if (e.key === 'ArrowDown' && !ctx.isOpen) {
           e.preventDefault();
           ctx.open();

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -136,11 +136,12 @@ export function DateTimePickerRoot({
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
 
   const [isOpen, setIsOpen] = useState(false);
+  // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue ?? adapter.today(displayTimezone),
+    () => currentValue ?? adapter.today(displayTimezone),
   );
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue ?? adapter.today(displayTimezone),
+    () => currentValue ?? adapter.today(displayTimezone),
   );
 
   useChangeEffect(isOpen, onOpenChange);

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -209,6 +209,23 @@ export function RangePickerCalendar({
 
       if (newFocused) {
         e.preventDefault();
+
+        // WAI-ARIA grid pattern: skip disabled cells while keyboard-navigating.
+        // Step in the original direction up to one full grid (42 cells) before giving up.
+        const skipStep =
+          e.key === 'ArrowLeft' ||
+          e.key === 'ArrowUp' ||
+          e.key === 'PageUp' ||
+          e.key === 'Home'
+            ? -1
+            : 1;
+        let attempts = 0;
+        while (isDateDisabled(newFocused, disabled, adapter) && attempts < 42) {
+          newFocused = adapter.addDays(newFocused, skipStep);
+          attempts++;
+        }
+        if (attempts >= 42) return;
+
         ctx.setFocusedDate(newFocused);
 
         if (!adapter.isSameMonth(newFocused, viewMonth)) {

--- a/packages/react/src/components/RangePicker/Input.tsx
+++ b/packages/react/src/components/RangePicker/Input.tsx
@@ -45,6 +45,9 @@ export const RangePickerInput = forwardRef<HTMLInputElement, RangePickerInputPro
       (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Escape') {
           ctx.close();
+        } else if (e.key === 'Enter' && ctx.isOpen) {
+          // Don't submit the surrounding form when the calendar is open.
+          e.preventDefault();
         } else if (e.key === 'ArrowDown' && !ctx.isOpen) {
           e.preventDefault();
           ctx.open();

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -104,12 +104,13 @@ export function RangePickerRoot({
 
   const [hoverDate, setHoverDate] = useState<ISODateString | null>(null);
 
+  // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
   const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(displayTimezone),
+    () => currentValue.start ?? adapter.today(displayTimezone),
   );
 
   const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(displayTimezone),
+    () => currentValue.start ?? adapter.today(displayTimezone),
   );
 
   useChangeEffect(isOpen, onOpenChange);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,7 @@
 // @kalyx/react — public API entry point
+// The published bundle is prefixed with `"use client";` (injected by tsup at build
+// time, see tsup.config.ts) so React Server Component hosts (Next.js App Router etc.)
+// treat it as a client boundary without consumers wrapping each import.
 
 export { DatePicker } from './components/DatePicker/index.js';
 export { RangePicker } from './components/RangePicker/index.js';

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsup";
 
+const USE_CLIENT_DIRECTIVE = '"use client";\n';
+
 export default defineConfig({
 	entry: ["src/index.ts"],
 	format: ["esm", "cjs"],
@@ -12,12 +14,21 @@ export default defineConfig({
 	esbuildOptions(options) {
 		options.jsx = "automatic";
 	},
+	// `banner` doesn't work for "use client" — esbuild strips top-level directives during
+	// bundling. We instead inject the directive after the bundle is written so React
+	// Server Component hosts (Next.js App Router etc.) treat the package as a client
+	// boundary without the consumer wrapping each import.
 	async onSuccess() {
 		const { gzipSync } = await import("zlib");
-		const { readFileSync } = await import("fs");
+		const { readFileSync, writeFileSync } = await import("fs");
 		const TARGET_KB = 12;
-		for (const [label, file] of [["ESM", "dist/index.js"], ["CJS", "dist/index.cjs"]] as const) {
+		const outputs = [["ESM", "dist/index.js"], ["CJS", "dist/index.cjs"]] as const;
+		for (const [label, file] of outputs) {
 			try {
+				const original = readFileSync(file, "utf8");
+				if (!original.startsWith(USE_CLIENT_DIRECTIVE.trim())) {
+					writeFileSync(file, USE_CLIENT_DIRECTIVE + original);
+				}
 				const content = readFileSync(file);
 				const kb = (gzipSync(content).length / 1024).toFixed(2);
 				const icon = parseFloat(kb) <= TARGET_KB ? "✅" : "⚠️";


### PR DESCRIPTION
## Summary

Resolves the 7 release-blocking defects identified in the multi-perspective audit. Without this PR, v1.0-rc cannot ship safely.

### Defects fixed

1. **`"use client"` directive missing** — bundle now starts with `"use client";` (injected by tsup `onSuccess` because esbuild strips top-level directives during bundling). Next.js App Router consumers no longer have to wrap each import.
2. **`today()` called on every render** — `viewMonth`/`focusedDate` `useState` seeds in `DatePicker`/`RangePicker`/`DateTimePicker` Root now use lazy initializers, so the adapter runs once per mount.
3. **Version desync** — `@kalyx/core@1.0.0-rc.0` → `1.0.0-rc.1` to match `@kalyx/react`.
4. **`@kalyx/core` LICENSE / CHANGELOG missing from npm tarball** — `files` field updated; `LICENSE` copied into both packages.
5. **Form auto-submit on Enter while calendar open** — `DatePicker.Input`, `RangePicker.Input`, `DateTimePicker.Input` now `preventDefault` on `Enter` whenever the popover is open.
6. **`aria-haspopup` missing on Trigger** — added `aria-haspopup="dialog"` to complete the WAI-ARIA combobox/dialog pattern.
7. **Calendar keyboard nav did not skip disabled days** — arrow keys / `PageUp`/`PageDown` / `Home` / `End` now step over disabled cells in `DatePicker.Calendar` and `RangePicker.Calendar` (capped at 42 attempts to handle fully-disabled ranges). `WeekPicker.Calendar` inherits via its wrapper.

### Out of scope (explicit)

- `TimePicker.Input` was reported as missing `role="combobox"` — but the component is **inline** (no popover), so the combobox role does not apply. Skipped.
- Removing leaked `Context` / internal hook `.d.ts` types from `dist/` requires `api-extractor` and is a follow-up.
- The remaining ~30 P1/P2 defects are split into PR #2 (a11y/API), PR #3 (performance), PR #4 (polish).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test:run` — 374/374 tests pass
- [x] `pnpm --filter @kalyx/react build` — ESM 11.57KB, CJS 11.58KB gzip (≤12KB target)
- [x] Verified `"use client";` is the first line of both `dist/index.js` and `dist/index.cjs`
- [ ] Manual smoke in Next.js App Router
- [ ] Manual: form submit blocked when Enter pressed with calendar open
- [ ] Manual: keyboard arrow keys skip a `disabled` rule range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v1.0.0-rc.1 릴리스 노트

* **버그 수정**
  * 날짜 선택기에서 비활성화된 날짜 스킵
  * Enter 키 입력 시 폼 자동 제출 방지
  * 접근성 개선 (aria-haspopup 속성 추가)

* **기능 개선**
  * Next.js App Router 지원
  * 날짜 선택기 성능 최적화

* **문서 및 배포**
  * LICENSE 파일 추가
  * API 엔트리포인트 문서 주석 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->