### PR TITLE
refactor(core): remove unused weekday utilities

### DIFF
--- a/.changeset/remove-deprecated-weekday-utils.md
+++ b/.changeset/remove-deprecated-weekday-utils.md
@@ -1,0 +1,12 @@
+---
+"@kalyx/core": patch
+---
+
+Remove unused English-hardcoded weekday utilities from `utils/date.ts`:
+
+- `WEEKDAY_LABELS` (constant)
+- `getOrderedWeekdays()` (function)
+
+Both were internal exports (never exposed via `@kalyx/core` public `index.ts`) and had no consumers anywhere in the workspace. They were superseded by the locale-aware `getWeekdayNames(locale, weekStartsOn)` in `utils/locale.ts`, which uses `Intl.DateTimeFormat` to produce the same shape with multi-language support.
+
+No public API surface changed.

--- a/.changeset/replace-mutable-ref-object.md
+++ b/.changeset/replace-mutable-ref-object.md
@@ -1,0 +1,9 @@
+---
+"@kalyx/react": patch
+---
+
+Replace deprecated `MutableRefObject<T>` with `RefObject<T>` in context types.
+
+`@types/react@19` marks `MutableRefObject` as deprecated (`Use 'RefObject' instead`). In React 19 `RefObject<T>` is itself mutable, so the swap is type-equivalent for the existing `referenceRef` usage in `DatePickerContext` and `RangePickerContext`.
+
+No runtime change. No public API surface change.

--- a/packages/core/src/utils/date.ts
+++ b/packages/core/src/utils/date.ts
@@ -45,20 +45,3 @@ export function parseInputValue(input: string, adapter: DateAdapter): string | n
 
   return null;
 }
-
-/** Default weekday labels (English) */
-export const WEEKDAY_LABELS = {
-  short: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const,
-  full: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'] as const,
-};
-
-/** Returns weekdays ordered according to the given week start */
-export function getOrderedWeekdays(weekStartsOn: 0 | 1 = 0) {
-  const days = WEEKDAY_LABELS.short.map((short, i) => ({
-    short,
-    full: WEEKDAY_LABELS.full[i]!,
-  }));
-
-  if (weekStartsOn === 0) return days;
-  return [...days.slice(weekStartsOn), ...days.slice(0, weekStartsOn)];
-}

--- a/packages/react/src/context/DatePickerContext.ts
+++ b/packages/react/src/context/DatePickerContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type { MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 import type {
   DateAdapter,
   DatePickerLabels,
@@ -10,7 +10,7 @@ import type {
 
 export interface DatePickerContextValue {
   /** Floating UI reference element (set by Input/Trigger, read by Popover) */
-  referenceRef: MutableRefObject<HTMLElement | null>;
+  referenceRef: RefObject<HTMLElement | null>;
   /** Currently selected date (ISO 8601 UTC) */
   value: ISODateString | null;
   /** Date selection handler */

--- a/packages/react/src/context/RangePickerContext.ts
+++ b/packages/react/src/context/RangePickerContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import type { MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 import type {
   DateAdapter,
   DateRange,
@@ -14,7 +14,7 @@ export type RangeSelectingTarget = 'start' | 'end';
 
 export interface RangePickerContextValue {
   /** Floating UI reference element */
-  referenceRef: MutableRefObject<HTMLElement | null>;
+  referenceRef: RefObject<HTMLElement | null>;
   /** Currently selected range */
   value: DateRange;
   /** Update the entire range object */


### PR DESCRIPTION
## Summary

- Removed `WEEKDAY_LABELS` and `getOrderedWeekdays()` from `packages/core/src/utils/date.ts` — both were internal exports with zero consumers, superseded by the locale-aware `getWeekdayNames(locale, weekStartsOn)` in `utils/locale.ts` (Intl-based, multi-language).
- Added changeset (`@kalyx/core` patch). No public API surface changed.

## Background

Audit triggered by request to clean deprecated logic. Findings:

| Category | Result |
|---|---|
| `@deprecated` JSDoc in `packages/` | 0 |
| Unused exports | **2 found** (this PR) + `formatTimeFromISO` kept (public API, documented) |
| date-fns deprecated APIs | 0 (v4.1.0, standard signatures only) |
| §8 forbidden patterns | 0 (existing `new Date()` and `document.*` usages are intentional / SSR-safe) |

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:run` (378 tests pass)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm check-bundle` (12.07KB / 13KB target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 영어 고정 요일 유틸리티를 제거하고 로케일 기반의 향상된 기능으로 대체했습니다. 다국어 지원이 개선되어 더욱 유연한 날짜 처리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->