### PR TITLE
ci(security): silence false-positive issues from feature-branch force-pushes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,16 @@ on:
   schedule:
     # Monday 09:00 KST (UTC 00:00)
     - cron: '0 0 * * 1'
+  # Restrict push trigger to main so feature-branch force-pushes don't race with
+  # branch deletion (the SARIF upload step references the original ref, and the
+  # auto-merge + delete-branch flow can remove it before the upload completes,
+  # causing a false-positive failure that auto-creates a noise issue).
   push:
+    branches: [main]
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
+  pull_request:
     paths:
       - '**/package.json'
       - 'pnpm-lock.yaml'
@@ -50,7 +59,11 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     needs: [osv-scan, license-check]
-    if: failure()
+    # Only file an issue for failures on main / scheduled runs / manual dispatch.
+    # PR-context failures already surface in the PR's check list, so creating a
+    # parallel tracking issue would be duplicate noise (and the issue body's
+    # workflow link would point to a soon-to-be-deleted feature branch).
+    if: failure() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7


### PR DESCRIPTION
## Problem

After merging the v1.0-rc PR series (#25, #26, #28, #29, #30, #31), the auto-generated security issues kept reappearing (#23, #24, #27, #32, #33). The OSV scan itself was passing locally — \`osv-scanner --lockfile=pnpm-lock.yaml\` reports \`No issues found\`. The actual failure was:

\`\`\`
##[error]ref 'refs/heads/feat/playground' not found in this repository
\`\`\`

The reusable \`google/osv-scanner-action\` workflow runs SARIF upload to GitHub code-scanning **after** the scan completes. When a PR uses \`--delete-branch\` on merge (every PR in this series did), the branch is gone by the time the upload step references it. Job-level result is \`failure\`, so \`notify-on-failure\` fires and creates an issue, even though no vulnerability exists.

## Fix

1. **Restrict the push trigger to main** — feature-branch pushes still get OSV + license coverage via the existing \`pull_request:\` trigger.
2. **Gate the notify-on-failure job** on \`github.event_name != 'pull_request'\` — PR failures already appear in the PR check list, so a duplicate tracking issue is just noise.

## Test plan

- [x] Local \`osv-scanner --lockfile=pnpm-lock.yaml\` — 0 advisories
- [ ] After merge, force-pushing to a feature branch then merging it should NOT create a new security issue
- [ ] Real vulnerabilities on \`main\` (or the weekly cron) still create tracking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)