### PR TITLE
fix(v1-rc3): a11y + SSR safety + docs drift sync

### DIFF
--- a/.changeset/v1-rc1-a11y-ssr-fixes.md
+++ b/.changeset/v1-rc1-a11y-ssr-fixes.md
@@ -1,0 +1,17 @@
+---
+"@kalyx/react": patch
+"@kalyx/core": patch
+---
+
+P1 audit follow-ups for v1.0-rc:
+
+- **SSR hydration safety in 4 commit/drilldown grids** — `DatePicker.MonthGrid`, `DatePicker.YearGrid`, `MonthPicker.Grid`, and `YearPicker.Grid` previously called `adapter.today()` directly inside their render bodies, producing a server/client clock-mismatch hydration warning across day boundaries (and intermittently wrong "today" highlights in tz-different SSR setups). Today is now snapshotted via `useState(null)` + post-mount `useEffect`, so the server output and the first client render agree, and the highlight settles on the first effect tick.
+- **`AmPmToggle` now follows the WAI-ARIA radiogroup pattern** — Arrow / Home / End / Space / Enter move and commit selection between AM and PM, and `tabIndex` is roving (only the checked radio is in the tab order). Previously both buttons were tabbable and arrow keys were ignored.
+- **`DatePicker.Preset` / `RangePicker.Preset` now use `aria-pressed`** instead of `role="option"` + `aria-selected`. `role="option"` is invalid outside `role="listbox"` / `role="combobox"`, so axe was flagging the previous markup. Active state still appears on `data-active` for CSS targeting.
+- **`RangePicker.Calendar` no longer advertises `aria-multiselectable="true"`** — a date range is one selection (two endpoints), not a multi-select grid.
+- **Test stability** — `useRangePicker` `respects disabled rules` test pinned to April 2026 via `defaultValue` so the calendar grid contains the expected weekend day regardless of the system clock (was failing once the clock crossed into May).
+- **`labels.ts` test coverage** — first unit tests for the default-label exports.
+
+Behavioral notes for users (none of these are breaking for code that follows the documented `data-*` styling contract):
+- If you targeted Preset buttons via `[aria-selected="true"]` in CSS, switch to `[aria-pressed="true"]` or `[data-active]`.
+- If you targeted the range grid via `[aria-multiselectable]`, that attribute is gone; use `[role="grid"]` on the calendar root instead.

--- a/.claude/commands/check-bundle.md
+++ b/.claude/commands/check-bundle.md
@@ -1,6 +1,6 @@
 ---
 name: check-bundle
-description: 현재 번들 크기를 분석하고 12KB 목표 달성 여부를 확인한다.
+description: 현재 번들 크기를 분석하고 13KB 목표 달성 여부를 확인한다.
 ---
 
 # /check-bundle
@@ -8,7 +8,7 @@ description: 현재 번들 크기를 분석하고 12KB 목표 달성 여부를 �
 ## 설명
 
 빌드 후 번들 크기를 분석한다.
-목표: `@kalyx/react` gzip 12KB 미만
+목표: `@kalyx/react` gzip 13KB 이하 (rc 단계에서 12KB → 13KB 상향, commit e93d082)
 
 ## Claude가 수행할 작업
 
@@ -38,9 +38,9 @@ import('./packages/react/dist/index.js').then(m => {
 
 | 상태 | gzip 크기 | 조치 |
 |---|---|---|
-| ✅ OK | < 10KB | 문제없음 |
-| ⚠️ 주의 | 10-12KB | 최적화 검토 |
-| ❌ 초과 | > 12KB | 반드시 축소 필요 |
+| ✅ OK | ≤ 12KB | 문제없음 |
+| ⚠️ 주의 | 12–13KB | 최적화 검토 |
+| ❌ 초과 | > 13KB | 반드시 축소 필요 |
 
 ## 크기 초과 시 점검 항목
 

--- a/.claude/skills/rc-announcement.md
+++ b/.claude/skills/rc-announcement.md
@@ -17,14 +17,15 @@ triggers:
 
 ---
 
-## 전제 상태 (2026-04-21 기준 handoff 시점)
+## 전제 상태 (2026-05-06 기준 handoff 시점)
 
-- `.changeset/pre.json`: `mode: pre`, `tag: rc`, `@kalyx/core` / `@kalyx/react` 버전 `1.0.0-rc.0` (예상)
-- main에 병합된 주요 준비 작업:
-  - feat/v1-rc-preparation (ca7180e)
-  - MonthPicker / YearPicker / WeekPicker 추가
-  - Presets, onOpenChange, onCalendarNavigate 콜백
-- Bundle 수치: **11.36 KB** gzip (모든 README·docs·배지 통일 완료 — 2026-04-25)
+- `.changeset/pre.json`: `mode: pre`, `tag: rc`, `@kalyx/core` / `@kalyx/react` 버전 `1.0.0-rc.3`
+- 번들 한계 12 → **13 KB**로 상향 (commit e93d082, PR #37)
+- rc.0 → rc.3 동안의 주요 변경:
+  - P0 release blockers (#25), P1 a11y·API·docs (#26), perf memoization (#28), P2 polish (#29)
+  - 포커스된 날짜에 Enter 키 커밋 + 13KB ceiling (#36, #37)
+- Bundle 측정값: **12.27 KB / 12.48 KB** gzip (ESM / CJS, target ≤ 13KB)
+- **dist-tag 주의**: `pre.json.tag: rc` 이므로 publish 시 `--tag rc`. 사용자 안내가 `@next` 라면 통일 필요.
 
 > 이 상태는 시점 스냅샷. 새 세션에서 먼저 "작업 전 검증"으로 실제 상태를 확인한다.
 
@@ -142,18 +143,18 @@ pnpm --filter docs-site start    # 로컬 브라우저에서 배너 확인
 
 ### Step 4. README 배지 + Try the RC 섹션
 
-**현재 상태**: README·docs·배지 모두 `11.36KB`로 통일 완료 (2026-04-25).
+**현재 상태 (2026-05-06)**: rc.3 시점, ESM 12.27 KB / CJS 12.48 KB. 한계 13KB. README·docs·배지 12KB → 13KB + 11.36 → 12.07 통일 작업 완료.
 
 **변경 지점** (`README.md`, `README.ko.md` 둘 다):
-1. bundle 배지 gzip 수치 업데이트
-2. npm 배지 아래 RC 배지 추가:
+1. bundle 배지 gzip 수치 업데이트 (12.27KB)
+2. npm 배지 아래 RC 배지 추가 — **dist-tag는 `rc`** (`pre.json.tag` 와 일치):
    ```md
-   [![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
+   [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
    ```
 3. 설치 스니펫 옆에 "Try the RC" 블록 추가:
    ```md
    > **Trying the v1.0 release candidate?**
-   > `pnpm add @kalyx/react@next` — please report issues with the `v1-rc` tag.
+   > `pnpm add @kalyx/react@rc` — please report issues with the `v1-rc` tag.
    ```
 
 ---
@@ -163,16 +164,16 @@ pnpm --filter docs-site start    # 로컬 브라우저에서 배너 확인
 **업로드하지 말 것**. 초안만 `.github/RC_SOCIAL_DRAFT.md`에 저장하고 사용자가 확인 후 직접 게시.
 
 X/Twitter (280자):
-> Kalyx v1.0-rc is out — the headless React DatePicker that ships complete. Single / range / time / month / year / week pickers, ISO 8601 UTC, IANA timezone, ~11KB gzip.
+> Kalyx v1.0-rc is out — the headless React DatePicker that ships complete. Single / range / time / month / year / week pickers, ISO 8601 UTC, IANA timezone, ~12KB gzip.
 >
-> `pnpm add @kalyx/react@next`
+> `pnpm add @kalyx/react@rc`
 >
 > Feedback welcome.
 
 LinkedIn:
-> After months of composition-first API work, Kalyx v1.0 is in release candidate. One library covers Date, Range, Time, DateTime, Month, Year, Week pickers — zero CSS, SSR-safe, IANA timezone. Bundle stays under 12KB gzipped.
+> After months of composition-first API work, Kalyx v1.0 is in release candidate. One library covers Date, Range, Time, DateTime, Month, Year, Week pickers — zero CSS, SSR-safe, IANA timezone. Bundle stays at ~12KB gzipped (≤13KB ceiling).
 >
-> Trying the RC: `pnpm add @kalyx/react@next`. Issues: https://github.com/jiji-hoon96/kalyx/issues (tag `v1-rc`).
+> Trying the RC: `pnpm add @kalyx/react@rc`. Issues: https://github.com/jiji-hoon96/kalyx/issues (tag `v1-rc`).
 
 ---
 
@@ -190,7 +191,7 @@ LinkedIn:
 
 - [ ] `v1-rc` 라벨 open 이슈 0건 (또는 모두 "v1.1 이후"로 이관)
 - [ ] RC 기간 2주 이상 경과
-- [ ] 번들 크기 12KB gzip 이하 유지 (`pnpm check-bundle` 통과)
+- [ ] 번들 크기 13KB gzip 이하 유지 (`pnpm check-bundle` 통과)
 - [ ] 모든 picker에 대해 axe 접근성 통과
 - [ ] SSR 스모크 테스트 통과 (`e2e-and-docs.yml` 그린)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] `pnpm lint` passes
 - [ ] `pnpm test:run` passes
 - [ ] `pnpm build` succeeds
-- [ ] Bundle size checked (`pnpm check-bundle` ≤ 12KB)
+- [ ] Bundle size checked (`pnpm check-bundle` ≤ 13KB)
 - [ ] Changeset added (if public API changed)
 - [ ] New public APIs have JSDoc comments
 - [ ] Accessibility: axe passes, keyboard navigation works

--- a/.github/RELEASE_NOTES_RC.md
+++ b/.github/RELEASE_NOTES_RC.md
@@ -1,6 +1,6 @@
-# v1.0.0-rc.0 — First Release Candidate
+# v1.0.0-rc.3 — Release Candidate
 
-This is the first RC for Kalyx v1.0. The public API is frozen; we're collecting feedback before cutting the stable release.
+This is the latest RC for Kalyx v1.0 (rc.0 → rc.3). The public API is frozen; we're collecting feedback before cutting the stable release.
 
 ## What's in
 
@@ -9,17 +9,18 @@ This is the first RC for Kalyx v1.0. The public API is frozen; we're collecting 
 - **Event callbacks** — `onOpenChange`, `onCalendarNavigate` on all picker roots
 - **WeekPicker mutation fix** — WeekPicker no longer mutates the shared calendar config
 - **IANA timezone** — DST-safe `displayTimezone` on Date/DateTime/Range pickers
-- **API freeze** — public API surface is now stable; any breaking change requires a major bump
+- **rc.1 → rc.3 fixes** — P0 release blockers (#25), P1 a11y/API/docs (#26), perf memoization (#28), P2 polish (#29), Enter-on-focused-day (#36), bundle ceiling raised 12 → 13 KB (#37)
+- **API freeze** — public API surface is stable; any breaking change requires a major bump
 
 ## Bundle
 
-- ESM: **11.36 KB** gzip (target: ≤ 12 KB)
-- CJS: **11.36 KB** gzip
+- ESM: **12.27 KB** gzip (target: ≤ 13 KB)
+- CJS: **12.48 KB** gzip
 
 ## Install
 
 ```bash
-pnpm add @kalyx/react@next   # 1.0.0-rc.0
+pnpm add @kalyx/react@rc   # currently 1.0.0-rc.3 (dist-tag matches .changeset/pre.json)
 ```
 
 ## Feedback

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ test-results
 *.tsbuildinfo
 .next
 out
- 
+scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 - **React Aria**: 기능 완전하지만 복잡하고, `@internationalized/date` 의존 강제 (date-fns 비호환).
 - **Headless UI**: DatePicker 구현 거부 ("유지보수가 너무 큼").
 
-**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + < 12KB
+**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 13KB
 
 ### 포지셔닝
 
@@ -69,7 +69,7 @@ Ark UI가 포기한 TimePicker 통합
 | 스타일링 | Zero CSS (Headless) | CSS 충돌 원천 차단 |
 | 날짜 코어 | Adapter 패턴 + date-fns 기본 (v1.1에서 `@kalyx/adapter-date-fns`로 분리 예정 — [§14](#14-현재-이니셔티브-2026-04-기준)) | Temporal API 전환 대비, 사용자가 dayjs/luxon 선택 가능 |
 | 포지셔닝 | Floating UI | 3KB, SSR 안전, Popper.js 후계자 |
-| 번들 목표 | **< 12KB gzip** | react-datepicker 62KB 대비 |
+| 번들 목표 | **≤ 13KB gzip** | react-datepicker 62KB 대비 (RC 단계에서 12 → 13KB 상향, commit e93d082) |
 | 테스트 | Vitest + Testing Library + jest-axe | |
 | 빌드 | tsup (ESM + CJS 이중 출력) | |
 | 모노레포 | pnpm workspaces | |
@@ -248,7 +248,7 @@ kalyx/
 │   ├── docs/                         ← 데모 사이트 (Next.js, 정적 빌드)
 │   └── docs-site/                    ← 문서 사이트 (Docusaurus, i18n)
 ├── scripts/
-│   ├── check-bundle-size.js          ← 번들 크기 측정 (12KB 제한)
+│   ├── check-bundle-size.js          ← 번들 크기 측정 (13KB 제한)
 │   └── check-tree-shaking.js         ← tree-shaking 검증
 ├── test/
 │   └── setup.ts                      ← Vitest 전역 설정
@@ -257,7 +257,7 @@ kalyx/
 
 ---
 
-## 5. 구현 현황 (v1.0-rc.0 기준)
+## 5. 구현 현황 (v1.0-rc.3 기준)
 
 ### 컴포넌트 (7종 — 모두 구현 완료 ✅)
 
@@ -476,7 +476,7 @@ PR 열기 전 확인:
 | 커맨드 | 설명 |
 |---|---|
 | `/new-component` | 새 서브 컴포넌트 스캐폴딩 (컴포넌트·타입·테스트 파일 생성) |
-| `/check-bundle` | 빌드 후 번들 크기 측정, 12KB 초과 시 실패 |
+| `/check-bundle` | 빌드 후 번들 크기 측정, 13KB 초과 시 실패 |
 | `/check-a11y` | axe 자동 검사 + ARIA 수동 체크리스트 |
 | `/release` | Changesets 기반 버전 범프·CHANGELOG·npm 배포 가이드 |
 
@@ -564,8 +564,8 @@ pnpm changeset publish # npm 배포 (CI 자동)
 
 ### A. v1.0 Release Candidate 공지
 
-- **상태**: `1.0.0-rc.0` pre-mode 진입 완료 (`.changeset/pre.json`), main에 머지됨
-- **남은 작업**: npm publish 검증, GitHub Release 드래프트, docs 공지 배너, README 배지 갱신, 피드백 채널(`v1-rc` 라벨) 설정
+- **상태**: `1.0.0-rc.3` 까지 publish 됨 (`.changeset/pre.json` `mode: pre`, `tag: rc`). 17개 changeset이 누적된 상태로 pre-mode 유지 중.
+- **남은 작업**: npm `next` 사용자 안내 vs 실제 dist-tag(`rc`) 통일, GitHub Release 노트 갱신, RC 기간 만료 후 `pnpm changeset pre exit` → 1.0.0 stable
 - **스킬 파일**: `.claude/skills/rc-announcement.md`
 - **졸업 조건**: RC 기간 2주 + `v1-rc` open 이슈 0건 + 번들 ≤13KB + axe/SSR 그린
 
@@ -607,7 +607,7 @@ pnpm changeset publish # npm 배포 (CI 자동)
 □ 접근성 기준을 만족하는가? (axe 통과)
 □ 테스트가 작성됐는가? (커버리지 기준 충족)
 □ JSDoc 주석이 있는가? (공개 API)
-□ 번들에 불필요한 의존성을 추가하지 않았는가? (12KB 목표)
+□ 번들에 불필요한 의존성을 추가하지 않았는가? (13KB 목표)
 □ 내부 구현이 index.ts에 실수로 export되지 않았는가?
 □ changeset 파일을 추가했는가? (공개 API 변경 시 필수)
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,11 +6,11 @@
 
 **마침내 완성된 Headless React DatePicker.**
 
-[문서](https://kalyx-docs.vercel.app/ko) · [English Docs](https://kalyx-docs.vercel.app) · [npm](https://www.npmjs.com/package/@kalyx/react) · [GitHub](https://github.com/jiji-hoon96/kalyx)
+[문서](https://kalyx-docs.vercel.app/ko) · [English](https://kalyx-docs.vercel.app) · [npm](https://www.npmjs.com/package/@kalyx/react) · [README.md](./README.md)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-12.07KB-brightgreen)](#번들-크기)
+[![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
+[![Bundle](https://img.shields.io/badge/gzip-12.27KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -19,16 +19,13 @@
 
 ---
 
-> English README: [README.md](./README.md)
-
-Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜, 날짜 범위, 시간, 날짜+시간을 하나의 조합형 API로 다룹니다 — gzip 13KB 이하, CSS 없음, SSR 안전.
+Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~12 KB (≤ 13 KB), CSS 없음, SSR 안전.
 
 ```bash
 pnpm add @kalyx/react
 ```
 
-> **v1.0 릴리즈 후보(RC)를 사용해 보세요!**
-> `pnpm add @kalyx/react@next` — 이슈는 [`v1-rc`](https://github.com/jiji-hoon96/kalyx/issues?q=label%3Av1-rc) 라벨로 등록해 주세요.
+> **v1.0 RC를 시도?** `pnpm add @kalyx/react@rc` — 이슈는 [`v1-rc`](https://github.com/jiji-hoon96/kalyx/issues?q=label%3Av1-rc) 라벨로.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -41,196 +38,73 @@ import { DatePicker } from '@kalyx/react';
 </DatePicker>
 ```
 
+`onChange`는 항상 `ISODateString | null` — UTC 안전, `Date` 객체 없음.
+
 ## 왜 Kalyx인가
 
-2026년 React 생태계는 양극단만 있습니다 — Kalyx가 그 공백을 채웁니다.
+2026년 React 생태계는 양극단입니다 — **react-day-picker**는 캘린더 그리드만, **react-datepicker**는 통합됐지만 40–60 KB · CSS 결합, **Ark UI**는 TimePicker를 제거, **React Aria**는 `@internationalized/date` 강제. Kalyx는 그 사이를 채웁니다 — Headless + 통합 + date-fns 호환 + SSR 안전.
 
-bundlephobia 기준 (2026년 4월). 각주는 표 아래를 참조.
-
-| 라이브러리 | 버전 | 번들 (min+gzip) | Headless | Input | TimePicker | DateTimePicker | RangePicker | 값 계약 | Timezone |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| react-day-picker | 9.14 | 2.4 KB¹ | ✅ | ❌ BYO | ❌ | ❌ | ✅ | `Date` | ⚠️ |
-| react-datepicker | 9.1 | 44 KB | ❌ (CSS 필수) | ✅ | ⚠️ prop | ⚠️ 결합형 | ✅ 분리형 | `Date` | ⚠️ |
-| Ark UI | 5.36 | 265 KB² | ✅ | ✅ | ❌ (제거됨) | ❌ | ✅ | `Date` | ⚠️ |
-| React Aria | 1.17 | 247 KB² | ✅ | ✅ | ✅ | ✅ | ✅ | `CalendarDate` | ✅ |
-| **Kalyx** | 1.0.0-rc.1 | **12.07 KB** | ✅ | ✅ | ✅ 전용 | ✅ 전용 | ✅ 전용 | ISO 8601 UTC | ✅ `displayTimezone` |
-
-1. react-day-picker는 캘린더 그리드만 제공 — Kalyx와 동일한 스콥을 맞추려면 Input·Popover·TimePicker를 직접 조합해야 함. 2.4 KB는 기본 엔트리 기준.
-2. `@ark-ui/react`와 `react-aria-components`는 40+ 컴포넌트를 포함한 모노리스 패키지 — 트리셰이킹 시 더 작아지지만 `@internationalized/date` 등 생태계를 통째로 끌어들임.
+상세 비교표 → [docs-site](https://kalyx-docs.vercel.app/ko/docs/intro#%EB%B9%84%EA%B5%90).
 
 ## 특징
 
 - **Zero CSS** — 임포트할 스타일시트도, 재정의할 클래스도 없음.
-- **진짜 조합형** — Radix 스타일 dot 표기. props 폭발 없음.
-- **Headless** — Tailwind, shadcn/ui, Chakra, 어떤 CSS와도 짝 지을 수 있음.
-- **SSR 안전** — Next.js App Router에서 검증. `useId` 기반 안정 ID.
+- **Composition API** — Radix 스타일 dot 표기. props 폭발 없음.
+- **SSR 안전** — Next.js App Router 검증.
 - **ISO 8601 UTC 문자열** — `Date` 객체의 함정 없음.
-- **타임존 인지** — `displayTimezone` prop으로 IANA 타임존과 DST를 안전하게 처리. UTC 저장 계약은 그대로.
-- **접근성** — WAI-ARIA, 풀 키보드, axe 자동 통과.
-- **트리셰이킹** — 렌더하는 만큼만 비용.
-- **TypeScript 우선** — strict, `any` 없음.
+- **IANA 타임존** — `displayTimezone`이 DST·civil day 처리, 저장 계약은 UTC.
+- **접근성** — WAI-ARIA + 풀 키보드, axe 자동 통과.
+- **트리셰이킹** — `sideEffects: false`. 임포트한 만큼만 비용.
+- **TypeScript strict** — `any` 없음.
 
 ## 패키지
 
 | 패키지 | 역할 |
-| --- | --- |
+|---|---|
 | [`@kalyx/react`](./packages/react) | React 컴포넌트·훅·타입 |
 | [`@kalyx/core`](./packages/core) | 플랫폼 독립 날짜 로직·어댑터 |
 
-## 빠른 시작
-
-```tsx
-'use client';
-
-import { useState } from 'react';
-import { DatePicker, type ISODateString } from '@kalyx/react';
-
-export function BookingField() {
-  const [date, setDate] = useState<ISODateString | null>(null);
-  return (
-    <DatePicker value={date} onChange={setDate}>
-      <DatePicker.Input placeholder="YYYY-MM-DD" />
-      <DatePicker.Trigger />
-      <DatePicker.Popover>
-        <DatePicker.Calendar />
-      </DatePicker.Popover>
-    </DatePicker>
-  );
-}
-```
-
-값은 항상 `ISODateString | null`:
-
-```ts
-// onChange → "2026-04-15T00:00:00.000Z" | null
-```
-
-[빠른 시작 가이드 →](https://kalyx-docs.vercel.app/ko/docs/getting-started/quick-start)
-
-## Tailwind CSS로 스타일링
-
-Kalyx는 headless입니다 — `classNames`와 `data-*` 속성으로 직접 스타일을 입힙니다.
-
-### classNames 사용
-
-```tsx
-<DatePicker value={date} onChange={setDate}>
-  <DatePicker.Input
-    className="w-64 rounded-lg border border-gray-300 px-3 py-2 text-sm
-               focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-    placeholder="날짜 선택"
-  />
-  <DatePicker.Popover className="mt-1 rounded-xl border bg-white p-4 shadow-lg">
-    <DatePicker.Calendar
-      classNames={{
-        header: "flex items-center justify-between mb-2",
-        title: "text-sm font-semibold",
-        navButton: "p-1 rounded hover:bg-gray-100",
-        grid: "w-full border-collapse",
-        weekdayHeader: "text-xs font-medium text-gray-500 pb-2",
-        day: "h-9 w-9 rounded-lg text-sm hover:bg-gray-100",
-        daySelected: "bg-blue-600 text-white hover:bg-blue-700",
-        dayToday: "font-bold text-blue-600",
-        dayDisabled: "text-gray-300 cursor-not-allowed",
-        dayOutsideMonth: "text-gray-300",
-      }}
-    />
-  </DatePicker.Popover>
-</DatePicker>
-```
-
-### data 속성 활용
-
-모든 상호작용 상태는 `data-*` 속성으로 노출되어 CSS나 Tailwind arbitrary selector로 다룰 수 있습니다:
-
-```css
-[data-selected] { @apply bg-blue-600 text-white; }
-[data-today] { @apply font-bold ring-1 ring-blue-400; }
-[data-disabled] { @apply opacity-30 cursor-not-allowed; }
-[data-in-range] { @apply bg-blue-100; }
-[data-range-start] { @apply rounded-l-lg bg-blue-600 text-white; }
-[data-range-end] { @apply rounded-r-lg bg-blue-600 text-white; }
-```
-
-더 많은 레시피: [Tailwind](https://kalyx-docs.vercel.app/ko/docs/recipes/tailwind) · [shadcn/ui](https://kalyx-docs.vercel.app/ko/docs/recipes/shadcn) · [React Hook Form](https://kalyx-docs.vercel.app/ko/docs/recipes/react-hook-form)
-
 ## 컴포넌트
+
+7개 조합형 픽커 + 3개 headless 훅:
 
 ```tsx
 import {
-  DatePicker,       // 단일 날짜
-  RangePicker,      // 프리셋 포함 범위
-  TimePicker,       // 시 + 분 (+ 초)
-  DateTimePicker,   // 날짜 + 시간 결합
-  MonthPicker,      // 월 선택
-  YearPicker,       // 연도 선택
-  WeekPicker,       // 주 단위 범위 선택
+  DatePicker, RangePicker, TimePicker, DateTimePicker,
+  MonthPicker, YearPicker, WeekPicker,
+  useDatePicker, useRangePicker, useTimePicker,
 } from '@kalyx/react';
 ```
 
-각 Root는 dot 표기로 서브 컴포넌트를 노출합니다.
-
-```tsx
-<DatePicker.Input />
-<DatePicker.Trigger />
-<DatePicker.Popover />
-<DatePicker.Calendar />
-<DatePicker.MonthGrid />
-<DatePicker.YearGrid />
-<DatePicker.Presets />
-```
-
-## 훅
-
-```tsx
-import { useDatePicker, useRangePicker, useTimePicker } from '@kalyx/react';
-```
-
-컴포넌트로 표현되지 않는 완전 커스텀 UI를 만들 때 사용합니다.
+API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레이션 가이드는 모두 **[공식 문서](https://kalyx-docs.vercel.app/ko)** 에 있습니다.
 
 ## 문서
 
-전체 문서는 **[kalyx-docs.vercel.app](https://kalyx-docs.vercel.app/ko)** 에 있습니다.
+- [소개](https://kalyx-docs.vercel.app/ko/docs/intro) · [빠른 시작](https://kalyx-docs.vercel.app/ko/docs/getting-started/quick-start)
+- [컴포넌트](https://kalyx-docs.vercel.app/ko/docs/components/datepicker) · [훅](https://kalyx-docs.vercel.app/ko/docs/hooks/use-date-picker)
+- [레시피](https://kalyx-docs.vercel.app/ko/docs/recipes/tailwind) · [테스트](https://kalyx-docs.vercel.app/ko/docs/recipes/testing) · [문제 해결](https://kalyx-docs.vercel.app/ko/docs/troubleshooting)
+- [마이그레이션 (react-datepicker / react-day-picker / React Aria)](https://kalyx-docs.vercel.app/ko/docs/migration)
 
-- [소개](https://kalyx-docs.vercel.app/ko/docs/intro)
-- [설치](https://kalyx-docs.vercel.app/ko/docs/getting-started/installation)
-- [Composition API](https://kalyx-docs.vercel.app/ko/docs/concepts/composition)
-- [컴포넌트](https://kalyx-docs.vercel.app/ko/docs/components/datepicker)
-- [훅](https://kalyx-docs.vercel.app/ko/docs/hooks/use-date-picker)
-- [레시피 — Tailwind / shadcn / React Hook Form](https://kalyx-docs.vercel.app/ko/docs/recipes/tailwind)
-- [테스트](https://kalyx-docs.vercel.app/ko/docs/recipes/testing)
-- [문제 해결](https://kalyx-docs.vercel.app/ko/docs/troubleshooting)
-- [마이그레이션 가이드](https://kalyx-docs.vercel.app/ko/docs/migration)
+## 번들
 
-## 번들 크기
-
-```
-@kalyx/react  →  gzip 12.07 KB  (v1.0.0-rc.1, 7개 컴포넌트, "use client" 자동 주입)
-```
-
-CI에서 `≤ 13 KB`로 강제. `@kalyx/core`에 `sideEffects: false`가 설정돼 있어 임포트 단위 트리셰이킹이 작동합니다 — `TimePicker`만 쓰면 DatePicker 코드가 사라집니다.
+`@kalyx/react` v1.0.0-rc.3 → **12.27 KB** gzip (ESM) / **12.48 KB** (CJS). CI 한계 ≤ 13 KB.
 
 ## 지원 환경
 
-- React 19+
-- 모든 모던 브라우저 (Chrome, Firefox, Safari, Edge)
-- SSR: Next.js App Router·Pages Router, Remix, `renderToString`
-- 개발 시 Node ≥ 20
+React 19+ · 모든 모던 브라우저 · SSR: Next.js App Router / Pages Router / Remix · Node ≥ 20.
 
 ## 기여
 
 ```bash
 pnpm install
-pnpm test           # 단위 + 컴포넌트 테스트
-pnpm test:e2e       # Playwright
+pnpm test            # 단위 + 컴포넌트
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle   # ≤ 13 KB 강제
-pnpm --filter docs-site start  # 문서 사이트 localhost:3000
+pnpm check-bundle    # ≤ 13 KB
 ```
 
-PR 환영. 보내기 전에 아키텍처 원칙이 담긴 [CLAUDE.md](./CLAUDE.md)를 확인하세요.
+아키텍처 원칙은 [CLAUDE.md](./CLAUDE.md) 참고.
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 **The headless React DatePicker, finally complete.**
 
-[Docs](https://kalyx-docs.vercel.app) · [한국어 문서](https://kalyx-docs.vercel.app/ko) · [npm](https://www.npmjs.com/package/@kalyx/react) · [GitHub](https://github.com/jiji-hoon96/kalyx)
+[Docs](https://kalyx-docs.vercel.app) · [한국어](https://kalyx-docs.vercel.app/ko) · [npm](https://www.npmjs.com/package/@kalyx/react) · [README.ko](./README.ko.md)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![RC](https://img.shields.io/npm/v/@kalyx/react/next?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-12.07KB-brightgreen)](#bundle-size)
+[![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
+[![Bundle](https://img.shields.io/badge/gzip-12.27KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -19,16 +19,13 @@
 
 ---
 
-> 한국어 README: [README.ko.md](./README.ko.md)
-
-Kalyx is a headless React DatePicker library that ships **complete**. One composable API covers single dates, date ranges, time, and date-time — under 13 KB gzipped, zero CSS, SSR-safe.
+Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~12 KB gzip (≤13 KB ceiling), zero CSS, SSR-safe.
 
 ```bash
 pnpm add @kalyx/react
 ```
 
-> **Trying the v1.0 release candidate?**
-> `pnpm add @kalyx/react@next` — please report issues with the [`v1-rc`](https://github.com/jiji-hoon96/kalyx/issues?q=label%3Av1-rc) label.
+> **Trying v1.0?** `pnpm add @kalyx/react@rc` — feedback via [`v1-rc`](https://github.com/jiji-hoon96/kalyx/issues?q=label%3Av1-rc) issue label.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -41,208 +38,73 @@ import { DatePicker } from '@kalyx/react';
 </DatePicker>
 ```
 
-## Why Kalyx?
+`onChange` always returns `ISODateString | null` — UTC-safe, no `Date` objects.
 
-The React ecosystem in 2026 has two extremes — Kalyx fills the gap.
+## Why Kalyx
 
-Numbers come from bundlephobia (April 2026). See [notes below the table](#footnotes).
+The 2026 React date-picker landscape forces a tradeoff: **react-day-picker** ships only a calendar grid; **react-datepicker** is integrated but 40–60 KB and CSS-coupled; **Ark UI** dropped TimePicker; **React Aria** locks you into `@internationalized/date`. Kalyx fills the gap — headless + integrated + date-fns compatible + SSR-safe.
 
-| | Kalyx | react-datepicker | react-day-picker | Ark UI | React Aria |
-|---|---|---|---|---|---|
-| Version measured | 1.0.0-rc.1 | 9.1.0 | 9.14.0 | 5.36.1 | 1.17.0 |
-| Bundle (min+gzip) | **12.07 KB** | 44 KB | 2.4 KB¹ | 265 KB² | 247 KB² |
-| DatePicker | ✅ | ✅ | ✅ | ✅ | ✅ |
-| RangePicker | ✅ dedicated | ✅ two-picker pattern | ✅ `mode="range"` | ✅ | ✅ |
-| TimePicker | ✅ dedicated | ⚠️ `showTimeSelect` prop | ❌ | ❌ (removed) | ✅ |
-| DateTimePicker | ✅ dedicated | ⚠️ combined picker | ❌ | ❌ | ✅ |
-| Text Input included | ✅ | ✅ | ❌ BYO | ✅ | ✅ |
-| Headless (Zero CSS) | ✅ | ❌ CSS required | ✅ | ✅ | ✅ |
-| Composition API | ✅ dot notation | ❌ 100+ props | ✅ | ✅ | ✅ |
-| SSR Safe | ✅ | ⚠️ | ✅ | ✅ | ✅ |
-| TypeScript Strict | ✅ | ⚠️ | ✅ | ✅ | ✅ |
-| Value contract | ISO 8601 UTC string | `Date` object | `Date` object | `Date` object | `CalendarDate` (internationalized/date) |
-| date-fns compatible | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Timezone-aware (IANA, DST) | ✅ `displayTimezone` | ⚠️ native `Date` pitfalls | ⚠️ via adapter | ⚠️ partial | ✅ `@internationalized/date` |
-| React 19+ | ✅ | ✅ | ✅ | ✅ | ✅ |
-
-#### Footnotes
-
-1. react-day-picker ships only a calendar grid — no Input, no TimePicker, no DateTimePicker. Matching Kalyx's feature surface means composing it with your own input, popover, and time components. The 2.4 KB figure is the default entry point.
-2. `@ark-ui/react` and `react-aria-components` are full component monoliths covering 40+ patterns. Both are tree-shakeable, so an app that only imports DatePicker will ship substantially less — but also inherits a multi-package ecosystem (`@internationalized/date`, Ark's state-chart engine). Kalyx targets the "I want a DatePicker, not a framework" use case.
+Detailed comparison table → [docs-site](https://kalyx-docs.vercel.app/docs/intro#comparison).
 
 ## Features
 
-- **Zero CSS** — no stylesheets to import, no classes to override.
-- **True composition** — Radix-style dot notation. No prop explosions.
-- **Headless** — pair with Tailwind, shadcn/ui, Chakra, or any CSS.
-- **SSR-safe** — verified on Next.js App Router. `useId` for stable IDs.
-- **ISO 8601 UTC strings** — no `Date` object footguns.
-- **Timezone-aware** — opt-in `displayTimezone` prop handles IANA zones and DST without changing the UTC storage contract.
-- **Accessible** — WAI-ARIA, full keyboard, passes axe out of the box.
-- **Tree-shakable** — pay only for what you render.
-- **TypeScript first** — strict types, zero `any`.
+- **Zero CSS** — bring your own (Tailwind, shadcn/ui, Chakra, plain CSS).
+- **Composition API** — Radix-style dot notation. No prop explosions.
+- **SSR-safe** — Next.js App Router verified.
+- **ISO 8601 UTC strings** — eliminates `Date`-object footguns.
+- **IANA timezone-aware** — opt-in `displayTimezone` handles DST without changing storage.
+- **Accessible** — WAI-ARIA + full keyboard, axe-clean.
+- **Tree-shakable** — `sideEffects: false`. Use only what you import.
+- **TypeScript strict** — no `any`.
 
 ## Packages
 
 | Package | Purpose |
-| --- | --- |
-| [`@kalyx/react`](./packages/react) | React components, hooks, and types |
-| [`@kalyx/core`](./packages/core) | Platform-independent date logic and adapters |
-
-## Quick Start
-
-```tsx
-'use client';
-
-import { useState } from 'react';
-import { DatePicker, type ISODateString } from '@kalyx/react';
-
-export function BookingField() {
-  const [date, setDate] = useState<ISODateString | null>(null);
-  return (
-    <DatePicker value={date} onChange={setDate}>
-      <DatePicker.Input placeholder="YYYY-MM-DD" />
-      <DatePicker.Trigger />
-      <DatePicker.Popover>
-        <DatePicker.Calendar />
-      </DatePicker.Popover>
-    </DatePicker>
-  );
-}
-```
-
-Value is always an `ISODateString | null`:
-
-```ts
-// onChange receives "2026-04-15T00:00:00.000Z" | null
-```
-
-See the [Quick Start guide →](https://kalyx-docs.vercel.app/docs/getting-started/quick-start)
-
-## Styling with Tailwind CSS
-
-Kalyx is headless — bring your own styles via `classNames` and `data-*` attributes.
-
-### Using classNames
-
-```tsx
-<DatePicker value={date} onChange={setDate}>
-  <DatePicker.Input
-    className="w-64 rounded-lg border border-gray-300 px-3 py-2 text-sm
-               focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-    placeholder="Select a date"
-  />
-  <DatePicker.Popover className="mt-1 rounded-xl border bg-white p-4 shadow-lg">
-    <DatePicker.Calendar
-      classNames={{
-        header: "flex items-center justify-between mb-2",
-        title: "text-sm font-semibold",
-        navButton: "p-1 rounded hover:bg-gray-100",
-        grid: "w-full border-collapse",
-        weekdayHeader: "text-xs font-medium text-gray-500 pb-2",
-        day: "h-9 w-9 rounded-lg text-sm hover:bg-gray-100",
-        daySelected: "bg-blue-600 text-white hover:bg-blue-700",
-        dayToday: "font-bold text-blue-600",
-        dayDisabled: "text-gray-300 cursor-not-allowed",
-        dayOutsideMonth: "text-gray-300",
-      }}
-    />
-  </DatePicker.Popover>
-</DatePicker>
-```
-
-### Using data attributes
-
-All interactive states are exposed as `data-*` attributes for CSS or Tailwind arbitrary selectors:
-
-```css
-[data-selected] { @apply bg-blue-600 text-white; }
-[data-today] { @apply font-bold ring-1 ring-blue-400; }
-[data-disabled] { @apply opacity-30 cursor-not-allowed; }
-[data-in-range] { @apply bg-blue-100; }
-[data-range-start] { @apply rounded-l-lg bg-blue-600 text-white; }
-[data-range-end] { @apply rounded-r-lg bg-blue-600 text-white; }
-```
-
-See more recipes: [Tailwind](https://kalyx-docs.vercel.app/docs/recipes/tailwind) · [shadcn/ui](https://kalyx-docs.vercel.app/docs/recipes/shadcn) · [React Hook Form](https://kalyx-docs.vercel.app/docs/recipes/react-hook-form)
+|---|---|
+| [`@kalyx/react`](./packages/react) | Components, hooks, and types |
+| [`@kalyx/core`](./packages/core) | Platform-independent date logic + adapters |
 
 ## Components
 
+7 composable pickers + 3 headless hooks:
+
 ```tsx
 import {
-  DatePicker,       // single date
-  RangePicker,      // date range with presets
-  TimePicker,       // hour + minute (+ seconds)
-  DateTimePicker,   // combined date + time
-  MonthPicker,      // month-only selection
-  YearPicker,       // year-only selection
-  WeekPicker,       // full-week range selection
+  DatePicker, RangePicker, TimePicker, DateTimePicker,
+  MonthPicker, YearPicker, WeekPicker,
+  useDatePicker, useRangePicker, useTimePicker,
 } from '@kalyx/react';
 ```
 
-Each root exposes sub-components via dot notation:
-
-```tsx
-<DatePicker.Input />
-<DatePicker.Trigger />
-<DatePicker.Popover />
-<DatePicker.Calendar />
-<DatePicker.MonthGrid />
-<DatePicker.YearGrid />
-<DatePicker.Presets />
-```
-
-## Hooks
-
-```tsx
-import { useDatePicker, useRangePicker, useTimePicker } from '@kalyx/react';
-```
-
-Use when you need a fully custom UI that the components can't express.
+API reference, recipes (Tailwind / shadcn / React Hook Form), and migration guides live in the **[full docs](https://kalyx-docs.vercel.app)**.
 
 ## Documentation
 
-Full documentation is at **[kalyx-docs.vercel.app](https://kalyx-docs.vercel.app)**.
+- [Introduction](https://kalyx-docs.vercel.app/docs/intro) · [Quick Start](https://kalyx-docs.vercel.app/docs/getting-started/quick-start)
+- [Components](https://kalyx-docs.vercel.app/docs/components/datepicker) · [Hooks](https://kalyx-docs.vercel.app/docs/hooks/use-date-picker)
+- [Recipes](https://kalyx-docs.vercel.app/docs/recipes/tailwind) · [Testing](https://kalyx-docs.vercel.app/docs/recipes/testing) · [Troubleshooting](https://kalyx-docs.vercel.app/docs/troubleshooting)
+- [Migration from react-datepicker / react-day-picker / React Aria](https://kalyx-docs.vercel.app/docs/migration)
 
-- [Introduction](https://kalyx-docs.vercel.app/docs/intro)
-- [Installation](https://kalyx-docs.vercel.app/docs/getting-started/installation)
-- [Composition API](https://kalyx-docs.vercel.app/docs/concepts/composition)
-- [Components](https://kalyx-docs.vercel.app/docs/components/datepicker)
-- [Hooks](https://kalyx-docs.vercel.app/docs/hooks/use-date-picker)
-- [Recipes — Tailwind / shadcn / React Hook Form](https://kalyx-docs.vercel.app/docs/recipes/tailwind)
-- [Testing](https://kalyx-docs.vercel.app/docs/recipes/testing)
-- [Troubleshooting](https://kalyx-docs.vercel.app/docs/troubleshooting)
-- [Migration guide](https://kalyx-docs.vercel.app/docs/migration)
+## Bundle
 
-## Bundle size
-
-```
-@kalyx/react  →  12.07 KB gzip  (v1.0.0-rc.1, 7 components, "use client" injected)
-```
-
-Enforced in CI at `≤ 13 KB`. Tree-shakable per import — `@kalyx/core` is published with `sideEffects: false`, so using only `TimePicker` drops the DatePicker code.
+`@kalyx/react` v1.0.0-rc.3 → **12.27 KB** gzip (ESM) / **12.48 KB** (CJS). CI gate: ≤ 13 KB.
 
 ## Browser support
 
-- React 19+
-- All modern browsers (Chrome, Firefox, Safari, Edge)
-- SSR: Next.js App Router, Pages Router, Remix, any `renderToString` env
-- Node ≥ 20 for development
+React 19+ · all modern browsers · SSR: Next.js App Router / Pages Router / Remix · Node ≥ 20.
 
 ## Contributing
 
 ```bash
 pnpm install
-pnpm test           # unit + component tests
-pnpm test:e2e       # Playwright
+pnpm test            # unit + component
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle   # enforce ≤ 13 KB
-pnpm --filter docs-site start  # docs site at localhost:3000
+pnpm check-bundle    # ≤ 13 KB
 ```
 
-PRs welcome. Before opening one, see [CLAUDE.md](./CLAUDE.md) for the architecture principles.
+See [CLAUDE.md](./CLAUDE.md) for architecture principles.
 
 ## License
 

--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~11.36 KB** (v1.0.0-rc.0, 7 components). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~12.27 KB** (v1.0.0-rc.3, 7 components, CI ceiling 13 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/docs/components/datepicker.md
+++ b/apps/docs-site/docs/components/datepicker.md
@@ -284,7 +284,7 @@ type DatePickerYearGridClassNames = {
 
 ## `<DatePicker.Presets>` / `<DatePicker.Preset>` (optional)
 
-Quick-select buttons for common dates. `<DatePicker.Presets>` is a `role="group"` container; each `<DatePicker.Preset>` is a `role="option"` button that commits and closes the popover on click.
+Quick-select buttons for common dates. `<DatePicker.Presets>` is a `role="group"` container; each `<DatePicker.Preset>` is a regular toggle button (using `aria-pressed`) that commits and closes the popover on click.
 
 ```tsx
 <DatePicker value={date} onChange={setDate}>
@@ -301,7 +301,7 @@ Quick-select buttons for common dates. `<DatePicker.Presets>` is a `role="group"
 </DatePicker>
 ```
 
-Preset keys: `today`, `tomorrow`, `yesterday`, `startOfMonth`, `endOfMonth`, `startOfYear`. Or pass a concrete `date` (ISO 8601 UTC) for anything else. Active presets get `aria-selected="true"` when the resolved date matches the current `value` (timezone-aware via `displayTimezone`).
+Preset keys: `today`, `tomorrow`, `yesterday`, `startOfMonth`, `endOfMonth`, `startOfYear`. Or pass a concrete `date` (ISO 8601 UTC) for anything else. Active presets get `aria-pressed="true"` and `data-active` when the resolved date matches the current `value` (timezone-aware via `displayTimezone`).
 
 ## Event callbacks
 

--- a/apps/docs-site/docs/getting-started/installation.md
+++ b/apps/docs-site/docs/getting-started/installation.md
@@ -69,5 +69,5 @@ If TypeScript compiles and the page renders an input, you're done.
 
 ## Next
 
-- [Quick Start →](./quick-start.mdx)
-- [Composition API →](../concepts/composition.md)
+- [Quick Start →](./quick-start)
+- [Composition API →](../concepts/composition)

--- a/apps/docs-site/docs/getting-started/quick-start.mdx
+++ b/apps/docs-site/docs/getting-started/quick-start.mdx
@@ -105,7 +105,7 @@ Every sub-component accepts `classNames` and forwards `className`/`style`/`ref`.
 </DatePicker>
 ```
 
-See the full [Tailwind recipe →](../recipes/tailwind.md).
+See the full [Tailwind recipe →](../recipes/tailwind).
 
 ## 4. Read the value
 
@@ -118,7 +118,7 @@ onChange={(iso) => {
 }}
 ```
 
-See [ISO Strings →](../concepts/iso-string.md) for why.
+See [ISO Strings →](../concepts/iso-string) for why.
 
 ## 5. Try a range
 
@@ -147,7 +147,7 @@ export function VacationRange() {
 
 ## Next
 
-- [Composition API →](../concepts/composition.md)
-- [Components → DatePicker](../components/datepicker.md)
-- [Components → RangePicker](../components/rangepicker.md)
-- [Hooks → useDatePicker](../hooks/use-date-picker.md)
+- [Composition API →](../concepts/composition)
+- [Components → DatePicker](../components/datepicker)
+- [Components → RangePicker](../components/rangepicker)
+- [Hooks → useDatePicker](../hooks/use-date-picker)

--- a/apps/docs-site/docs/intro.md
+++ b/apps/docs-site/docs/intro.md
@@ -36,10 +36,10 @@ Kalyx fills the gap:
 - **Headless philosophy** — no stylesheets, no classes you must override.
 - **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
 - **Composition first** — Radix-style dot notation. No 100-prop monoliths.
-- **Under 12 KB gzip** — measured, enforced in CI.
+- **~12 KB gzip (≤ 13 KB ceiling)** — measured, enforced in CI.
 - **SSR-safe** — tested with Next.js App Router.
 - **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
-- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone.md).
+- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone).
 
 ## Who it's for
 
@@ -66,7 +66,7 @@ useTimePicker               …and more
 
 ## Next steps
 
-- [Install the package →](./getting-started/installation.md)
-- [Quick Start (5 min) →](./getting-started/quick-start.mdx)
-- [Composition API →](./concepts/composition.md)
-- [Components →](./components/datepicker.md)
+- [Install the package →](./getting-started/installation)
+- [Quick Start (5 min) →](./getting-started/quick-start)
+- [Composition API →](./concepts/composition)
+- [Components →](./components/datepicker)

--- a/apps/docs-site/docs/troubleshooting.md
+++ b/apps/docs-site/docs/troubleshooting.md
@@ -186,7 +186,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 ### Bundle size seems larger than expected
 
-Kalyx's `@kalyx/react` is < 12KB gzipped. If your bundle is larger:
+Kalyx's `@kalyx/react` is ~12 KB gzipped (CI ceiling 13 KB). If your bundle is larger:
 
 1. Check that tree-shaking is working — only import what you use
 2. `date-fns` is a dependency and adds ~5KB for the functions Kalyx uses. If you already use date-fns in your app, the cost is shared.

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -101,7 +101,7 @@ const config: Config = {
     },
     metadata: [
       {name: 'keywords', content: 'react, datepicker, headless, typescript, tailwind, accessible, ssr, calendar, timepicker, rangepicker'},
-      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in under 12KB.'},
+      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~12 KB (≤ 13 KB ceiling).'},
     ],
     navbar: {
       title: 'Kalyx',

--- a/apps/docs-site/i18n/ko-KR/code.json
+++ b/apps/docs-site/i18n/ko-KR/code.json
@@ -1,6 +1,6 @@
 {
   "home.eyebrow": {
-    "message": "Headless · SSR 안전 · 12KB 이하",
+    "message": "Headless · SSR 안전 · 13KB 이하",
     "description": "홈 상단 뱃지 텍스트"
   },
   "home.title.line1": {
@@ -16,7 +16,7 @@
     "description": "홈 타이틀 2번째 줄"
   },
   "home.subtitle": {
-    "message": "7개의 조합형 피커 — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker. CSS 없음, SSR 안전, 12KB 이하.",
+    "message": "7개의 조합형 피커 — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker. CSS 없음, SSR 안전, 13KB 이하.",
     "description": "홈 부제"
   },
   "home.cta.start": {
@@ -80,11 +80,11 @@
     "description": "기능: 접근성 설명"
   },
   "home.feat.bundle.title": {
-    "message": "12KB 이하",
+    "message": "13KB 이하",
     "description": "기능: 번들"
   },
   "home.feat.bundle.desc": {
-    "message": "7개 피커를 gzip 11.36KB에 담음 — react-datepicker 60KB 대비 일부. 사용한 만큼만 트리셰이킹됩니다.",
+    "message": "7개 피커를 gzip 12.27KB에 담음 — react-datepicker 60KB 대비 일부. 사용한 만큼만 트리셰이킹됩니다.",
     "description": "기능: 번들 설명"
   },
   "home.compare.eyebrow": {
@@ -148,7 +148,7 @@
     "description": "홈 메타 타이틀"
   },
   "home.meta.description": {
-    "message": "Input, Calendar, TimePicker, RangePicker를 12KB 이하로 담은 Headless·SSR 안전 React DatePicker.",
+    "message": "Input, Calendar, TimePicker, RangePicker를 13KB 이하로 담은 Headless·SSR 안전 React DatePicker (실측 12.27KB).",
     "description": "홈 메타 디스크립션"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~11.36 KB** (v1.0.0-rc.0, 7 components). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~12.27 KB** (v1.0.0-rc.3, 7 components, CI ceiling 13 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -152,4 +152,4 @@ export const ja: DatePickerLabels = {
 ## 다음
 
 - [접근성 →](./accessibility.md)
-- [마이그레이션 가이드 (v0.2 → v0.3) →](../migration.md#v02--v03--aria-라벨-i18n)
+- [마이그레이션 가이드 (v0.2 → v0.3) →](../migration.md#v02--v03--aria-labels-i18n)

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -69,5 +69,5 @@ TypeScript 컴파일과 페이지 렌더링에 input이 보이면 완료입니�
 
 ## 다음
 
-- [빠른 시작 →](./quick-start.md)
-- [Composition API →](../concepts/composition.md)
+- [빠른 시작 →](./quick-start)
+- [Composition API →](../concepts/composition)

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/intro.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/intro.md
@@ -36,10 +36,10 @@ Kalyx fills the gap:
 - **Headless philosophy** — no stylesheets, no classes you must override.
 - **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
 - **Composition first** — Radix-style dot notation. No 100-prop monoliths.
-- **Under 12 KB gzip** — measured, enforced in CI.
+- **~12 KB gzip (≤ 13 KB ceiling)** — measured, enforced in CI.
 - **SSR-safe** — tested with Next.js App Router.
 - **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
-- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone.md).
+- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone).
 
 ## Who it's for
 
@@ -66,7 +66,7 @@ useTimePicker               …and more
 
 ## Next steps
 
-- [Install the package →](./getting-started/installation.md)
-- [Quick Start (5 min) →](./getting-started/quick-start.mdx)
-- [Composition API →](./concepts/composition.md)
-- [Components →](./components/datepicker.md)
+- [Install the package →](./getting-started/installation)
+- [Quick Start (5 min) →](./getting-started/quick-start)
+- [Composition API →](./concepts/composition)
+- [Components →](./components/datepicker)

--- a/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/troubleshooting.md
+++ b/apps/docs-site/i18n/ko-KR/docusaurus-plugin-content-docs/current/troubleshooting.md
@@ -186,7 +186,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 ### Bundle size seems larger than expected
 
-Kalyx's `@kalyx/react` is < 12KB gzipped. If your bundle is larger:
+Kalyx's `@kalyx/react` is ~12 KB gzipped (CI ceiling 13 KB). If your bundle is larger:
 
 1. Check that tree-shaking is working — only import what you use
 2. `date-fns` is a dependency and adds ~5KB for the functions Kalyx uses. If you already use date-fns in your app, the cost is shared.

--- a/apps/docs-site/i18n/ko/code.json
+++ b/apps/docs-site/i18n/ko/code.json
@@ -1,6 +1,6 @@
 {
   "home.eyebrow": {
-    "message": "Headless · SSR 안전 · 12KB 이하",
+    "message": "Headless · SSR 안전 · 13KB 이하",
     "description": "홈 상단 뱃지 텍스트"
   },
   "home.title.line1": {
@@ -16,7 +16,7 @@
     "description": "홈 타이틀 2번째 줄"
   },
   "home.subtitle": {
-    "message": "7개의 조합형 피커 — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker. CSS 없음, SSR 안전, 12KB 이하.",
+    "message": "7개의 조합형 피커 — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker. CSS 없음, SSR 안전, 13KB 이하.",
     "description": "홈 부제"
   },
   "home.cta.start": {
@@ -80,11 +80,11 @@
     "description": "기능: 접근성 설명"
   },
   "home.feat.bundle.title": {
-    "message": "12KB 이하",
+    "message": "13KB 이하",
     "description": "기능: 번들"
   },
   "home.feat.bundle.desc": {
-    "message": "7개 피커를 gzip 11.36KB에 담음 — react-datepicker 60KB 대비 일부. 사용한 만큼만 트리셰이킹됩니다.",
+    "message": "7개 피커를 gzip 12.27KB에 담음 — react-datepicker 60KB 대비 일부. 사용한 만큼만 트리셰이킹됩니다.",
     "description": "기능: 번들 설명"
   },
   "home.compare.eyebrow": {
@@ -148,7 +148,7 @@
     "description": "홈 메타 타이틀"
   },
   "home.meta.description": {
-    "message": "Input, Calendar, TimePicker, RangePicker를 12KB 이하로 담은 Headless·SSR 안전 React DatePicker.",
+    "message": "Input, Calendar, TimePicker, RangePicker를 13KB 이하로 담은 Headless·SSR 안전 React DatePicker (실측 12.27KB).",
     "description": "홈 메타 디스크립션"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~11.36 KB** (v1.0.0-rc.0, 7 components). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~12.27 KB** (v1.0.0-rc.3, 7 components, CI ceiling 13 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -152,4 +152,4 @@ export const ja: DatePickerLabels = {
 ## 다음
 
 - [접근성 →](./accessibility.md)
-- [마이그레이션 가이드 (v0.2 → v0.3) →](../migration.md#v02--v03--aria-라벨-i18n)
+- [마이그레이션 가이드 (v0.2 → v0.3) →](../migration.md#v02--v03--aria-labels-i18n)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -69,5 +69,5 @@ TypeScript 컴파일과 페이지 렌더링에 input이 보이면 완료입니�
 
 ## 다음
 
-- [빠른 시작 →](./quick-start.mdx)
-- [Composition API →](../concepts/composition.md)
+- [빠른 시작 →](./quick-start)
+- [Composition API →](../concepts/composition)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/quick-start.mdx
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/quick-start.mdx
@@ -67,7 +67,7 @@ export function BirthdayPicker() {
 </DatePicker>
 ```
 
-자세한 내용은 [Tailwind 레시피 →](../recipes/tailwind.md)에.
+자세한 내용은 [Tailwind 레시피 →](../recipes/tailwind)에.
 
 ## 4. 값 읽기
 
@@ -80,7 +80,7 @@ onChange={(iso) => {
 }}
 ```
 
-이유는 [ISO 문자열 →](../concepts/iso-string.md)에.
+이유는 [ISO 문자열 →](../concepts/iso-string)에.
 
 ## 5. 범위 선택
 
@@ -109,7 +109,7 @@ export function VacationRange() {
 
 ## 다음
 
-- [Composition API →](../concepts/composition.md)
-- [컴포넌트 → DatePicker](../components/datepicker.md)
-- [컴포넌트 → RangePicker](../components/rangepicker.md)
-- [훅 → useDatePicker](../hooks/use-date-picker.md)
+- [Composition API →](../concepts/composition)
+- [컴포넌트 → DatePicker](../components/datepicker)
+- [컴포넌트 → RangePicker](../components/rangepicker)
+- [훅 → useDatePicker](../hooks/use-date-picker)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
@@ -36,10 +36,10 @@ Kalyx fills the gap:
 - **Headless philosophy** — no stylesheets, no classes you must override.
 - **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
 - **Composition first** — Radix-style dot notation. No 100-prop monoliths.
-- **Under 12 KB gzip** — measured, enforced in CI.
+- **~12 KB gzip (≤ 13 KB ceiling)** — measured, enforced in CI.
 - **SSR-safe** — tested with Next.js App Router.
 - **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
-- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone.md).
+- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone).
 
 ## Who it's for
 
@@ -66,7 +66,7 @@ useTimePicker               …and more
 
 ## Next steps
 
-- [Install the package →](./getting-started/installation.md)
-- [Quick Start (5 min) →](./getting-started/quick-start.mdx)
-- [Composition API →](./concepts/composition.md)
-- [Components →](./components/datepicker.md)
+- [Install the package →](./getting-started/installation)
+- [Quick Start (5 min) →](./getting-started/quick-start)
+- [Composition API →](./concepts/composition)
+- [Components →](./components/datepicker)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
@@ -186,7 +186,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 ### Bundle size seems larger than expected
 
-Kalyx's `@kalyx/react` is < 12KB gzipped. If your bundle is larger:
+Kalyx's `@kalyx/react` is ~12 KB gzipped (CI ceiling 13 KB). If your bundle is larger:
 
 1. Check that tree-shaking is working — only import what you use
 2. `date-fns` is a dependency and adds ~5KB for the functions Kalyx uses. If you already use date-fns in your app, the cost is shared.

--- a/apps/docs-site/src/pages/index.tsx
+++ b/apps/docs-site/src/pages/index.tsx
@@ -15,7 +15,7 @@ function Hero(): ReactNode {
           <div>
             <span className={styles.eyebrow}>
               <span className={styles.eyebrowDot} aria-hidden="true" />
-              <Translate id="home.eyebrow">Headless · SSR-safe · under 12KB</Translate>
+              <Translate id="home.eyebrow">Headless · SSR-safe · ~12 KB</Translate>
             </span>
             <h1 className={styles.title}>
               <Translate id="home.title.line1">The headless</Translate>{' '}
@@ -28,7 +28,7 @@ function Hero(): ReactNode {
             <p className={styles.subtitle}>
               <Translate id="home.subtitle">
                 7 composable pickers — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker,
-                YearPicker, and WeekPicker. Zero CSS, SSR-safe, under 12 KB.
+                YearPicker, and WeekPicker. Zero CSS, SSR-safe, ~12 KB (≤ 13 KB ceiling).
               </Translate>
             </p>
             <div className={styles.ctas}>
@@ -146,10 +146,10 @@ const features: Feature[] = [
       </svg>
     ),
     titleId: 'home.feat.bundle.title',
-    titleDefault: 'Under 12KB',
+    titleDefault: '~12 KB',
     descId: 'home.feat.bundle.desc',
     descDefault:
-      "11.36KB gzip for 7 pickers — a fraction of react-datepicker’s 60KB. Tree-shakable down to what you use.",
+      "12.27 KB gzip for 7 pickers — a fraction of react-datepicker’s 60 KB. Tree-shakable down to what you use.",
   },
 ];
 
@@ -362,7 +362,7 @@ export default function Home(): ReactNode {
       description={translate({
         id: 'home.meta.description',
         message:
-          'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in under 12KB.',
+          'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~12 KB (≤ 13 KB ceiling).',
       })}>
       <Hero />
       <main>

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -18,7 +18,7 @@ export default function HomePage() {
 				<strong>Headless지만 Calendar Grid만 제공하는 react-day-picker</strong>
 				와, <strong>통합됐지만 CSS 필수 import에 timezone 버그가 만성인 react-datepicker</strong>.
 				Kalyx는 이 빈자리를 채운다 — Headless, Composition API, 통합된 7개
-				picker (Date/Range/Time/DateTime/Month/Year/Week), SSR 안전, &lt; 12KB.
+				picker (Date/Range/Time/DateTime/Month/Year/Week), SSR 안전, ~12 KB (≤ 13 KB).
 			</p>
 
 			<h2>핵심 특징</h2>
@@ -57,7 +57,7 @@ export default function HomePage() {
 					<code>RangePicker.Presets</code>로 원클릭 빠른 선택.
 				</li>
 				<li>
-					<strong>{'< 12KB gzip'}</strong> — 현재 11.37KB (7개 picker 전체).
+					<strong>{'≤ 13KB gzip'}</strong> — 현재 12.27KB (7개 picker 전체).
 					react-datepicker (40-60KB) 대비 1/4 이상 가벼움.
 				</li>
 			</ul>

--- a/packages/core/src/__tests__/labels.test.ts
+++ b/packages/core/src/__tests__/labels.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DATEPICKER_LABELS,
+  DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS,
+  DEFAULT_DATETIMEPICKER_LABELS,
+} from '../utils/labels.js';
+
+describe('labels — defaults', () => {
+  it('DatePicker exposes the documented label keys', () => {
+    expect(DEFAULT_DATEPICKER_LABELS).toMatchObject({
+      triggerOpen: expect.any(String),
+      triggerClose: expect.any(String),
+      popoverLabel: expect.any(String),
+      prevMonth: expect.any(String),
+      nextMonth: expect.any(String),
+      prevYear: expect.any(String),
+      nextYear: expect.any(String),
+      prevDecade: expect.any(String),
+      nextDecade: expect.any(String),
+    });
+  });
+
+  it('RangePicker extends DatePicker labels and adds range-specific keys', () => {
+    expect(DEFAULT_RANGEPICKER_LABELS.prevMonth).toBe(DEFAULT_DATEPICKER_LABELS.prevMonth);
+    expect(DEFAULT_RANGEPICKER_LABELS.popoverLabel).toBe('Choose date range');
+    expect(DEFAULT_RANGEPICKER_LABELS).toMatchObject({
+      startInput: expect.any(String),
+      endInput: expect.any(String),
+      presetsGroup: expect.any(String),
+    });
+  });
+
+  it('TimePicker exposes hour/minute formatters that produce strings', () => {
+    expect(DEFAULT_TIMEPICKER_LABELS.timeInput).toBe('Time');
+    expect(DEFAULT_TIMEPICKER_LABELS.hourOption(9)).toBe('9 hours');
+    expect(DEFAULT_TIMEPICKER_LABELS.minuteOption(30)).toBe('30 minutes');
+  });
+
+  it('DateTimePicker merges DatePicker + TimePicker and adds dateTimeInput', () => {
+    expect(DEFAULT_DATETIMEPICKER_LABELS.prevMonth).toBe(DEFAULT_DATEPICKER_LABELS.prevMonth);
+    expect(DEFAULT_DATETIMEPICKER_LABELS.timeInput).toBe(DEFAULT_TIMEPICKER_LABELS.timeInput);
+    expect(DEFAULT_DATETIMEPICKER_LABELS.dateTimeInput).toBe('Date and time');
+  });
+
+  it('DateTimePicker hourOption/minuteOption are inherited from TimePicker', () => {
+    expect(DEFAULT_DATETIMEPICKER_LABELS.hourOption(0)).toBe(
+      DEFAULT_TIMEPICKER_LABELS.hourOption(0),
+    );
+    expect(DEFAULT_DATETIMEPICKER_LABELS.minuteOption(45)).toBe(
+      DEFAULT_TIMEPICKER_LABELS.minuteOption(45),
+    );
+  });
+
+  it('default label objects do not share mutable state across pickers', () => {
+    // Mutating the DatePicker default must not leak into RangePicker / DateTimePicker.
+    const before = DEFAULT_RANGEPICKER_LABELS.prevMonth;
+    (DEFAULT_DATEPICKER_LABELS as { prevMonth: string }).prevMonth = '__mutated__';
+    expect(DEFAULT_RANGEPICKER_LABELS.prevMonth).toBe(before);
+    // restore
+    (DEFAULT_DATEPICKER_LABELS as { prevMonth: string }).prevMonth = 'Previous month';
+  });
+});

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -49,6 +49,6 @@ src/
 ## 빌드
 
 ```bash
-pnpm --filter @kalyx/react build     # tsup: ESM + CJS + DTS (번들 목표 ≤12KB)
+pnpm --filter @kalyx/react build     # tsup: ESM + CJS + DTS (번들 목표 ≤13KB)
 pnpm --filter @kalyx/react typecheck
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,9 @@
 # @kalyx/react
 
-> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · under 12 KB gzip.
+> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~12 KB gzip (≤ 13 KB ceiling).
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-11.36KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-12.27KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -507,8 +507,8 @@ describe('DatePicker — Presets', () => {
         </DatePicker.Presets>
       </DatePicker>,
     );
-    expect(screen.getByRole('option', { name: 'Today' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Tomorrow' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Today' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tomorrow' })).toBeInTheDocument();
   });
 
   it('commits today when the today preset is clicked', async () => {
@@ -522,7 +522,7 @@ describe('DatePicker — Presets', () => {
       </DatePicker>,
     );
 
-    await user.click(screen.getByRole('option', { name: 'Today' }));
+    await user.click(screen.getByRole('button', { name: 'Today' }));
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/));
@@ -539,12 +539,12 @@ describe('DatePicker — Presets', () => {
       </DatePicker>,
     );
 
-    await user.click(screen.getByRole('option', { name: 'Christmas' }));
+    await user.click(screen.getByRole('button', { name: 'Christmas' }));
 
     expect(onChange).toHaveBeenCalledWith('2026-12-25T00:00:00.000Z');
   });
 
-  it('marks the matching preset as aria-selected', () => {
+  it('marks the matching preset as aria-pressed', () => {
     render(
       <DatePicker value="2026-12-25T00:00:00.000Z" onChange={vi.fn()}>
         <DatePicker.Presets>
@@ -554,12 +554,12 @@ describe('DatePicker — Presets', () => {
       </DatePicker>,
     );
 
-    expect(screen.getByRole('option', { name: 'Christmas' })).toHaveAttribute(
-      'aria-selected',
+    expect(screen.getByRole('button', { name: 'Christmas' })).toHaveAttribute(
+      'aria-pressed',
       'true',
     );
-    expect(screen.getByRole('option', { name: "New Year's" })).toHaveAttribute(
-      'aria-selected',
+    expect(screen.getByRole('button', { name: "New Year's" })).toHaveAttribute(
+      'aria-pressed',
       'false',
     );
   });
@@ -575,7 +575,7 @@ describe('DatePicker — Presets', () => {
       </DatePicker>,
     );
 
-    await user.click(screen.getByRole('option', { name: 'Start of month' }));
+    await user.click(screen.getByRole('button', { name: 'Start of month' }));
 
     // The first day of the current month (any month) — ends with "01T..."
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/-01T00:00:00\.000Z$/));
@@ -592,7 +592,7 @@ describe('DatePicker — Presets', () => {
       </DatePicker>,
     );
 
-    await user.click(screen.getByRole('option', { name: 'Today' }));
+    await user.click(screen.getByRole('button', { name: 'Today' }));
     expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/components/DatePicker/MonthGrid.tsx
+++ b/packages/react/src/components/DatePicker/MonthGrid.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { HTMLAttributes } from 'react';
-import { getMonthName } from '@kalyx/core';
+import { getMonthName, type ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
 
 export interface DatePickerMonthGridClassNames {
@@ -43,12 +43,18 @@ export function DatePickerMonthGrid({
   ...props
 }: DatePickerMonthGridProps) {
   const ctx = useDatePickerContext('DatePicker.MonthGrid');
-  const { adapter, viewMonth, locale } = ctx;
+  const { adapter, viewMonth, locale, displayTimezone } = ctx;
 
   const currentYear = adapter.getYear(viewMonth);
   const currentMonth = adapter.getMonth(viewMonth);
-  const todayMonth = adapter.getMonth(adapter.today());
-  const todayYear = adapter.getYear(adapter.today());
+  // SSR-safe: today is null on server and during hydration, set after mount.
+  // Avoids server/client clock-mismatch hydration warnings across day boundaries.
+  const [today, setToday] = useState<ISODateString | null>(null);
+  useEffect(() => {
+    setToday(adapter.today(displayTimezone));
+  }, [adapter, displayTimezone]);
+  const todayMonth = today !== null ? adapter.getMonth(today) : -1;
+  const todayYear = today !== null ? adapter.getYear(today) : -1;
 
   const navigateYear = useCallback(
     (direction: number) => {

--- a/packages/react/src/components/DatePicker/Presets.tsx
+++ b/packages/react/src/components/DatePicker/Presets.tsx
@@ -141,11 +141,13 @@ export function DatePickerPreset({
     return ctx.adapter.isSameDay(ctx.value, target, ctx.displayTimezone);
   })();
 
+  // role="option" is invalid outside role="listbox"/role="combobox"; the parent
+  // <DatePicker.Presets> is role="group". Use a regular button with aria-pressed
+  // so the active state is announced as a toggle.
   return (
     <button
       type="button"
-      role="option"
-      aria-selected={isActive}
+      aria-pressed={isActive}
       data-active={isActive || undefined}
       disabled={ctx.isDisabled}
       onClick={handleClick}

--- a/packages/react/src/components/DatePicker/YearGrid.tsx
+++ b/packages/react/src/components/DatePicker/YearGrid.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HTMLAttributes } from 'react';
+import type { ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
 
 export interface DatePickerYearGridClassNames {
@@ -32,10 +33,15 @@ export interface DatePickerYearGridProps extends Omit<HTMLAttributes<HTMLDivElem
  */
 export function DatePickerYearGrid({ classNames, onSelect, ...props }: DatePickerYearGridProps) {
   const ctx = useDatePickerContext('DatePicker.YearGrid');
-  const { adapter, viewMonth } = ctx;
+  const { adapter, viewMonth, displayTimezone } = ctx;
 
   const currentYear = adapter.getYear(viewMonth);
-  const todayYear = adapter.getYear(adapter.today());
+  // SSR-safe: today is null on server and during hydration, set after mount.
+  const [today, setToday] = useState<ISODateString | null>(null);
+  useEffect(() => {
+    setToday(adapter.today(displayTimezone));
+  }, [adapter, displayTimezone]);
+  const todayYear = today !== null ? adapter.getYear(today) : -1;
 
   // 12-year range (decade block containing the current year)
   const decadeStart = currentYear - (currentYear % 12);

--- a/packages/react/src/components/MonthPicker/Grid.tsx
+++ b/packages/react/src/components/MonthPicker/Grid.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HTMLAttributes } from 'react';
-import { getMonthName } from '@kalyx/core';
+import { getMonthName, type ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
 
 export interface MonthPickerGridClassNames {
@@ -54,9 +54,13 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
     }
   }, [value, adapter, displayTimezone]);
 
-  const today = adapter.today(displayTimezone);
-  const todayYear = adapter.getYear(today);
-  const todayMonth = adapter.getMonth(today);
+  // SSR-safe: today is null on server and during hydration, set after mount.
+  const [today, setToday] = useState<ISODateString | null>(null);
+  useEffect(() => {
+    setToday(adapter.today(displayTimezone));
+  }, [adapter, displayTimezone]);
+  const todayYear = today !== null ? adapter.getYear(today) : -1;
+  const todayMonth = today !== null ? adapter.getMonth(today) : -1;
 
   const navigateYear = useCallback(
     (direction: number) => {

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -218,10 +218,7 @@ export function RangePickerCalendar({
         // WAI-ARIA grid pattern: skip disabled cells while keyboard-navigating.
         // Step in the original direction up to one full grid (42 cells) before giving up.
         const skipStep =
-          e.key === 'ArrowLeft' ||
-          e.key === 'ArrowUp' ||
-          e.key === 'PageUp' ||
-          e.key === 'Home'
+          e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp' || e.key === 'Home'
             ? -1
             : 1;
         let attempts = 0;
@@ -281,11 +278,12 @@ export function RangePickerCalendar({
         </button>
       </div>
 
+      {/* aria-multiselectable intentionally omitted: a date range is one selection
+          (two endpoints), not multi-select. */}
       <table
         ref={gridRef}
         role="grid"
         aria-label={title}
-        aria-multiselectable="true"
         aria-rowcount={weeks.length + 1}
         aria-colcount={7}
         className={classNames?.grid}

--- a/packages/react/src/components/RangePicker/Presets.tsx
+++ b/packages/react/src/components/RangePicker/Presets.tsx
@@ -178,11 +178,12 @@ export function RangePickerPreset({
     );
   })();
 
+  // role="option" is invalid outside role="listbox"/role="combobox"; parent is
+  // role="group". Use a regular toggle button with aria-pressed.
   return (
     <button
       type="button"
-      role="option"
-      aria-selected={isActive}
+      aria-pressed={isActive}
       data-active={isActive || undefined}
       disabled={ctx.isDisabled}
       onClick={handleClick}

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -296,13 +296,13 @@ describe('RangePicker — accessibility', () => {
     expect(start).toHaveAttribute('aria-haspopup', 'dialog');
   });
 
-  it('sets aria-multiselectable="true" on the grid', async () => {
+  it('does not advertise aria-multiselectable on the grid (a range is one selection)', async () => {
     const user = userEvent.setup();
     renderRangePicker();
 
     await user.click(screen.getByLabelText('Start date'));
     const grid = screen.getByRole('grid');
-    expect(grid).toHaveAttribute('aria-multiselectable', 'true');
+    expect(grid).not.toHaveAttribute('aria-multiselectable');
   });
 
   it('passes axe accessibility checks (closed state)', async () => {
@@ -369,7 +369,7 @@ describe('RangePicker — Presets', () => {
     const { onChange } = renderWithPresets();
     await user.click(screen.getByLabelText('Start date'));
 
-    await user.click(screen.getByRole('option', { name: 'Today' }));
+    await user.click(screen.getByRole('button', { name: 'Today' }));
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -388,7 +388,7 @@ describe('RangePicker — Presets', () => {
     const { onChange } = renderWithPresets();
     await user.click(screen.getByLabelText('Start date'));
 
-    await user.click(screen.getByRole('option', { name: 'Last 7 days' }));
+    await user.click(screen.getByRole('button', { name: 'Last 7 days' }));
 
     const call = (onChange as ReturnType<typeof vi.fn>).mock.calls[0]![0] as DateRange;
     expect(call.start).toBeTruthy();
@@ -406,7 +406,7 @@ describe('RangePicker — Presets', () => {
     await user.click(screen.getByLabelText('Start date'));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('option', { name: 'Today' }));
+    await user.click(screen.getByRole('button', { name: 'Today' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
@@ -416,14 +416,14 @@ describe('RangePicker — Presets', () => {
     await user.click(screen.getByLabelText('Start date'));
 
     // Click "Today"
-    await user.click(screen.getByRole('option', { name: 'Today' }));
+    await user.click(screen.getByRole('button', { name: 'Today' }));
 
     // Reopen the popover
     await user.click(screen.getByLabelText('Start date'));
 
     // The "Today" option should be active
-    const todayOption = screen.getByRole('option', { name: 'Today' });
-    expect(todayOption).toHaveAttribute('aria-selected', 'true');
+    const todayOption = screen.getByRole('button', { name: 'Today' });
+    expect(todayOption).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('sets the correct range for "Last 30 days"', async () => {
@@ -431,7 +431,7 @@ describe('RangePicker — Presets', () => {
     const { onChange } = renderWithPresets();
     await user.click(screen.getByLabelText('Start date'));
 
-    await user.click(screen.getByRole('option', { name: 'Last 30 days' }));
+    await user.click(screen.getByRole('button', { name: 'Last 30 days' }));
 
     const call = (onChange as ReturnType<typeof vi.fn>).mock.calls[0]![0] as DateRange;
     expect(call.start).toBeTruthy();
@@ -447,7 +447,7 @@ describe('RangePicker — Presets', () => {
     const { onChange } = renderWithPresets();
     await user.click(screen.getByLabelText('Start date'));
 
-    await user.click(screen.getByRole('option', { name: 'This month' }));
+    await user.click(screen.getByRole('button', { name: 'This month' }));
 
     const call = (onChange as ReturnType<typeof vi.fn>).mock.calls[0]![0] as DateRange;
     expect(call.start).toBeTruthy();
@@ -474,7 +474,7 @@ describe('RangePicker — Presets', () => {
       </RangePicker>,
     );
     await user.click(screen.getByLabelText('Start date'));
-    await user.click(screen.getByRole('option', { name: 'Q1 2026' }));
+    await user.click(screen.getByRole('button', { name: 'Q1 2026' }));
 
     expect(onChange).toHaveBeenCalledWith({
       start: '2026-01-01T00:00:00.000Z',

--- a/packages/react/src/components/TimePicker/AmPmToggle.tsx
+++ b/packages/react/src/components/TimePicker/AmPmToggle.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import type { HTMLAttributes } from 'react';
+import { useCallback, useRef } from 'react';
+import type { HTMLAttributes, KeyboardEvent } from 'react';
 import { to12Hour, to24Hour } from '@kalyx/core';
 import { useTimePickerContext } from '../../context/TimePickerContext.js';
 
@@ -19,22 +19,67 @@ export interface TimePickerAmPmToggleProps extends Omit<
 /**
  * TimePicker.AmPmToggle — AM/PM toggle shown only in 12-hour mode.
  * Returns null in 24-hour mode.
+ *
+ * Implements the WAI-ARIA radiogroup pattern: only the checked radio is in the
+ * tab order; ArrowLeft/Right/Up/Down + Home/End move selection between radios.
  */
 export function TimePickerAmPmToggle({ classNames, ...props }: TimePickerAmPmToggleProps) {
   const ctx = useTimePickerContext('TimePicker.AmPmToggle');
-
-  if (ctx.format !== '12h') return null;
-
-  const { period, hours12 } = to12Hour(ctx.currentTime.hours);
+  const amRef = useRef<HTMLButtonElement | null>(null);
+  const pmRef = useRef<HTMLButtonElement | null>(null);
 
   const setPeriod = useCallback(
     (newPeriod: 'AM' | 'PM') => {
       if (ctx.isDisabled || ctx.isReadOnly) return;
+      const { hours12 } = to12Hour(ctx.currentTime.hours);
       const newHours24 = to24Hour(hours12, newPeriod);
       ctx.setTime({ hours: newHours24 });
     },
-    [hours12, ctx],
+    [ctx],
   );
+
+  if (ctx.format !== '12h') return null;
+
+  const { period } = to12Hour(ctx.currentTime.hours);
+
+  const focusOther = (target: 'AM' | 'PM') => {
+    (target === 'AM' ? amRef : pmRef).current?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>, target: 'AM' | 'PM') => {
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case 'ArrowLeft':
+      case 'ArrowUp': {
+        e.preventDefault();
+        const next: 'AM' | 'PM' = target === 'AM' ? 'PM' : 'AM';
+        setPeriod(next);
+        focusOther(next);
+        break;
+      }
+      case 'Home': {
+        e.preventDefault();
+        setPeriod('AM');
+        focusOther('AM');
+        break;
+      }
+      case 'End': {
+        e.preventDefault();
+        setPeriod('PM');
+        focusOther('PM');
+        break;
+      }
+      case ' ':
+      case 'Enter': {
+        e.preventDefault();
+        setPeriod(target);
+        break;
+      }
+      default:
+        break;
+    }
+  };
 
   const renderButton = (target: 'AM' | 'PM') => {
     const isSelected = period === target;
@@ -44,13 +89,16 @@ export function TimePickerAmPmToggle({ classNames, ...props }: TimePickerAmPmTog
 
     return (
       <button
+        ref={target === 'AM' ? amRef : pmRef}
         type="button"
         role="radio"
         aria-checked={isSelected}
+        tabIndex={isSelected ? 0 : -1}
         data-selected={isSelected || undefined}
         disabled={ctx.isDisabled}
         className={optionClass}
         onClick={() => setPeriod(target)}
+        onKeyDown={(e) => handleKeyDown(e, target)}
       >
         {target}
       </button>

--- a/packages/react/src/components/YearPicker/Grid.tsx
+++ b/packages/react/src/components/YearPicker/Grid.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HTMLAttributes } from 'react';
+import type { ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
 
 export interface YearPickerGridClassNames {
@@ -54,7 +55,12 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
     }
   }, [value, adapter, displayTimezone]);
 
-  const todayYear = adapter.getYear(adapter.today(displayTimezone));
+  // SSR-safe: today is null on server and during hydration, set after mount.
+  const [today, setToday] = useState<ISODateString | null>(null);
+  useEffect(() => {
+    setToday(adapter.today(displayTimezone));
+  }, [adapter, displayTimezone]);
+  const todayYear = today !== null ? adapter.getYear(today) : -1;
 
   const navigateDecade = useCallback(
     (direction: number) => {

--- a/packages/react/src/hooks/useRangePicker.test.tsx
+++ b/packages/react/src/hooks/useRangePicker.test.tsx
@@ -128,7 +128,14 @@ describe('useRangePicker — calendar grid', () => {
   });
 
   it('respects disabled rules', () => {
-    const { result } = renderHook(() => useRangePicker({ disabled: [{ dayOfWeek: [0, 6] }] }));
+    // Pin viewMonth to April 2026 via defaultValue so the calendar grid contains 2026-04-04
+    // regardless of the system clock (this test was previously time-dependent).
+    const { result } = renderHook(() =>
+      useRangePicker({
+        defaultValue: { start: ISO_APR_10, end: null },
+        disabled: [{ dayOfWeek: [0, 6] }],
+      }),
+    );
 
     const weekend = result.current.calendar
       .flat()


### PR DESCRIPTION
## Summary

Audit follow-ups against the v1.0-rc.3 build, surfaced by a multi-perspective review.

- **a11y** — `AmPmToggle` now follows the WAI-ARIA radiogroup pattern (Arrow/Home/End/Space/Enter, roving `tabIndex`); `DatePicker.Preset` / `RangePicker.Preset` use `aria-pressed` instead of invalid `role="option"` outside a listbox; `RangePicker.Calendar` drops semantically wrong `aria-multiselectable="true"`.
- **SSR** — 4 commit/drilldown grids (`DatePicker.MonthGrid` / `YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid`) snapshot `today` via `useState(null)` + post-mount `useEffect`, eliminating server/client clock-mismatch hydration warnings across day boundaries.
- **Test stability** — `useRangePicker` `respects disabled rules` test is no longer time-dependent (was failing once the system clock crossed into May 2026). New `labels.ts` unit suite closes the §7 "core utils 100%" gap.
- **Docs drift** — `12KB → 13KB` ceiling sync across 30+ locations (CLAUDE.md, packages/react/CLAUDE.md, READMEs, docs-site en + ko + ko-KR mirrors, code.json, PR template, RELEASE_NOTES_RC, rc-announcement.md, /check-bundle skill, docusaurus.config); version `rc.0/rc.1 → rc.3`; measured size `11.36/11.37/12.07 → 12.27 / 12.48`; root README slimmed (`249 → 111` / `237 → 111` lines), recipes/comparison detail moved to docs-site; relative doc links lose `.md`/`.mdx` extensions and the Korean migration anchor is corrected — docs-site build now reports **0** broken-link / **0** broken-anchor warnings (was 8).

## Behavioral notes (no breaking change for code following the documented `data-*` styling contract)

- If you targeted Preset buttons via `[aria-selected="true"]` in CSS, switch to `[aria-pressed="true"]` or `[data-active]`.
- If you targeted the range grid via `[aria-multiselectable]`, use `[role="grid"]` on the calendar root instead.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes — **384 / 384** (was 377/378, broken `useRangePicker` test fixed)
- [x] `pnpm build` passes (apps/docs + apps/docs-site, both locales)
- [x] `pnpm check-bundle` passes — ESM 12.27 KB / CJS 12.48 KB ≤ 13 KB
- [x] axe assertions still green on all 7 pickers
- [x] docs-site build: 0 broken-link / 0 broken-anchor warnings
- [x] Changeset added (`v1-rc1-a11y-ssr-fixes.md`, patch / patch)

## Out of scope (follow-up work)

- Keyboard handlers on `DatePicker.MonthGrid` / `YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid` (separate PR — bigger refactor).
- Component-level integration tests for leap-year, `minDate`/`maxDate`, per-day disabled.
- `e2e-and-docs.yml` name vs. behavior alignment (CLAUDE.md §13 claims docs deploy; workflow only runs Playwright).
- Decision: keep `dist-tag: rc` per `pre.json` or add `next` alias on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Accessibility (접근성)**
  * 시간 선택 컨트롤의 키보드 네비게이션 개선
  * 날짜 프리셋 선택을 위한 ARIA 속성 업데이트

* **Server-Side Rendering (SSR)**
  * 달력 및 그리드 컴포넌트의 수화(hydration) 안정성 향상

* **Bundle Size**
  * 번들 크기 제한을 12KB에서 13KB로 조정

* **Documentation**
  * 가이드, API 문서 및 설치 지침 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->