### PR TITLE
fix(changeset): security-postcss references non-workspace 'kalyx' package

### DIFF
--- a/.changeset/security-postcss.md
+++ b/.changeset/security-postcss.md
@@ -1,5 +1,6 @@
 ---
-"kalyx": patch
+"@kalyx/react": patch
+"@kalyx/core": patch
 ---
 
 Security: pin transitive `postcss` to `>=8.5.10` via `pnpm.overrides`.


### PR DESCRIPTION
## Problem

User reported the release workflow was still failing after PR #37. The bundle gate now passes (12.07KB ≤ 13KB), but \`Changesets 릴리즈\` step fails:

\`\`\`
🦋  error Error: Found changeset security-postcss for package kalyx
which is not in the workspace
\`\`\`

The security-postcss changeset I authored in PR #31 used \`"kalyx": patch\` as the front-matter target. \`kalyx\` is the root workspace package — it has \`private: true\` and isn't visible to changesets. Every release run since #31 has been failing on this.

## Fix

Re-target the changeset to the actual published packages:

\`\`\`diff
 ---
-"kalyx": patch
+"@kalyx/react": patch
+"@kalyx/core": patch
 ---
\`\`\`

The override is dev-time only (build pipeline transitive), so a patch bump is the right severity for both packages.

## Test plan

- [x] Local: \`pnpm changeset status\` reports the bumps cleanly (no errors)
- [ ] After merge: \`Release\` workflow on main proceeds past \`Changesets 릴리즈\` and either creates a Version PR (if any new changesets) or publishes (if Version PR already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)