### PR TITLE
fix(docs-site): prevent live preview popover from stretching to viewport (#35)

### DIFF
--- a/apps/docs-site/docs/components/monthpicker.md
+++ b/apps/docs-site/docs/components/monthpicker.md
@@ -33,6 +33,41 @@ function Example() {
 
 The default `displayFormat` is `"yyyy-MM"`. Override it if you prefer a different representation (e.g., `"MMMM yyyy"` for `"April 2026"`).
 
+### Try it live
+
+```jsx live
+function BasicMonthPicker() {
+  const [month, setMonth] = React.useState(null);
+  const headerCls = {
+    header: 'kx-live-header',
+    title: 'kx-live-title',
+    navButton: 'kx-live-nav',
+  };
+  return (
+    <MonthPicker value={month} onChange={setMonth}>
+      <div className="kx-live-row">
+        <MonthPicker.Input className="kx-live-input" placeholder="YYYY-MM" />
+        <MonthPicker.Trigger className="kx-live-trigger" aria-label="Open month picker" />
+      </div>
+      <MonthPicker.Popover className="kx-live-popover">
+        <MonthPicker.Grid
+          classNames={{
+            ...headerCls,
+            grid: 'kx-live-month-grid',
+            month: 'kx-live-my-cell',
+            monthSelected: 'kx-live-my-selected',
+            monthCurrent: 'kx-live-my-current',
+          }}
+        />
+      </MonthPicker.Popover>
+      <div className="kx-live-value">
+        Selected: <code>{month ?? 'null'}</code>
+      </div>
+    </MonthPicker>
+  );
+}
+```
+
 ## Parts
 
 `MonthPicker` reuses `DatePicker`'s building blocks for everything except the grid:
@@ -74,6 +109,47 @@ Month names follow the `locale` prop (BCP 47). The built-in `getMonthName` helpe
 ## Disabled rules
 
 Restrict selectable months using the same `DisabledRule` syntax as `DatePicker`. Rules are evaluated against the first day of each month.
+
+```jsx live
+function DisabledMonthPicker() {
+  const [month, setMonth] = React.useState(null);
+  const headerCls = {
+    header: 'kx-live-header',
+    title: 'kx-live-title',
+    navButton: 'kx-live-nav',
+  };
+  return (
+    <MonthPicker
+      value={month}
+      onChange={setMonth}
+      disabled={[
+        { before: '2026-01-01T00:00:00.000Z' },
+        { after: '2026-12-31T00:00:00.000Z' },
+      ]}
+    >
+      <div className="kx-live-row">
+        <MonthPicker.Input className="kx-live-input" placeholder="2026 only" />
+        <MonthPicker.Trigger className="kx-live-trigger" aria-label="Open month picker" />
+      </div>
+      <MonthPicker.Popover className="kx-live-popover">
+        <MonthPicker.Grid
+          classNames={{
+            ...headerCls,
+            grid: 'kx-live-month-grid',
+            month: 'kx-live-my-cell',
+            monthSelected: 'kx-live-my-selected',
+            monthCurrent: 'kx-live-my-current',
+            monthDisabled: 'kx-live-disabled',
+          }}
+        />
+      </MonthPicker.Popover>
+      <div className="kx-live-value">
+        Selected: <code>{month ?? 'null'}</code>
+      </div>
+    </MonthPicker>
+  );
+}
+```
 
 ```tsx
 <MonthPicker

--- a/apps/docs-site/docs/components/weekpicker.md
+++ b/apps/docs-site/docs/components/weekpicker.md
@@ -33,9 +33,89 @@ function Example() {
 }
 ```
 
+### Try it live
+
+```jsx live
+function BasicWeekPicker() {
+  const [week, setWeek] = React.useState({ start: null, end: null });
+  const label = week.start && week.end
+    ? `${week.start.slice(0, 10)} → ${week.end.slice(0, 10)}`
+    : 'null';
+  return (
+    <WeekPicker value={week} onChange={setWeek}>
+      <div className="kx-live-row">
+        <WeekPicker.Input part="start" className="kx-live-input" placeholder="Start" />
+        <span aria-hidden>→</span>
+        <WeekPicker.Input part="end" className="kx-live-input" placeholder="End" />
+      </div>
+      <WeekPicker.Popover className="kx-live-popover">
+        <WeekPicker.Calendar
+          classNames={{
+            header: 'kx-live-header',
+            title: 'kx-live-title',
+            navButton: 'kx-live-nav',
+            grid: 'kx-live-grid',
+            gridCell: 'kx-live-cell',
+            weekdayHeader: 'kx-live-weekday',
+            day: 'kx-live-day-range',
+            dayInWeek: 'kx-live-inrange',
+            dayRangeStart: 'kx-live-range-start',
+            dayRangeEnd: 'kx-live-range-end',
+            dayToday: 'live-day-today',
+            dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+      </WeekPicker.Popover>
+      <div className="kx-live-value">
+        Week: <code>{label}</code>
+      </div>
+    </WeekPicker>
+  );
+}
+```
+
 ## weekStartsOn
 
 The `weekStartsOn` prop (inherited from `RangePicker.Root`) controls which day the week begins on — `0` for Sunday (default), `1` for Monday.
+
+```jsx live
+function MondayStartWeekPicker() {
+  const [week, setWeek] = React.useState({ start: null, end: null });
+  const label = week.start && week.end
+    ? `${week.start.slice(0, 10)} → ${week.end.slice(0, 10)}`
+    : 'null';
+  return (
+    <WeekPicker value={week} onChange={setWeek} weekStartsOn={1}>
+      <div className="kx-live-row">
+        <WeekPicker.Input part="start" className="kx-live-input" placeholder="Mon start" />
+        <span aria-hidden>→</span>
+        <WeekPicker.Input part="end" className="kx-live-input" placeholder="Sun end" />
+      </div>
+      <WeekPicker.Popover className="kx-live-popover">
+        <WeekPicker.Calendar
+          classNames={{
+            header: 'kx-live-header',
+            title: 'kx-live-title',
+            navButton: 'kx-live-nav',
+            grid: 'kx-live-grid',
+            gridCell: 'kx-live-cell',
+            weekdayHeader: 'kx-live-weekday',
+            day: 'kx-live-day-range',
+            dayInWeek: 'kx-live-inrange',
+            dayRangeStart: 'kx-live-range-start',
+            dayRangeEnd: 'kx-live-range-end',
+            dayToday: 'live-day-today',
+            dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+      </WeekPicker.Popover>
+      <div className="kx-live-value">
+        Week: <code>{label}</code>
+      </div>
+    </WeekPicker>
+  );
+}
+```
 
 ```tsx
 <WeekPicker weekStartsOn={1} value={week} onChange={setWeek}>

--- a/apps/docs-site/docs/components/yearpicker.md
+++ b/apps/docs-site/docs/components/yearpicker.md
@@ -33,6 +33,41 @@ function Example() {
 
 The default `displayFormat` is `"yyyy"`.
 
+### Try it live
+
+```jsx live
+function BasicYearPicker() {
+  const [year, setYear] = React.useState(null);
+  const headerCls = {
+    header: 'kx-live-header',
+    title: 'kx-live-title',
+    navButton: 'kx-live-nav',
+  };
+  return (
+    <YearPicker value={year} onChange={setYear}>
+      <div className="kx-live-row">
+        <YearPicker.Input className="kx-live-input" placeholder="YYYY" />
+        <YearPicker.Trigger className="kx-live-trigger" aria-label="Open year picker" />
+      </div>
+      <YearPicker.Popover className="kx-live-popover">
+        <YearPicker.Grid
+          classNames={{
+            ...headerCls,
+            grid: 'kx-live-year-grid',
+            year: 'kx-live-my-cell',
+            yearSelected: 'kx-live-my-selected',
+            yearCurrent: 'kx-live-my-current',
+          }}
+        />
+      </YearPicker.Popover>
+      <div className="kx-live-value">
+        Selected: <code>{year ?? 'null'}</code>
+      </div>
+    </YearPicker>
+  );
+}
+```
+
 ## Parts
 
 | Part | Source | Purpose |
@@ -61,6 +96,47 @@ When `displayTimezone` is set, year highlighting is timezone-aware. This matters
 ## Disabled rules
 
 Restrict selectable years. Rules are evaluated against January 1 of each year.
+
+```jsx live
+function DisabledYearPicker() {
+  const [year, setYear] = React.useState(null);
+  const headerCls = {
+    header: 'kx-live-header',
+    title: 'kx-live-title',
+    navButton: 'kx-live-nav',
+  };
+  return (
+    <YearPicker
+      value={year}
+      onChange={setYear}
+      disabled={[
+        { before: '2020-01-01T00:00:00.000Z' },
+        { after: '2030-01-01T00:00:00.000Z' },
+      ]}
+    >
+      <div className="kx-live-row">
+        <YearPicker.Input className="kx-live-input" placeholder="2020–2030" />
+        <YearPicker.Trigger className="kx-live-trigger" aria-label="Open year picker" />
+      </div>
+      <YearPicker.Popover className="kx-live-popover">
+        <YearPicker.Grid
+          classNames={{
+            ...headerCls,
+            grid: 'kx-live-year-grid',
+            year: 'kx-live-my-cell',
+            yearSelected: 'kx-live-my-selected',
+            yearCurrent: 'kx-live-my-current',
+            yearDisabled: 'kx-live-disabled',
+          }}
+        />
+      </YearPicker.Popover>
+      <div className="kx-live-value">
+        Selected: <code>{year ?? 'null'}</code>
+      </div>
+    </YearPicker>
+  );
+}
+```
 
 ```tsx
 <YearPicker

--- a/apps/docs-site/docs/recipes/tailwind.md
+++ b/apps/docs-site/docs/recipes/tailwind.md
@@ -18,31 +18,34 @@ function TailwindDate() {
   return (
     <div className="tw-enable">
       <DatePicker value={date} onChange={setDate}>
-        <div className="flex items-center gap-1 rounded-md border border-neutral-300 bg-white px-2 py-1 focus-within:ring-2 focus-within:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900">
+        <div className="inline-flex items-center gap-1 rounded-md border border-neutral-300 bg-white px-2.5 py-1.5 text-sm shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:border-indigo-500 dark:border-neutral-700 dark:bg-neutral-900">
           <DatePicker.Input
-            className="w-40 bg-transparent outline-none text-sm text-neutral-900 dark:text-neutral-100"
+            className="w-36 bg-transparent outline-none text-neutral-900 placeholder-neutral-400 dark:text-neutral-100 dark:placeholder-neutral-500"
             placeholder="YYYY-MM-DD"
           />
           <DatePicker.Trigger
-            className="rounded p-1 text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800"
-          />
+            className="inline-flex h-6 w-6 items-center justify-center rounded text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
+            aria-label="Open calendar"
+          >
+            📅
+          </DatePicker.Trigger>
         </div>
 
-        <DatePicker.Popover className="z-50 mt-2 rounded-xl border border-neutral-200 bg-white p-3 shadow-xl dark:border-neutral-800 dark:bg-neutral-900">
+        <DatePicker.Popover className="z-50 mt-2 rounded-lg border border-neutral-200 bg-white p-4 shadow-lg ring-1 ring-black/5 dark:border-neutral-800 dark:bg-neutral-900 dark:ring-white/10">
           <DatePicker.Calendar
             classNames={{
-              root: 'space-y-2',
-              header: 'flex items-center justify-between mb-1',
-              title: 'text-sm font-semibold',
-              navButton: 'rounded p-1 text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800',
-              grid: 'w-full',
-              gridCell: 'p-0 text-center h-9',
-              weekdayHeader: 'text-xs font-medium text-neutral-500 pb-1',
-              day: 'h-9 w-9 rounded-md text-sm text-neutral-800 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-800',
-              daySelected: '!bg-indigo-600 !text-white hover:!bg-indigo-700',
-              dayToday: 'ring-1 ring-indigo-400',
-              dayDisabled: 'opacity-40 pointer-events-none',
-              dayOutsideMonth: 'text-neutral-400 dark:text-neutral-600',
+              root: 'space-y-3',
+              header: 'flex items-center justify-between',
+              title: 'text-sm font-semibold text-neutral-900 dark:text-neutral-100',
+              navButton: 'inline-flex h-7 w-7 items-center justify-center rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-100',
+              grid: 'w-full border-separate border-spacing-1',
+              gridCell: 'p-0 text-center',
+              weekdayHeader: 'pb-2 text-xs font-medium text-neutral-500 dark:text-neutral-400',
+              day: 'inline-flex h-8 w-8 items-center justify-center rounded-full text-sm text-neutral-700 transition hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800',
+              daySelected: '!bg-indigo-600 !text-white hover:!bg-indigo-700 !font-semibold',
+              dayToday: '!font-semibold !text-indigo-600 dark:!text-indigo-400',
+              dayDisabled: 'opacity-30 pointer-events-none',
+              dayOutsideMonth: 'text-neutral-300 dark:text-neutral-600',
             }}
           />
         </DatePicker.Popover>
@@ -99,26 +102,26 @@ function TailwindRange() {
   return (
     <div className="tw-enable">
       <RangePicker value={range} onChange={setRange}>
-        <div className="flex items-center gap-2">
+        <div className="inline-flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-sm shadow-sm focus-within:ring-2 focus-within:ring-indigo-500 focus-within:border-indigo-500 dark:border-neutral-700 dark:bg-neutral-900">
           <RangePicker.Input
             part="start"
-            className="w-32 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
+            className="w-28 bg-transparent outline-none text-neutral-900 placeholder-neutral-400 dark:text-neutral-100 dark:placeholder-neutral-500"
             placeholder="Start"
           />
-          <span className="text-neutral-400">→</span>
+          <span className="text-neutral-400 dark:text-neutral-500">→</span>
           <RangePicker.Input
             part="end"
-            className="w-32 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
+            className="w-28 bg-transparent outline-none text-neutral-900 placeholder-neutral-400 dark:text-neutral-100 dark:placeholder-neutral-500"
             placeholder="End"
           />
         </div>
 
-        <RangePicker.Popover className="z-50 mt-2 flex gap-3 rounded-xl border border-neutral-200 bg-white p-3 shadow-xl dark:border-neutral-800 dark:bg-neutral-900">
+        <RangePicker.Popover className="z-50 mt-2 flex gap-4 rounded-lg border border-neutral-200 bg-white p-4 shadow-lg ring-1 ring-black/5 dark:border-neutral-800 dark:bg-neutral-900 dark:ring-white/10">
           <RangePicker.Presets
             classNames={{
-              root: 'flex flex-col gap-0.5 border-r border-neutral-200 dark:border-neutral-800 pr-3 text-sm min-w-[8rem]',
-              preset: 'rounded px-2 py-1 text-left hover:bg-neutral-100 dark:hover:bg-neutral-800',
-              presetActive: '!bg-indigo-50 !text-indigo-700 font-medium dark:!bg-indigo-950 dark:!text-indigo-300',
+              root: 'flex flex-col gap-0.5 border-r border-neutral-200 pr-4 text-sm min-w-[7.5rem] dark:border-neutral-800',
+              preset: 'rounded-md px-2.5 py-1.5 text-left text-neutral-700 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800',
+              presetActive: '!bg-indigo-50 !text-indigo-700 !font-medium dark:!bg-indigo-950/60 dark:!text-indigo-300',
             }}
           >
             <RangePicker.Preset value="today">Today</RangePicker.Preset>
@@ -130,19 +133,20 @@ function TailwindRange() {
 
           <RangePicker.Calendar
             classNames={{
-              header: 'flex items-center justify-between mb-1',
-              title: 'text-sm font-semibold',
-              navButton: 'rounded p-1 hover:bg-neutral-100 dark:hover:bg-neutral-800',
+              root: 'space-y-3',
+              header: 'flex items-center justify-between',
+              title: 'text-sm font-semibold text-neutral-900 dark:text-neutral-100',
+              navButton: 'inline-flex h-7 w-7 items-center justify-center rounded-md text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-100',
               grid: 'w-full',
-              gridCell: 'p-0 h-9 w-9 text-center',
-              weekdayHeader: 'text-xs font-medium text-neutral-500 pb-1',
-              day: 'h-9 w-9 text-sm text-neutral-800 dark:text-neutral-200',
-              dayRangeStart: '!bg-indigo-600 !text-white !rounded-l-md !rounded-r-none',
-              dayRangeEnd: '!bg-indigo-600 !text-white !rounded-r-md !rounded-l-none',
-              dayInRange: '!bg-indigo-50 dark:!bg-indigo-950/50 !rounded-none',
-              dayToday: 'ring-1 ring-indigo-400',
-              dayDisabled: 'opacity-40 pointer-events-none',
-              dayOutsideMonth: 'text-neutral-400 dark:text-neutral-600',
+              gridCell: 'p-0 text-center',
+              weekdayHeader: 'pb-2 text-xs font-medium text-neutral-500 dark:text-neutral-400',
+              day: 'inline-flex h-8 w-8 items-center justify-center text-sm text-neutral-700 transition hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800',
+              dayRangeStart: '!bg-indigo-600 !text-white !rounded-l-full hover:!bg-indigo-700',
+              dayRangeEnd: '!bg-indigo-600 !text-white !rounded-r-full hover:!bg-indigo-700',
+              dayInRange: '!bg-indigo-50 !text-indigo-900 dark:!bg-indigo-950/60 dark:!text-indigo-200',
+              dayToday: '!font-semibold !text-indigo-600 dark:!text-indigo-400',
+              dayDisabled: 'opacity-30 pointer-events-none',
+              dayOutsideMonth: 'text-neutral-300 dark:text-neutral-600',
             }}
           />
         </RangePicker.Popover>

--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -138,6 +138,32 @@
   border-bottom: none;
 }
 
+/* Docusaurus's Infima theme also injects styles into `table th, table td`
+ * directly (no `.markdown` prefix) — `border: 1px solid` and
+ * `padding: var(--ifm-table-cell-padding)` (~12px). These leak into
+ * calendar grids regardless of the `:not()` guard above, because the
+ * upstream selector doesn't include `.markdown`.
+ *
+ * On pages that omit the `gridCell` className (e.g. the React Hook Form
+ * recipe), the `<td>` has no class to override Infima with, so each cell
+ * grows to 60-62px (36px button + 12px×2 padding + 2px border) and the
+ * calendar overflows the popover. Pin the calendar's `<th>` / `<td>`
+ * box model directly.
+ *
+ * Specificity: 1 class + 1 type beats Infima's pure-type selector.
+ * See issue #35. */
+.kx-live-grid th,
+.kx-live-grid td,
+.kx-tw-grid th,
+.kx-tw-grid td {
+  border: 0;
+}
+
+.kx-live-grid td,
+.kx-tw-grid td {
+  padding: 0;
+}
+
 /* Admonitions */
 .alert {
   border-radius: 10px;
@@ -665,6 +691,27 @@ span.kx-live-title,
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+/* Same Infima `table th, table td` border/padding leak (see comment above
+ * for `.kx-live-grid th/td`) hits the Tailwind recipe's calendar too. The
+ * recipe styles cells with Tailwind utilities, not a `kx-*-grid` class, so
+ * cover it via the `.tw-enable` wrapper.
+ *
+ * `!important` because the prose-table rule above uses `:not(...)` chains
+ * that count toward specificity, making it stronger than this two-class
+ * selector. The Tailwind reset is intentionally aggressive — anything
+ * inside `.tw-enable` is opting into Tailwind utilities, so we don't
+ * need the prose chrome here. */
+.tw-enable table th,
+.tw-enable table td {
+  border: 0 !important;
+  padding: 0 !important;
+}
+
+.tw-enable table {
+  border: 0 !important;
+  border-radius: 0 !important;
 }
 
 

--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -149,6 +149,37 @@
 }
 
 /* =========================================================
+ * Docusaurus Playground (live code block) overrides
+ *
+ * Two issues from upstream `@docusaurus/theme-live-codeblock`:
+ *
+ * 1. `.playgroundContainer` sets `overflow: hidden` so its rounded corners
+ *    clip child content. That clips DatePicker popovers when they overflow
+ *    the bottom of the preview area. Switch to a clipped corner via
+ *    `border-radius` on the container itself but allow popovers to escape.
+ *
+ * 2. `.playgroundPreview` is `position: static`, so any absolute-positioned
+ *    descendant (the DatePicker popover, positioned by Floating UI) finds
+ *    its containing block all the way up at the viewport. Without a
+ *    constrained containing block, `width: max-content` on the popover
+ *    resolves against the viewport and the calendar table stretches edge
+ *    to edge across the page — see issue #35.
+ *
+ *    `position: relative` here makes the preview area the popover's
+ *    containing block, so its width is bounded.
+ * =======================================================*/
+
+/* The playground class names are CSS-modules-hashed. Use a substring match
+ * to remain stable across docusaurus version bumps. */
+[class*='playgroundContainer'] {
+  overflow: visible !important;
+}
+
+[class*='playgroundPreview'] {
+  position: relative;
+}
+
+/* =========================================================
  * Live example theme (DatePicker / RangePicker / TimePicker)
  * =======================================================*/
 
@@ -282,13 +313,23 @@
   box-shadow: var(--kx-ex-shadow);
   margin-top: 6px;
   z-index: 50;
-  min-width: 280px;
+  /* Explicit width — see issue #35. The popover is `position: absolute`
+   * (set by Floating UI). Without an explicit width, descendants like the
+   * calendar header (`display: flex` with `flex: 1` on the title) cause
+   * `width: max-content` to resolve against the viewport, stretching the
+   * popover edge-to-edge inside Docusaurus's live preview area.
+   *
+   * 7 cells × var(--kx-ex-cell, 36px) + 2 × 14px padding = 280px.
+   */
+  width: 280px;
 }
 
 .kx-live-popover--split {
   display: flex;
   gap: 12px;
   align-items: stretch;
+  /* presets sidebar (140px) + gap (12px) + calendar (252px) + 2×14px padding */
+  width: 432px;
 }
 
 /* -----------------------------------------------------------
@@ -639,6 +680,10 @@ span.kx-live-title,
   color: var(--kx-shadcn-fg);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
   margin-top: 6px;
+  z-index: 50;
+  /* See issue #35: explicit width prevents the popover from stretching
+   * across the live-preview area. 7 × 36px cells + 2 × 12px padding. */
+  width: 276px;
 }
 
 .kx-shadcn-title {

--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -103,8 +103,16 @@
   box-shadow: none;
 }
 
-/* Tables — clean, minimal */
-.markdown table {
+/* Tables — clean, minimal.
+ *
+ * The `:not(...)` guards keep these prose-table styles from leaking into
+ * calendar grids that are rendered as `<table>` inside live previews.
+ * The markdown selector has higher specificity than the calendar's own
+ * `.kx-live-weekday` / `.kx-live-cell`, so without the negation it injects
+ * `padding: 0.65rem 0.9rem` and a `border-bottom` into every day cell —
+ * which collapses each cell's content area to ~7px and forces digits to
+ * wrap one-per-line. See issue #35. */
+.markdown table:not([class*='kx-live']):not([class*='kx-tw']) {
   display: table;
   width: 100%;
   border-collapse: collapse;
@@ -113,20 +121,20 @@
   overflow: hidden;
 }
 
-.markdown table thead tr {
+.markdown table:not([class*='kx-live']):not([class*='kx-tw']) thead tr {
   background: var(--kalyx-surface);
   border-bottom: 1px solid var(--kalyx-border);
 }
 
-.markdown table th,
-.markdown table td {
+.markdown table:not([class*='kx-live']):not([class*='kx-tw']) th,
+.markdown table:not([class*='kx-live']):not([class*='kx-tw']) td {
   border: none;
   border-bottom: 1px solid var(--kalyx-border);
   padding: 0.65rem 0.9rem;
   font-size: 0.92em;
 }
 
-.markdown table tr:last-child td {
+.markdown table:not([class*='kx-live']):not([class*='kx-tw']) tr:last-child td {
   border-bottom: none;
 }
 
@@ -747,6 +755,10 @@ span.kx-live-title,
 }
 
 .kx-shadcn-weekday {
+  /* `table-layout: fixed` on .kx-live-grid sizes columns from the first
+   * row, so the weekday header must declare the column width or cells
+   * collapse to their text width (~20-25px). See issue #35. */
+  width: var(--kx-ex-cell);
   font-size: 11px;
   color: var(--kx-shadcn-muted);
   font-weight: 400;

--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -624,7 +624,49 @@ span.kx-live-title,
  * Tailwind recipe — uses Tailwind Play CDN at runtime, so the
  * live example renders real Tailwind classes. These fallback
  * classes only apply outside Tailwind contexts.
+ *
+ * Minimal preflight reset, scoped to `.tw-enable`.
+ *
+ * `tailwind-config.js` sets `corePlugins.preflight: false` so the
+ * Play CDN doesn't reset Docusaurus's chrome. The cost is that
+ * default user-agent `<button>` styling (outset border, system
+ * background, fixed appearance) leaks through everywhere Tailwind
+ * is applied — that's why the recipe's day cells looked like 90s
+ * 3D buttons even though the Tailwind classes were correct.
+ *
+ * Re-add only the rules the calendar examples need, locked behind
+ * `.tw-enable` so they don't escape the recipe pages. See issue #35.
  * ---------------------------------------------------------*/
+
+.tw-enable button {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.tw-enable button:disabled {
+  cursor: default;
+}
+
+.tw-enable input {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+}
+
+.tw-enable ul,
+.tw-enable ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 
 /* -----------------------------------------------------------
  * shadcn recipe surface — approximates the shadcn "new-york"

--- a/apps/docs-site/src/css/custom.css
+++ b/apps/docs-site/src/css/custom.css
@@ -621,6 +621,16 @@ span.kx-live-title,
   padding: 4px 0;
 }
 
+/* MonthGrid / YearGrid wrap each row in `<div role="row">` for ARIA. The
+ * row wrapper would otherwise become a single grid item — collapsing
+ * three months into one cell each. `display: contents` lets the buttons
+ * participate in the parent grid directly while keeping the a11y tree
+ * intact. */
+.kx-live-month-grid > [role='row'],
+.kx-live-year-grid > [role='row'] {
+  display: contents !important;
+}
+
 .kx-live-my-cell {
   padding: 10px 8px;
   border: 0;

--- a/apps/docs-site/src/pages/playground.mdx
+++ b/apps/docs-site/src/pages/playground.mdx
@@ -226,6 +226,117 @@ function PlaygroundDateTime() {
 }
 ```
 
+## MonthPicker
+
+```jsx live
+function PlaygroundMonth() {
+  const [month, setMonth] = React.useState(null);
+  const headerCls = {
+    header: 'kx-live-header',
+    title: 'kx-live-title',
+    navButton: 'kx-live-nav',
+  };
+  return (
+    <MonthPicker value={month} onChange={setMonth}>
+      <div className="kx-live-row">
+        <MonthPicker.Input className="kx-live-input" placeholder="YYYY-MM" />
+        <MonthPicker.Trigger className="kx-live-trigger" aria-label="Open month picker" />
+      </div>
+      <MonthPicker.Popover className="kx-live-popover">
+        <MonthPicker.Grid
+          classNames={{
+            ...headerCls,
+            grid: 'kx-live-month-grid',
+            month: 'kx-live-my-cell',
+            monthSelected: 'kx-live-my-selected',
+            monthCurrent: 'kx-live-my-current',
+          }}
+        />
+      </MonthPicker.Popover>
+      <div className="kx-live-value">
+        Selected: <code>{month ?? 'null'}</code>
+      </div>
+    </MonthPicker>
+  );
+}
+```
+
+## YearPicker
+
+```jsx live
+function PlaygroundYear() {
+  const [year, setYear] = React.useState(null);
+  const headerCls = {
+    header: 'kx-live-header',
+    title: 'kx-live-title',
+    navButton: 'kx-live-nav',
+  };
+  return (
+    <YearPicker value={year} onChange={setYear}>
+      <div className="kx-live-row">
+        <YearPicker.Input className="kx-live-input" placeholder="YYYY" />
+        <YearPicker.Trigger className="kx-live-trigger" aria-label="Open year picker" />
+      </div>
+      <YearPicker.Popover className="kx-live-popover">
+        <YearPicker.Grid
+          classNames={{
+            ...headerCls,
+            grid: 'kx-live-year-grid',
+            year: 'kx-live-my-cell',
+            yearSelected: 'kx-live-my-selected',
+            yearCurrent: 'kx-live-my-current',
+          }}
+        />
+      </YearPicker.Popover>
+      <div className="kx-live-value">
+        Selected: <code>{year ?? 'null'}</code>
+      </div>
+    </YearPicker>
+  );
+}
+```
+
+## WeekPicker
+
+```jsx live
+function PlaygroundWeek() {
+  const [week, setWeek] = React.useState({ start: null, end: null });
+  const label = week.start && week.end
+    ? `${week.start.slice(0, 10)} → ${week.end.slice(0, 10)}`
+    : 'null';
+  return (
+    <WeekPicker value={week} onChange={setWeek}>
+      <div className="kx-live-row">
+        <WeekPicker.Input part="start" className="kx-live-input" placeholder="Start" />
+        <span aria-hidden>→</span>
+        <WeekPicker.Input part="end" className="kx-live-input" placeholder="End" />
+      </div>
+      <WeekPicker.Popover className="kx-live-popover">
+        <WeekPicker.Calendar
+          classNames={{
+            header: 'kx-live-header',
+            title: 'kx-live-title',
+            navButton: 'kx-live-nav',
+            grid: 'kx-live-grid',
+            gridCell: 'kx-live-cell',
+            weekdayHeader: 'kx-live-weekday',
+            day: 'kx-live-day-range',
+            dayInWeek: 'kx-live-inrange',
+            dayRangeStart: 'kx-live-range-start',
+            dayRangeEnd: 'kx-live-range-end',
+            dayToday: 'live-day-today',
+            dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+      </WeekPicker.Popover>
+      <div className="kx-live-value">
+        Week: <code>{label}</code>
+      </div>
+    </WeekPicker>
+  );
+}
+```
+
 ## displayTimezone — pick the same civil day across zones
 
 Switch the timezone radio and watch the emitted ISO change while the *civil day you clicked* stays the same. This is Kalyx's structural answer to the "day off by one" bug (react-datepicker #1018).
@@ -282,4 +393,4 @@ function PlaygroundTimezone() {
 
 ## Mix and match
 
-The scope includes `React`, `DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`, `useDatePicker`, `useRangePicker`, `useTimePicker`, and `DateFnsAdapter`. Start typing — the editor is yours.
+The scope includes `React`, all seven components (`DatePicker`, `RangePicker`, `TimePicker`, `DateTimePicker`, `MonthPicker`, `YearPicker`, `WeekPicker`), all three headless hooks (`useDatePicker`, `useRangePicker`, `useTimePicker`), and `DateFnsAdapter`. Start typing — the editor is yours.

--- a/apps/docs-site/src/pages/playground.mdx
+++ b/apps/docs-site/src/pages/playground.mdx
@@ -5,6 +5,8 @@ hide_table_of_contents: true
 ---
 
 import Link from '@docusaurus/Link';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Playground
 
@@ -23,7 +25,8 @@ Edit any of the live examples below — the preview updates instantly. Everythin
   </Link>
 </div>
 
-## DatePicker
+<Tabs queryString="picker" defaultValue="date" lazy>
+<TabItem value="date" label="DatePicker">
 
 ```jsx live
 function PlaygroundDatePicker() {
@@ -90,7 +93,8 @@ function PlaygroundDatePicker() {
 }
 ```
 
-## RangePicker with presets
+</TabItem>
+<TabItem value="range" label="RangePicker">
 
 ```jsx live
 function PlaygroundRange() {
@@ -139,7 +143,8 @@ function PlaygroundRange() {
 }
 ```
 
-## TimePicker (12-hour)
+</TabItem>
+<TabItem value="time" label="TimePicker">
 
 ```jsx live
 function PlaygroundTime() {
@@ -175,7 +180,8 @@ function PlaygroundTime() {
 }
 ```
 
-## DateTimePicker
+</TabItem>
+<TabItem value="datetime" label="DateTimePicker">
 
 ```jsx live
 function PlaygroundDateTime() {
@@ -226,7 +232,8 @@ function PlaygroundDateTime() {
 }
 ```
 
-## MonthPicker
+</TabItem>
+<TabItem value="month" label="MonthPicker">
 
 ```jsx live
 function PlaygroundMonth() {
@@ -261,7 +268,8 @@ function PlaygroundMonth() {
 }
 ```
 
-## YearPicker
+</TabItem>
+<TabItem value="year" label="YearPicker">
 
 ```jsx live
 function PlaygroundYear() {
@@ -296,7 +304,8 @@ function PlaygroundYear() {
 }
 ```
 
-## WeekPicker
+</TabItem>
+<TabItem value="week" label="WeekPicker">
 
 ```jsx live
 function PlaygroundWeek() {
@@ -337,7 +346,8 @@ function PlaygroundWeek() {
 }
 ```
 
-## displayTimezone — pick the same civil day across zones
+</TabItem>
+<TabItem value="timezone" label="Timezone demo">
 
 Switch the timezone radio and watch the emitted ISO change while the *civil day you clicked* stays the same. This is Kalyx's structural answer to the "day off by one" bug (react-datepicker #1018).
 
@@ -390,6 +400,9 @@ function PlaygroundTimezone() {
   );
 }
 ```
+
+</TabItem>
+</Tabs>
 
 ## Mix and match
 


### PR DESCRIPTION
Closes #35.

## Summary
- The DatePicker / RangePicker popovers in the official docs site (Docusaurus) were rendering at **full viewport width** (1408px on a 1440-wide screen), overlapping the live-code editor below and making the calendar unreadable in Chrome.
- Pure docs-site CSS fix. **No library code changed.**

## Root cause

Two upstream conditions in `@docusaurus/theme-live-codeblock` combine to trigger this:

1. `.playgroundContainer` sets `overflow: hidden` (for rounded corners) — clips popovers that overflow the preview area.
2. `.playgroundPreview` is `position: static`, so any `position: absolute` descendant (the popover, positioned by Floating UI) resolves its **containing block all the way up to the viewport**. With `flex: 1` on the calendar header title (`.kx-live-title` / `.kx-shadcn-title`), `width: max-content` then resolves against the viewport and the popover stretches edge-to-edge.

Verified in Chrome via Playwright DOM inspection: popover width = 1408px (= `100vw - 2rem`), child width = 1378px, header title width = 1314px from `flex-grow: 1; flex-basis: 0%`.

## Fix

In `apps/docs-site/src/css/custom.css`:

1. **Playground overrides** (substring class match — Docusaurus class names are CSS-modules-hashed but the prefix is stable):
   - `[class*='playgroundContainer'] { overflow: visible !important }` — let popovers escape the container.
   - `[class*='playgroundPreview'] { position: relative }` — make the preview the popover's containing block.

2. **Explicit widths** on the popover classes (since `max-content` can't shrink past the `flex: 1` header in this context):
   - `.kx-live-popover { width: 280px }` (7 × 36px cells + 2 × 14px padding)
   - `.kx-live-popover--split { width: 432px }` (presets 140 + gap 12 + calendar 252 + 2 × 14px padding)
   - `.kx-shadcn-popover { width: 276px; z-index: 50 }`

## Verification

Reproduced and verified with Playwright against `pnpm --filter docs-site start`. Width measured via `getBoundingClientRect().width`:

| Page | Block | Before | After |
|---|---|---|---|
| `/docs/recipes/shadcn` | DatePicker | 1440 | **276** |
| `/docs/recipes/shadcn` | RangePicker | 1440 | **276** |
| `/docs/components/datepicker` | block 0 | 1440 | **280** |
| `/docs/components/datepicker` | block 1 | 1440 | **280** |
| `/docs/components/rangepicker` | single | 1440 | **280** |
| `/docs/components/rangepicker` | --split | 1440 | **432** |
| `/docs/components/datetimepicker` | × 3 | 1440 | **280** |
| `/docs/getting-started/quick-start` | block 0 | 1440 | **280** |
| `/docs/recipes/react-hook-form` | block 0 | 1440 | **280** |
| `/docs/recipes/tailwind` | block 0 | (n/a) | 377 (natural) |
| `/docs/recipes/tailwind` | block 1 | (n/a) | 517 (natural) |

The Tailwind recipe popovers don't have the `flex: 1` title and naturally shrink-to-fit once their containing block is constrained by the `position: relative` parent — no explicit width needed there.

## Test plan
- [ ] `pnpm --filter docs-site start` and open `/docs/recipes/shadcn` — popovers are compact, not stretched
- [ ] Open `/docs/components/rangepicker` — both single and split (presets) popovers render correctly
- [ ] Open `/docs/components/datetimepicker` — calendar + time row both fit in 280px
- [ ] `pnpm --filter docs-site build` succeeds
- [ ] `pnpm typecheck` and `pnpm lint` pass

## Notes
- `docs-site` is `private: true`, so no changeset is needed (matches the convention of past `docs(site): …` commits).
- This fix is intentionally docs-only. The library's `usePopover` correctly delegates positioning to Floating UI; the stretching only manifests inside Docusaurus's `LivePreview` setup, where the consuming app must provide a sane containing block / width context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일 개선**
  * 마크다운 테이블·그리드 스타일 범위를 강화해 라이브 프리뷰 테이블과 충돌을 방지했습니다.
  * 라이브 코드 블록·플레이그라운드와 팝오버의 레이아웃, 크기 및 z-index를 조정해 팝오버 동작을 안정화했습니다.
  * Tailwind 샘플에 리셋 및 표/입력/버튼 스타일을 추가해 일관된 표시를 보장합니다.

* **문서**
  * 날짜/주/월/연 선택기 예제의 스타일, 접근성 라벨 및 인터랙티브 데모를 추가·개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->