### PR TITLE
docs(CLAUDE): §13 e2e workflow + §6 public-API alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,13 +366,37 @@ export { WeekPicker } from './components/WeekPicker';
 export { useDatePicker } from './hooks/useDatePicker';
 export { useRangePicker } from './hooks/useRangePicker';
 export { useTimePicker } from './hooks/useTimePicker';
-// 타입 + 어댑터 (re-export from @kalyx/core)
+// 컴포넌트별 props/classNames 타입 — 각 컴포넌트의 index.ts 가 re-export.
+// (예: DatePickerRootProps, DatePickerCalendarClassNames, RangePickerPresetProps,
+//      TimePickerHourListProps, MonthPickerGridProps 등)
+// Hook 옵션/반환 타입
+export type { UseDatePickerOptions, UseDatePickerReturn } from './hooks/useDatePicker';
+export type { UseRangePickerOptions, UseRangePickerReturn } from './hooks/useRangePicker';
+export type { UseTimePickerOptions, UseTimePickerReturn } from './hooks/useTimePicker';
+// 어댑터 + 코어 타입/유틸 (re-export from @kalyx/core)
 export { DateFnsAdapter } from '@kalyx/core';
-export type { ISODateString, DateRange, DisabledRule, DateAdapter, CalendarDay, TimeValue } from '@kalyx/core';
+export type {
+  ISODateString, DateRange, DisabledRule, DateAdapter,
+  CalendarDay, CalendarWeek, CalendarGrid, CalendarOptions, WeekStartsOn,
+  TimeValue, WeekdayInfo,
+  DatePickerLabels, RangePickerLabels, TimePickerLabels, DateTimePickerLabels,
+} from '@kalyx/core';
+export {
+  DEFAULT_DATEPICKER_LABELS, DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS, DEFAULT_DATETIMEPICKER_LABELS,
+} from '@kalyx/core';
 
 // ❌ 내부 구현 절대 export 금지
 export { formatDateInternal } from './utils/internal';
 ```
+
+`@kalyx/core`는 위 re-export 외에도 직접 사용자에게 다음을 노출한다:
+`getCalendarDays`, `isDateDisabled`, `minDate`, `maxDate`, `normalizeISO`, `parseInputValue`,
+`setTime`, `getTime`, `parseTimeString`, `formatTimeString`, `formatTimeFromISO`,
+`to12Hour`, `to24Hour`, `generateHours`, `generateMinutes`, `isSameTime`,
+`getMonthName`, `formatMonthYear`, `getWeekdayNames`, `formatFullDate`,
+`formatInTimezone`, `startOfDayInTimezone`, `isSameDayInTimezone`, `todayInTimezone`,
+`getTimezoneOffsetMinutes`, `civilMidnightFromUtcDay`, `getTimeInTimezone`, `setTimeInTimezone`.
 
 ---
 
@@ -548,7 +572,7 @@ pnpm changeset publish # npm 배포 (CI 자동)
 |---|---|---|
 | `pr-check.yml` | PR, main push | typecheck·lint·test·build·번들크기·SSR 검사 |
 | `release.yml` | main push | Changesets 버전 PR 생성 또는 npm publish |
-| `e2e-and-docs.yml` | main push | 크로스브라우저 E2E + GitHub Pages 배포 |
+| `e2e-and-docs.yml` | main push | 크로스브라우저 E2E (Playwright × chromium/firefox/webkit). docs-site 배포는 Vercel GitHub App이 별도로 처리 |
 | `security.yml` | 매주 월·의존성 변경 | 취약점·라이선스 감사 |
 
 **Branch Protection (main):**


### PR DESCRIPTION
## Summary

Two CLAUDE.md drifts from the post-rc.3 audit, plus closes the small remaining items from PR #43's follow-up list.

### §13 — `e2e-and-docs.yml` row

The workflow body (`.github/workflows/e2e-and-docs.yml`) only runs Playwright × chromium / firefox / webkit; there is no docs-site deploy step. docs-site deployment is handled by the **Vercel GitHub App** (which already runs against every PR — see the `Vercel` / `Vercel Preview Comments` checks on PR #43). The §13 row previously claimed "GitHub Pages 배포" which never existed in this repo. Row corrected.

### §6 — public-API example

The previous example understated the export surface. Updated to enumerate:

- Hook option/return types (`UseDatePickerOptions` / `Return`, etc.)
- Additional core types re-exported (`CalendarWeek`, `CalendarGrid`, `CalendarOptions`, `WeekStartsOn`, `WeekdayInfo`, `DatePickerLabels` / `RangePickerLabels` / `TimePickerLabels` / `DateTimePickerLabels`)
- Default-label constants (`DEFAULT_DATEPICKER_LABELS`, etc.)
- Direct `@kalyx/core` exports the example previously omitted (`getCalendarDays`, `isDateDisabled`, `minDate`/`maxDate`, `normalizeISO`, `parseInputValue`, `setTime`/`getTime`/`parseTimeString`, `formatTimeString`, `formatTimeFromISO`, `to12Hour`/`to24Hour`, `generateHours`/`generateMinutes`, `isSameTime`, `getMonthName`, `formatMonthYear`, `getWeekdayNames`, `formatFullDate`, `formatInTimezone`, `startOfDayInTimezone`, `isSameDayInTimezone`, `todayInTimezone`, `getTimezoneOffsetMinutes`, `civilMidnightFromUtcDay`, `getTimeInTimezone`/`setTimeInTimezone`)

### Closed by re-verification (no code change in this PR)

- **`ko` quick-start broken-link warning** — already fixed in #43 by stripping `.md`/`.mdx` extensions from relative doc links and the migration anchor. Re-verified locally: `pnpm --filter docs-site build` reports **0** broken-link / **0** broken-anchor warnings.

### Out of band (npm dist-tag — needs publish-account access)

Earlier RC announcements pointed users at `pnpm add @kalyx/react@next`, but `pre.json.tag: rc` means `changeset publish` only sets the `rc` dist-tag. PR #43 already migrated all repo-internal docs to `@rc`. To preserve compatibility for users who saw the earlier `@next` announcement, run (as the npm publisher):

```bash
npm dist-tag add @kalyx/react@1.0.0-rc.3 next
npm dist-tag add @kalyx/core@1.0.0-rc.3 next
```

That keeps `@next` resolving to the latest RC alongside `@rc`. Cannot be automated from this PR.

## Test plan

- [x] CLAUDE.md is documentation-only — no code, no changeset, no publish impact
- [x] `pnpm --filter docs-site build` — 0 broken-link / 0 broken-anchor (re-verified)
- [x] PR-Check workflow expected to pass (lint/typecheck/test/build/SSR/bundle all pass since no code touched)

## Out of scope (still in the audit follow-up backlog)

- Keyboard handlers on `DatePicker.MonthGrid` / `YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid` — separate PR (next session, bigger refactor).
- Component-level integration tests for leap year, `minDate` / `maxDate`, per-day disabled — same PR as the keyboard work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 공개 API 관련 문서가 확장되어 사용 가능한 컴포넌트, 훅, 타입 및 유틸리티가 더욱 명확하게 안내됩니다.
  * CI/CD 워크플로우 설명이 최신 배포 프로세스에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->