### PR TITLE
perf(v1.0-rc): memoize hot paths to reduce re-renders

### DIFF
--- a/.changeset/v1-rc1-perf.md
+++ b/.changeset/v1-rc1-perf.md
@@ -1,0 +1,9 @@
+---
+"@kalyx/react": patch
+---
+
+Performance: memoize hot paths to avoid wasted recomputation:
+
+- `DatePicker.Calendar` and `RangePicker.Calendar` now `useMemo` their `getCalendarDays` and `getWeekdayNames` results. Previously the 42-cell grid and 7 weekday tuples were rebuilt every parent re-render even when none of the inputs changed.
+- `TimePicker.HourList` and `TimePicker.MinuteList` `useMemo` their `generateHours(format)` / `generateMinutes(step)` arrays so the listbox identity is stable across renders.
+- `usePopover` middleware (`offset` / `flip` / `shift`) is now hoisted to a module-level constant, eliminating Floating UI's repeated middleware-array reconciliation.

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
@@ -64,17 +64,23 @@ export function DatePickerCalendar({
   const [announcement, setAnnouncement] = useState('');
 
   const { adapter, viewMonth, focusedDate, weekStartsOn, disabled, locale, displayTimezone } = ctx;
-  const weekdays = getWeekdayNames(locale, weekStartsOn);
+  // Memoized — weekday header tuples only change when locale or week start changes.
+  const weekdays = useMemo(() => getWeekdayNames(locale, weekStartsOn), [locale, weekStartsOn]);
 
   // Recompute cell flags with a timezone-aware today/selected matcher when displayTimezone is set.
   // The grid iteration stays in UTC — only the `isSelected` / `isToday` highlighting shifts.
-  const weeks = getCalendarDays(viewMonth, adapter, {
-    weekStartsOn,
-    selected: ctx.value,
-    focusedDate,
-    disabled,
-    timezone: displayTimezone,
-  });
+  // Memoized so the 42-cell grid isn't rebuilt on unrelated re-renders (parent state, etc.).
+  const weeks = useMemo(
+    () =>
+      getCalendarDays(viewMonth, adapter, {
+        weekStartsOn,
+        selected: ctx.value,
+        focusedDate,
+        disabled,
+        timezone: displayTimezone,
+      }),
+    [viewMonth, adapter, weekStartsOn, ctx.value, focusedDate, disabled, displayTimezone],
+  );
 
   const year = adapter.getYear(viewMonth);
   const month = adapter.getMonth(viewMonth);

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
@@ -85,16 +85,21 @@ export function RangePickerCalendar({
   } = ctx;
 
   const { locale } = ctx;
-  const weekdays = getWeekdayNames(locale, weekStartsOn);
+  // Memoized — see DatePicker/Calendar.tsx for the rationale.
+  const weekdays = useMemo(() => getWeekdayNames(locale, weekStartsOn), [locale, weekStartsOn]);
 
-  const weeks = getCalendarDays(viewMonth, adapter, {
-    weekStartsOn,
-    focusedDate,
-    disabled,
-    range: value,
-    rangeHover: hoverDate,
-    timezone: displayTimezone,
-  });
+  const weeks = useMemo(
+    () =>
+      getCalendarDays(viewMonth, adapter, {
+        weekStartsOn,
+        focusedDate,
+        disabled,
+        range: value,
+        rangeHover: hoverDate,
+        timezone: displayTimezone,
+      }),
+    [viewMonth, adapter, weekStartsOn, focusedDate, disabled, value, hoverDate, displayTimezone],
+  );
 
   const year = adapter.getYear(viewMonth);
   const month = adapter.getMonth(viewMonth);

--- a/packages/react/src/components/TimePicker/HourList.tsx
+++ b/packages/react/src/components/TimePicker/HourList.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { HTMLAttributes } from 'react';
 import { generateHours, to12Hour, to24Hour } from '@kalyx/core';
 import { useTimePickerContext } from '../../context/TimePickerContext.js';
@@ -28,7 +28,9 @@ export function TimePickerHourList({ classNames, ...props }: TimePickerHourListP
   const ctx = useTimePickerContext('TimePicker.HourList');
   const { format, currentTime, isDisabled, isReadOnly } = ctx;
 
-  const hours = generateHours(format);
+  // Stable across renders unless `format` changes — useListboxNavigation
+  // identity-compares its `items` array internally.
+  const hours = useMemo(() => generateHours(format), [format]);
 
   const selectedHourDisplay =
     format === '12h' ? to12Hour(currentTime.hours).hours12 : currentTime.hours;

--- a/packages/react/src/components/TimePicker/MinuteList.tsx
+++ b/packages/react/src/components/TimePicker/MinuteList.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { HTMLAttributes } from 'react';
 import { generateMinutes } from '@kalyx/core';
 import { useTimePickerContext } from '../../context/TimePickerContext.js';
@@ -25,7 +25,9 @@ export function TimePickerMinuteList({ classNames, ...props }: TimePickerMinuteL
   const ctx = useTimePickerContext('TimePicker.MinuteList');
   const { step, currentTime, isDisabled, isReadOnly } = ctx;
 
-  const minutes = generateMinutes(step);
+  // Stable across renders unless `step` changes — useListboxNavigation
+  // identity-compares its `items` array internally.
+  const minutes = useMemo(() => generateMinutes(step), [step]);
 
   const handleSelect = useCallback(
     (minute: number) => {

--- a/packages/react/src/hooks/usePopover.ts
+++ b/packages/react/src/hooks/usePopover.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useFloating, autoUpdate, offset, flip, shift } from '@floating-ui/react';
-import type { Placement } from '@floating-ui/react';
+import type { Middleware, Placement } from '@floating-ui/react';
+
+// Hoisted to module scope so it isn't reallocated on every render. Floating UI
+// shallow-compares the middleware array, so a fresh array each render forced
+// useless reposition cycles.
+const POPOVER_MIDDLEWARE: Middleware[] = [offset(4), flip(), shift({ padding: 8 })];
 
 export interface UsePopoverOptions {
   isOpen: boolean;
@@ -28,7 +33,7 @@ export function usePopover({
   const { refs, floatingStyles, isPositioned } = useFloating({
     open: isOpen,
     placement,
-    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    middleware: POPOVER_MIDDLEWARE,
     whileElementsMounted: autoUpdate,
   });
 


### PR DESCRIPTION
## Summary

Addresses 5 P1 performance defects from the multi-perspective audit. Independent of #25 / #26 (touches Calendar.tsx for memoization only — keyboard handlers from #25 are in different blocks; rebase straightforward).

### Hot paths now memoized

1. **`DatePicker.Calendar`, `RangePicker.Calendar`** — `getCalendarDays` and `getWeekdayNames` wrapped in `useMemo`. The 42-cell grid was previously rebuilt every parent re-render. With Range hover-preview interactions firing setState per `mouseenter`, this added up.
2. **`TimePicker.HourList`** — `generateHours(format)` memoized; the 12-hour or 24-hour array no longer reallocates per render.
3. **`TimePicker.MinuteList`** — `generateMinutes(step)` memoized; the same applies for the 60/step array.
4. **`usePopover`** — `[offset(4), flip(), shift({ padding: 8 })]` hoisted to a module-level `POPOVER_MIDDLEWARE` constant. Floating UI shallow-compares the middleware array, so a fresh array per render forced wasted reposition cycles.

### Out of scope (deferred)

- `MonthGrid` 12-month array memoization, `RangePicker.Presets` duplicate `resolvePreset` calls, `handleDayMouseEnter` deps tightening — micro-optimizations with smaller payoff; folded into PR-4 polish.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test:run` — 374/374 tests pass (no behavior change, only memoization)
- [ ] Manual: profile RangePicker hover preview (drag across grid) — should show fewer Calendar reconciliations

🤖 Generated with [Claude Code](https://claude.com/claude-code)