### PR TITLE
ci: raise bundle target to 13KB in release.yml + pr-check.yml

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -80,7 +80,7 @@ jobs:
           retention-days: 1
 
   bundle-size:
-    name: Bundle Size (≤12KB gzip)
+    name: Bundle Size (≤13KB gzip)
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -98,7 +98,7 @@ jobs:
         run: |
           BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
           KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=12
+          MAX=13
           echo "gzip_kb=$KB" >> $GITHUB_OUTPUT
           echo "📦 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
           if (( $(echo "$KB > $MAX" | bc -l) )); then
@@ -112,15 +112,15 @@ jobs:
         with:
           script: |
             const kb   = '${{ steps.check.outputs.gzip_kb }}';
-            const ok   = parseFloat(kb) <= 12;
+            const ok   = parseFloat(kb) <= 13;
             const icon = ok ? '✅' : '❌';
             const body = [
-              
+
               '',
               '| | gzip |',
               '|---|---|',
               `| **현재** | **${kb}KB** |`,
-              `| 목표 | ≤ 12KB |`,
+              `| 목표 | ≤ 13KB |`,
               '',
               ok
                 ? '번들 크기가 목표 이내입니다.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,10 @@ jobs:
         run: |
           BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
           KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          echo "📦 릴리즈 번들 크기: ${KB}KB"
-          if (( $(echo "$KB > 12" | bc -l) )); then
-            echo "❌ 번들 크기 12KB 초과 — 릴리즈 중단"
+          MAX=13
+          echo "📦 릴리즈 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
+          if (( $(echo "$KB > $MAX" | bc -l) )); then
+            echo "❌ 번들 크기 ${MAX}KB 초과 — 릴리즈 중단"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

User reported the release workflow on main was failing with:

\`\`\`
📦 릴리즈 번들 크기: 12.09KB
❌ 번들 크기 12KB 초과 — 릴리즈 중단
Error: Process completed with exit code 1.
\`\`\`

PR #36 raised the bundle target from 12KB to 13KB everywhere I knew about (\`scripts/check-bundle-size.js\`, \`tsup.config.ts\`, README en/ko, \`package.json\` description, \`CLAUDE.md\`), but missed two GitHub workflow files where the threshold was inlined as a bash literal.

## Fix

- \`.github/workflows/release.yml\` (line 53): \`"$KB > 12"\` → \`"$KB > $MAX"\` with \`MAX=13\`. Error message and "릴리즈 중단" copy use the variable too so future bumps are one-line.
- \`.github/workflows/pr-check.yml\`: job display name "Bundle Size (≤12KB gzip)" → "≤13KB", inline check \`MAX=12\` → \`MAX=13\`, PR-comment threshold \`<= 12\` → \`<= 13\`, and template "≤ 12KB" label → "≤ 13KB".

Both now agree with \`scripts/check-bundle-size.js\`'s \`TARGET_KB = 13\`.

## Test plan

- [x] Local: \`pnpm check-bundle\` — PASS at 12.07/12.09 KB ≤ 13 KB target
- [ ] After merge: \`release.yml\` on main no longer fails the bundle gate
- [ ] After merge: PR-check job name displays as "Bundle Size (≤13KB gzip)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)