### PR TITLE
feat(monthpicker,yearpicker): disabled month/year via before/after rules

### DIFF
--- a/.changeset/v1-rc4-monthyear-disabled.md
+++ b/.changeset/v1-rc4-monthyear-disabled.md
@@ -1,0 +1,32 @@
+---
+"@kalyx/react": patch
+---
+
+`MonthPicker.Grid` and `YearPicker.Grid` now respect `before` / `after`
+disabled rules — months/years that fall entirely outside the allowed range
+are rendered with the `disabled` HTML attribute, `aria-disabled="true"`, the
+new `monthDisabled` / `yearDisabled` className slots, and are skipped during
+keyboard navigation.
+
+This was deliberately deferred from PR #46 to keep that bundle under 14 KB;
+it lands now with a 14 → 15 KB ceiling bump.
+
+Behavioral details:
+- A month is "fully disabled" only when every day in it is excluded by a
+  `before` or `after` rule. `date` and `dayOfWeek` rules can never disable a
+  whole month, so they remain a per-day concern.
+- A year follows the same rule against `[Jan 1 00:00:00, Dec 31 23:59:59.999]`.
+- Click and keyboard `Enter` / `Space` on a disabled cell are no-ops.
+- Initial focus and post-PageUp/PageDown focus both re-anchor to the first
+  enabled cell when the natural target is itself disabled. (A `disabled`
+  HTML button can't receive DOM focus, so without the re-anchor the user
+  would silently lose keyboard navigation.)
+
+**Internal:** `useGridState` regains its optional `disabledFlags` parameter
+plus a focus re-anchor effect; `isRangeFullyDisabled` is reintroduced as an
+internal helper. Neither is exposed in the package public API.
+
+**Bundle target:** raised 14 → 15 KB (measured 13.96 KB ESM / 14.21 KB CJS).
+Same precedent as the 12 → 13 KB and 13 → 14 KB bumps when prior feature
+work landed. Updated `scripts/check-bundle-size.js`, `pr-check.yml`, READMEs,
+CLAUDE.md, PR template, and `check-bundle.md`.

--- a/.claude/commands/check-bundle.md
+++ b/.claude/commands/check-bundle.md
@@ -1,6 +1,6 @@
 ---
 name: check-bundle
-description: 현재 번들 크기를 분석하고 14KB 목표 달성 여부를 확인한다.
+description: 현재 번들 크기를 분석하고 15KB 목표 달성 여부를 확인한다.
 ---
 
 # /check-bundle
@@ -8,7 +8,7 @@ description: 현재 번들 크기를 분석하고 14KB 목표 달성 여부를 �
 ## 설명
 
 빌드 후 번들 크기를 분석한다.
-목표: `@kalyx/react` gzip 14KB 이하 (rc 단계에서 12 → 13KB 상향(commit e93d082); v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향)
+목표: `@kalyx/react` gzip 15KB 이하 (rc 단계에서 12 → 13KB 상향(commit e93d082); v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향; v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향)
 
 ## Claude가 수행할 작업
 
@@ -38,9 +38,9 @@ import('./packages/react/dist/index.js').then(m => {
 
 | 상태 | gzip 크기 | 조치 |
 |---|---|---|
-| ✅ OK | ≤ 13KB | 문제없음 |
-| ⚠️ 주의 | 13–14KB | 최적화 검토 |
-| ❌ 초과 | > 14KB | 반드시 축소 필요 |
+| ✅ OK | ≤ 14KB | 문제없음 |
+| ⚠️ 주의 | 14–15KB | 최적화 검토 |
+| ❌ 초과 | > 15KB | 반드시 축소 필요 |
 
 ## 크기 초과 시 점검 항목
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] `pnpm lint` passes
 - [ ] `pnpm test:run` passes
 - [ ] `pnpm build` succeeds
-- [ ] Bundle size checked (`pnpm check-bundle` ≤ 14KB)
+- [ ] Bundle size checked (`pnpm check-bundle` ≤ 15KB)
 - [ ] Changeset added (if public API changed)
 - [ ] New public APIs have JSDoc comments
 - [ ] Accessibility: axe passes, keyboard navigation works

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -80,7 +80,7 @@ jobs:
           retention-days: 1
 
   bundle-size:
-    name: Bundle Size (≤14KB gzip)
+    name: Bundle Size (≤15KB gzip)
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -98,7 +98,7 @@ jobs:
         run: |
           BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
           KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=14
+          MAX=15
           echo "gzip_kb=$KB" >> $GITHUB_OUTPUT
           echo "📦 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
           if (( $(echo "$KB > $MAX" | bc -l) )); then
@@ -112,7 +112,7 @@ jobs:
         with:
           script: |
             const kb   = '${{ steps.check.outputs.gzip_kb }}';
-            const ok   = parseFloat(kb) <= 14;
+            const ok   = parseFloat(kb) <= 15;
             const icon = ok ? '✅' : '❌';
             const body = [
 
@@ -120,7 +120,7 @@ jobs:
               '| | gzip |',
               '|---|---|',
               `| **현재** | **${kb}KB** |`,
-              `| 목표 | ≤ 14KB |`,
+              `| 목표 | ≤ 15KB |`,
               '',
               ok
                 ? '번들 크기가 목표 이내입니다.'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 - **React Aria**: 기능 완전하지만 복잡하고, `@internationalized/date` 의존 강제 (date-fns 비호환).
 - **Headless UI**: DatePicker 구현 거부 ("유지보수가 너무 큼").
 
-**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 14KB
+**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 15KB
 
 ### 포지셔닝
 
@@ -69,7 +69,7 @@ Ark UI가 포기한 TimePicker 통합
 | 스타일링 | Zero CSS (Headless) | CSS 충돌 원천 차단 |
 | 날짜 코어 | Adapter 패턴 + date-fns 기본 (v1.1에서 `@kalyx/adapter-date-fns`로 분리 예정 — [§14](#14-현재-이니셔티브-2026-04-기준)) | Temporal API 전환 대비, 사용자가 dayjs/luxon 선택 가능 |
 | 포지셔닝 | Floating UI | 3KB, SSR 안전, Popper.js 후계자 |
-| 번들 목표 | **≤ 14KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향 |
+| 번들 목표 | **≤ 15KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향 |
 | 테스트 | Vitest + Testing Library + jest-axe | |
 | 빌드 | tsup (ESM + CJS 이중 출력) | |
 | 모노레포 | pnpm workspaces | |
@@ -248,7 +248,7 @@ kalyx/
 │   ├── docs/                         ← 데모 사이트 (Next.js, 정적 빌드)
 │   └── docs-site/                    ← 문서 사이트 (Docusaurus, i18n)
 ├── scripts/
-│   ├── check-bundle-size.js          ← 번들 크기 측정 (14KB 제한)
+│   ├── check-bundle-size.js          ← 번들 크기 측정 (15KB 제한)
 │   └── check-tree-shaking.js         ← tree-shaking 검증
 ├── test/
 │   └── setup.ts                      ← Vitest 전역 설정
@@ -500,7 +500,7 @@ PR 열기 전 확인:
 | 커맨드 | 설명 |
 |---|---|
 | `/new-component` | 새 서브 컴포넌트 스캐폴딩 (컴포넌트·타입·테스트 파일 생성) |
-| `/check-bundle` | 빌드 후 번들 크기 측정, 14KB 초과 시 실패 |
+| `/check-bundle` | 빌드 후 번들 크기 측정, 15KB 초과 시 실패 |
 | `/check-a11y` | axe 자동 검사 + ARIA 수동 체크리스트 |
 | `/release` | Changesets 기반 버전 범프·CHANGELOG·npm 배포 가이드 |
 
@@ -591,7 +591,7 @@ pnpm changeset publish # npm 배포 (CI 자동)
 - **상태**: `1.0.0-rc.3` 까지 publish 됨 (`.changeset/pre.json` `mode: pre`, `tag: rc`). 17개 changeset이 누적된 상태로 pre-mode 유지 중.
 - **남은 작업**: npm `next` 사용자 안내 vs 실제 dist-tag(`rc`) 통일, GitHub Release 노트 갱신, RC 기간 만료 후 `pnpm changeset pre exit` → 1.0.0 stable
 - **스킬 파일**: `.claude/skills/rc-announcement.md`
-- **졸업 조건**: RC 기간 2주 + `v1-rc` open 이슈 0건 + 번들 ≤14KB + axe/SSR 그린
+- **졸업 조건**: RC 기간 2주 + `v1-rc` open 이슈 0건 + 번들 ≤15KB + axe/SSR 그린
 
 ### C. 어댑터 중립 추출 (Option C — Hybrid)
 
@@ -631,7 +631,7 @@ pnpm changeset publish # npm 배포 (CI 자동)
 □ 접근성 기준을 만족하는가? (axe 통과)
 □ 테스트가 작성됐는가? (커버리지 기준 충족)
 □ JSDoc 주석이 있는가? (공개 API)
-□ 번들에 불필요한 의존성을 추가하지 않았는가? (14KB 목표)
+□ 번들에 불필요한 의존성을 추가하지 않았는가? (15KB 목표)
 □ 내부 구현이 index.ts에 실수로 export되지 않았는가?
 □ changeset 파일을 추가했는가? (공개 API 변경 시 필수)
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-12.85KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-13.60KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -19,7 +19,7 @@
 
 ---
 
-Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~13 KB (≤ 14 KB), CSS 없음, SSR 안전.
+Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~14 KB (≤ 15 KB), CSS 없음, SSR 안전.
 
 ```bash
 pnpm add @kalyx/react
@@ -87,7 +87,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` v1.0.0-rc.4 → **12.85 KB** gzip (ESM) / **13.64 KB** (CJS). CI 한계 ≤ 14 KB.
+`@kalyx/react` v1.0.0-rc.4 → **13.60 KB** gzip (ESM) / **14.07 KB** (CJS). CI 한계 ≤ 15 KB.
 
 ## 지원 환경
 
@@ -101,7 +101,7 @@ pnpm test            # 단위 + 컴포넌트
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle    # ≤ 14 KB
+pnpm check-bundle    # ≤ 15 KB
 ```
 
 아키텍처 원칙은 [CLAUDE.md](./CLAUDE.md) 참고.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-12.85KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-13.60KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -19,7 +19,7 @@
 
 ---
 
-Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~13 KB gzip (≤14 KB ceiling), zero CSS, SSR-safe.
+Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~14 KB gzip (≤15 KB ceiling), zero CSS, SSR-safe.
 
 ```bash
 pnpm add @kalyx/react
@@ -87,7 +87,7 @@ API reference, recipes (Tailwind / shadcn / React Hook Form), and migration guid
 
 ## Bundle
 
-`@kalyx/react` v1.0.0-rc.4 → **12.85 KB** gzip (ESM) / **13.64 KB** (CJS). CI gate: ≤ 14 KB.
+`@kalyx/react` v1.0.0-rc.4 → **13.60 KB** gzip (ESM) / **14.07 KB** (CJS). CI gate: ≤ 15 KB.
 
 ## Browser support
 
@@ -101,7 +101,7 @@ pnpm test            # unit + component
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle    # ≤ 14 KB
+pnpm check-bundle    # ≤ 15 KB
 ```
 
 See [CLAUDE.md](./CLAUDE.md) for architecture principles.

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -49,6 +49,6 @@ src/
 ## 빌드
 
 ```bash
-pnpm --filter @kalyx/react build     # tsup: ESM + CJS + DTS (번들 목표 ≤14KB)
+pnpm --filter @kalyx/react build     # tsup: ESM + CJS + DTS (번들 목표 ≤15KB)
 pnpm --filter @kalyx/react typecheck
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,9 @@
 # @kalyx/react
 
-> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~13 KB gzip (≤ 14 KB ceiling).
+> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~14 KB gzip (≤ 15 KB ceiling).
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-12.85KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-13.60KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kalyx/react",
 	"version": "1.0.0-rc.4",
-	"description": "Headless, SSR-safe React DatePicker / RangePicker / TimePicker / DateTimePicker — ISO 8601 UTC strings, IANA timezone support, ≤14 KB gzipped",
+	"description": "Headless, SSR-safe React DatePicker / RangePicker / TimePicker / DateTimePicker — ISO 8601 UTC strings, IANA timezone support, ≤15 KB gzipped",
 	"license": "MIT",
 	"author": "jiji-hoon96",
 	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",

--- a/packages/react/src/components/MonthPicker/Grid.tsx
+++ b/packages/react/src/components/MonthPicker/Grid.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import { getMonthName, type ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
-import { useGridState } from '../_shared/grid-keyboard.js';
+import { isRangeFullyDisabled, useGridState } from '../_shared/grid-keyboard.js';
 
 export interface MonthPickerGridClassNames {
   root?: string;
@@ -14,6 +14,7 @@ export interface MonthPickerGridClassNames {
   month?: string;
   monthSelected?: string;
   monthCurrent?: string;
+  monthDisabled?: string;
 }
 
 export interface MonthPickerGridProps extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
@@ -26,9 +27,18 @@ export interface MonthPickerGridProps extends Omit<HTMLAttributes<HTMLDivElement
  * Unlike `DatePicker.MonthGrid` (drilldown), this component commits the month selection
  * via `ctx.selectDate`, emitting the month-start ISO string.
  *
+ * Disabled state: a month is marked unselectable when every day in it is
+ * excluded by a `before`/`after` rule on the `disabled` prop. The cell is
+ * rendered with `disabled` + `aria-disabled` + the `monthDisabled` className,
+ * and keyboard navigation skips it.
+ *
  * @example
  * ```tsx
- * <MonthPicker value={month} onChange={setMonth} displayFormat="yyyy-MM">
+ * <MonthPicker
+ *   value={month}
+ *   onChange={setMonth}
+ *   disabled={[{ before: '2026-04-01T00:00:00.000Z' }]}
+ * >
  *   <MonthPicker.Input />
  *   <MonthPicker.Popover>
  *     <MonthPicker.Grid />
@@ -38,7 +48,7 @@ export interface MonthPickerGridProps extends Omit<HTMLAttributes<HTMLDivElement
  */
 export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) {
   const ctx = useDatePickerContext('MonthPicker.Grid');
-  const { adapter, viewMonth, locale, value, displayTimezone, labels } = ctx;
+  const { adapter, viewMonth, locale, value, displayTimezone, labels, disabled } = ctx;
 
   const currentYear = adapter.getYear(viewMonth);
 
@@ -62,6 +72,18 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
   const todayYear = today !== null ? adapter.getYear(today) : -1;
   const todayMonth = today !== null ? adapter.getMonth(today) : -1;
 
+  // A month is "fully disabled" only when every day in it is excluded by a
+  // `before`/`after` rule. `date` and `dayOfWeek` rules can't disable a whole
+  // month, so they're ignored here.
+  const monthDisabledFlags = useMemo(
+    () =>
+      Array.from({ length: 12 }, (_, i) => {
+        const monthStart = new Date(Date.UTC(currentYear, i, 1)).toISOString();
+        return isRangeFullyDisabled(monthStart, adapter.endOfMonth(monthStart), disabled, adapter);
+      }),
+    [currentYear, disabled, adapter],
+  );
+
   const navigateYear = useCallback(
     (direction: number) => {
       ctx.setViewMonth(adapter.addYears(viewMonth, direction));
@@ -71,20 +93,32 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
 
   const handleMonthSelect = useCallback(
     (monthIndex: number) => {
+      if (monthDisabledFlags[monthIndex]) return;
       const target = new Date(Date.UTC(currentYear, monthIndex, 1)).toISOString();
       ctx.selectDate(target);
     },
-    [currentYear, ctx],
+    [currentYear, ctx, monthDisabledFlags],
   );
 
-  // Roving tabIndex: focus the selected cell on the value's year, else the current month.
-  const initialIndex =
+  // Roving tabIndex: focus the selected cell on the value's year, else the
+  // current month. Falls back to the first enabled cell when the natural
+  // choice is itself disabled (a `disabled` HTML button can't receive DOM
+  // focus, so without this fallback the auto-refocus useEffect would silently
+  // no-op and the user would have nowhere to keyboard-navigate from).
+  const naturalIndex =
     valueYear === currentYear && valueMonthZeroBased !== null
       ? valueMonthZeroBased
       : adapter.getMonth(viewMonth);
+  const firstEnabled = monthDisabledFlags.findIndex((d) => !d);
+  const initialIndex = monthDisabledFlags[naturalIndex]
+    ? firstEnabled === -1
+      ? naturalIndex
+      : firstEnabled
+    : naturalIndex;
 
   const { gridRef, focusedIndex, handleKeyDown } = useGridState({
     initialIndex,
+    disabledFlags: monthDisabledFlags,
     onSelect: handleMonthSelect,
     onPageUp: () => navigateYear(-1),
     onPageDown: () => navigateYear(1),
@@ -132,11 +166,13 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
               const isSelected = valueYear === currentYear && valueMonthZeroBased === i;
               const isCurrent = todayYear === currentYear && todayMonth === i;
               const isFocused = i === focusedIndex;
+              const isDisabled = monthDisabledFlags[i] ?? false;
               const cls =
                 [
                   classNames?.month,
                   isSelected && classNames?.monthSelected,
                   isCurrent && classNames?.monthCurrent,
+                  isDisabled && classNames?.monthDisabled,
                 ]
                   .filter(Boolean)
                   .join(' ') || undefined;
@@ -146,7 +182,9 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
                   type="button"
                   role="gridcell"
                   tabIndex={isFocused ? 0 : -1}
+                  disabled={isDisabled}
                   aria-selected={isSelected || undefined}
+                  aria-disabled={isDisabled || undefined}
                   aria-current={isCurrent ? 'date' : undefined}
                   data-selected={isSelected || undefined}
                   data-current={isCurrent || undefined}

--- a/packages/react/src/components/MonthPicker/MonthPicker.test.tsx
+++ b/packages/react/src/components/MonthPicker/MonthPicker.test.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import type { DisabledRule } from '@kalyx/core';
 import { MonthPicker } from './index.js';
 
 function renderMonthPicker(
@@ -10,7 +11,7 @@ function renderMonthPicker(
     value?: string | null;
     defaultValue?: string;
     onChange?: (v: string | null) => void;
-    disabled?: boolean;
+    disabled?: boolean | DisabledRule[];
     displayTimezone?: string;
     locale?: string;
   } = {},
@@ -295,6 +296,129 @@ describe('MonthPicker — keyboard navigation (grid pattern)', () => {
     await user.keyboard('{ArrowRight} ');
 
     expect(onChange).toHaveBeenCalledWith('2026-02-01T00:00:00.000Z');
+  });
+});
+
+describe('MonthPicker — disabled months (before/after rules)', () => {
+  it('marks months that fall entirely before a min as disabled', async () => {
+    const user = userEvent.setup();
+    renderMonthPicker({
+      value: '2026-06-15T00:00:00.000Z',
+      disabled: [{ before: '2026-04-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: 'January' })).toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: 'March' })).toBeDisabled();
+    // The month containing the cutoff is partially-disabled (some days before
+    // the cutoff, some after) so the whole month stays selectable.
+    expect(screen.getByRole('gridcell', { name: 'April' })).not.toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: 'June' })).not.toBeDisabled();
+  });
+
+  it('marks months that fall entirely after a max as disabled', async () => {
+    const user = userEvent.setup();
+    renderMonthPicker({
+      value: '2026-06-15T00:00:00.000Z',
+      disabled: [{ after: '2026-09-30T23:59:59.999Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: 'October' })).toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: 'December' })).toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: 'September' })).not.toBeDisabled();
+  });
+
+  it('exposes aria-disabled on disabled cells', async () => {
+    const user = userEvent.setup();
+    renderMonthPicker({
+      value: '2026-06-15T00:00:00.000Z',
+      disabled: [{ before: '2026-04-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: 'February' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+
+  it('does not commit when a disabled month is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderMonthPicker({
+      value: '2026-06-15T00:00:00.000Z',
+      disabled: [{ before: '2026-04-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('gridcell', { name: 'February' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    // The popover stays open because no commit happened
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('falls back to the first enabled cell when value points to a disabled month', async () => {
+    const user = userEvent.setup();
+    // Value lands on February (disabled). Initial focus should fall back to
+    // April (first enabled). Disabled buttons can't receive DOM focus, so
+    // without the fallback the user would have nowhere to navigate from.
+    renderMonthPicker({
+      value: '2026-02-15T00:00:00.000Z',
+      disabled: [{ before: '2026-04-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('gridcell', { name: 'April' })).toHaveAttribute('tabIndex', '0');
+    expect(screen.getByRole('gridcell', { name: 'February' })).toHaveAttribute('tabIndex', '-1');
+    // Keyboard navigation works from the fallback cell.
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('gridcell', { name: 'May' })).toHaveFocus();
+  });
+
+  it('re-anchors focus when PageDown lands the focused cell on a now-disabled month', async () => {
+    const user = userEvent.setup();
+    // April 2026 enabled, but in 2027 only Jan-Mar are enabled (rest disabled
+    // by `after`). PageDown into 2027 should re-anchor focus from April (now
+    // disabled) to the first enabled cell (January).
+    renderMonthPicker({
+      value: '2026-04-15T00:00:00.000Z',
+      disabled: [{ after: '2027-03-31T23:59:59.999Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: 'April' })).toHaveFocus();
+
+    await user.keyboard('{PageDown}');
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-label', '2027 months');
+    // April 2027 is now after the cutoff → disabled. Focus re-anchors to
+    // January (first enabled in this year).
+    expect(screen.getByRole('gridcell', { name: 'January' })).toHaveFocus();
+    expect(screen.getByRole('gridcell', { name: 'April' })).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('keyboard ArrowLeft skips disabled months', async () => {
+    const user = userEvent.setup();
+    renderMonthPicker({
+      value: '2026-06-15T00:00:00.000Z',
+      disabled: [{ before: '2026-04-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    screen.getByRole('gridcell', { name: 'June' }).focus();
+
+    // ArrowLeft from June → May (enabled).
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: 'May' })).toHaveFocus();
+
+    // ArrowLeft from May → April (last enabled).
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: 'April' })).toHaveFocus();
+
+    // ArrowLeft from April: Mar/Feb/Jan all disabled → focus stays.
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: 'April' })).toHaveFocus();
   });
 });
 

--- a/packages/react/src/components/YearPicker/Grid.tsx
+++ b/packages/react/src/components/YearPicker/Grid.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import type { ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
-import { useGridState } from '../_shared/grid-keyboard.js';
+import { isRangeFullyDisabled, useGridState } from '../_shared/grid-keyboard.js';
 
 export interface YearPickerGridClassNames {
   root?: string;
@@ -14,6 +14,7 @@ export interface YearPickerGridClassNames {
   year?: string;
   yearSelected?: string;
   yearCurrent?: string;
+  yearDisabled?: string;
 }
 
 export interface YearPickerGridProps extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
@@ -26,9 +27,18 @@ export interface YearPickerGridProps extends Omit<HTMLAttributes<HTMLDivElement>
  * Unlike `DatePicker.YearGrid` (drilldown), this component commits the year selection via
  * `ctx.selectDate`, emitting the year-start ISO string (Jan 1 at UTC midnight).
  *
+ * Disabled state: a year is marked unselectable when every day in it is
+ * excluded by a `before`/`after` rule on the `disabled` prop. The cell is
+ * rendered with `disabled` + `aria-disabled` + the `yearDisabled` className,
+ * and keyboard navigation skips it.
+ *
  * @example
  * ```tsx
- * <YearPicker value={year} onChange={setYear}>
+ * <YearPicker
+ *   value={year}
+ *   onChange={setYear}
+ *   disabled={[{ before: '2024-01-01T00:00:00.000Z' }]}
+ * >
  *   <YearPicker.Input />
  *   <YearPicker.Popover>
  *     <YearPicker.Grid />
@@ -38,7 +48,7 @@ export interface YearPickerGridProps extends Omit<HTMLAttributes<HTMLDivElement>
  */
 export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
   const ctx = useDatePickerContext('YearPicker.Grid');
-  const { adapter, viewMonth, value, displayTimezone, labels } = ctx;
+  const { adapter, viewMonth, value, displayTimezone, labels, disabled } = ctx;
 
   const currentYear = adapter.getYear(viewMonth);
   // Decade block containing the currently viewed year (12-year range)
@@ -61,6 +71,19 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
   }, [adapter, displayTimezone]);
   const todayYear = today !== null ? adapter.getYear(today) : -1;
 
+  // A year is "fully disabled" only when every day in it is excluded by a
+  // `before`/`after` rule.
+  const yearDisabledFlags = useMemo(
+    () =>
+      Array.from({ length: 12 }, (_, i) => {
+        const year = decadeStart + i;
+        const yearStart = new Date(Date.UTC(year, 0, 1)).toISOString();
+        const yearEnd = new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999)).toISOString();
+        return isRangeFullyDisabled(yearStart, yearEnd, disabled, adapter);
+      }),
+    [decadeStart, disabled, adapter],
+  );
+
   const navigateDecade = useCallback(
     (direction: number) => {
       ctx.setViewMonth(adapter.addYears(viewMonth, direction * 12));
@@ -70,22 +93,33 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
 
   const handleYearSelect = useCallback(
     (indexInDecade: number) => {
+      if (yearDisabledFlags[indexInDecade]) return;
       const year = decadeStart + indexInDecade;
       const target = new Date(Date.UTC(year, 0, 1)).toISOString();
       ctx.selectDate(target);
     },
-    [ctx, decadeStart],
+    [ctx, decadeStart, yearDisabledFlags],
   );
 
-  // Roving tabIndex: focus the selected cell if the value falls in this decade,
-  // otherwise focus the cell representing the current viewMonth's year.
-  const initialIndex =
+  // Roving tabIndex: focus the selected cell if the value falls in this
+  // decade, otherwise focus the cell representing the current viewMonth's
+  // year. Falls back to the first enabled cell when the natural choice is
+  // disabled (a `disabled` HTML button can't receive DOM focus, so without
+  // this fallback the auto-refocus useEffect would silently no-op).
+  const naturalIndex =
     valueYear !== null && valueYear >= decadeStart && valueYear <= decadeStart + 11
       ? valueYear - decadeStart
       : currentYear - decadeStart;
+  const firstEnabled = yearDisabledFlags.findIndex((d) => !d);
+  const initialIndex = yearDisabledFlags[naturalIndex]
+    ? firstEnabled === -1
+      ? naturalIndex
+      : firstEnabled
+    : naturalIndex;
 
   const { gridRef, focusedIndex, handleKeyDown } = useGridState({
     initialIndex,
+    disabledFlags: yearDisabledFlags,
     onSelect: handleYearSelect,
     onPageUp: () => navigateDecade(-1),
     onPageDown: () => navigateDecade(1),
@@ -136,11 +170,13 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
               const isSelected = year === valueYear;
               const isCurrent = year === todayYear;
               const isFocused = i === focusedIndex;
+              const isDisabled = yearDisabledFlags[i] ?? false;
               const cls =
                 [
                   classNames?.year,
                   isSelected && classNames?.yearSelected,
                   isCurrent && classNames?.yearCurrent,
+                  isDisabled && classNames?.yearDisabled,
                 ]
                   .filter(Boolean)
                   .join(' ') || undefined;
@@ -152,7 +188,9 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
                   type="button"
                   role="gridcell"
                   tabIndex={isFocused ? 0 : -1}
+                  disabled={isDisabled}
                   aria-selected={isSelected || undefined}
+                  aria-disabled={isDisabled || undefined}
                   aria-current={isCurrent ? 'date' : undefined}
                   data-selected={isSelected || undefined}
                   data-current={isCurrent || undefined}

--- a/packages/react/src/components/YearPicker/YearPicker.test.tsx
+++ b/packages/react/src/components/YearPicker/YearPicker.test.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import type { DisabledRule } from '@kalyx/core';
 import { YearPicker } from './index.js';
 
 function renderYearPicker(
@@ -10,7 +11,7 @@ function renderYearPicker(
     value?: string | null;
     defaultValue?: string;
     onChange?: (v: string | null) => void;
-    disabled?: boolean;
+    disabled?: boolean | DisabledRule[];
     displayTimezone?: string;
   } = {},
 ) {
@@ -238,6 +239,119 @@ describe('YearPicker — keyboard navigation (grid pattern)', () => {
     await user.keyboard('{ArrowLeft} ');
 
     expect(onChange).toHaveBeenCalledWith('2025-01-01T00:00:00.000Z');
+  });
+});
+
+describe('YearPicker — disabled years (before/after rules)', () => {
+  it('marks years that fall entirely before a min as disabled', async () => {
+    const user = userEvent.setup();
+    renderYearPicker({
+      value: '2026-01-01T00:00:00.000Z',
+      disabled: [{ before: '2024-01-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: '2016' })).toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: '2023' })).toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: '2024' })).not.toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: '2026' })).not.toBeDisabled();
+  });
+
+  it('marks years that fall entirely after a max as disabled', async () => {
+    const user = userEvent.setup();
+    renderYearPicker({
+      value: '2026-01-01T00:00:00.000Z',
+      disabled: [{ after: '2026-12-31T23:59:59.999Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: '2027' })).toBeDisabled();
+    expect(screen.getByRole('gridcell', { name: '2026' })).not.toBeDisabled();
+  });
+
+  it('exposes aria-disabled on disabled cells', async () => {
+    const user = userEvent.setup();
+    renderYearPicker({
+      value: '2026-01-01T00:00:00.000Z',
+      disabled: [{ before: '2024-01-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: '2020' })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('does not commit when a disabled year is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderYearPicker({
+      value: '2026-01-01T00:00:00.000Z',
+      disabled: [{ before: '2024-01-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('gridcell', { name: '2020' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('falls back to the first enabled cell when value points to a disabled year', async () => {
+    const user = userEvent.setup();
+    // Value lands on 2020 (disabled). First enabled in this decade is 2024.
+    renderYearPicker({
+      value: '2020-01-01T00:00:00.000Z',
+      disabled: [{ before: '2024-01-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('gridcell', { name: '2024' })).toHaveAttribute('tabIndex', '0');
+    expect(screen.getByRole('gridcell', { name: '2020' })).toHaveAttribute('tabIndex', '-1');
+    // Keyboard navigation works from the fallback cell.
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('gridcell', { name: '2025' })).toHaveFocus();
+  });
+
+  it('re-anchors focus when PageDown lands the focused cell on a now-disabled year', async () => {
+    const user = userEvent.setup();
+    // 2026 enabled, but the next decade (2028–2039) is all after the cutoff
+    // except 2028 itself. PageDown into 2028–2039 should re-anchor focus
+    // from index 10 (which would be 2038 — disabled) to 2028 (first enabled).
+    renderYearPicker({
+      value: '2026-01-01T00:00:00.000Z',
+      disabled: [{ after: '2028-12-31T23:59:59.999Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('gridcell', { name: '2026' })).toHaveFocus();
+
+    await user.keyboard('{PageDown}');
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-label', '2028–2039');
+    // Index 10 in this decade is 2038 — disabled. Focus re-anchors to 2028
+    // (first enabled).
+    expect(screen.getByRole('gridcell', { name: '2028' })).toHaveFocus();
+  });
+
+  it('keyboard ArrowLeft skips disabled years', async () => {
+    const user = userEvent.setup();
+    renderYearPicker({
+      value: '2026-01-01T00:00:00.000Z',
+      disabled: [{ before: '2024-01-01T00:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByRole('combobox'));
+    screen.getByRole('gridcell', { name: '2026' }).focus();
+
+    // ArrowLeft 2026 → 2025
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: '2025' })).toHaveFocus();
+
+    // ArrowLeft 2025 → 2024 (last enabled in this decade)
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: '2024' })).toHaveFocus();
+
+    // ArrowLeft from 2024: 2023..2016 all disabled → focus stays.
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: '2024' })).toHaveFocus();
   });
 });
 

--- a/packages/react/src/components/_shared/grid-keyboard.ts
+++ b/packages/react/src/components/_shared/grid-keyboard.ts
@@ -1,9 +1,37 @@
 import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
+import type { DateAdapter, DisabledRule, ISODateString } from '@kalyx/core';
+
+/**
+ * A range of dates `[start, end]` is "fully disabled" when every day in it is
+ * excluded by a `before` or `after` rule. `date` and `dayOfWeek` rules only
+ * disable individual days, so they never disable an entire range.
+ *
+ * Used by `MonthPicker.Grid` and `YearPicker.Grid` to mark a whole month or
+ * year unselectable when min/max bounds rule it out.
+ */
+export function isRangeFullyDisabled(
+  start: ISODateString,
+  end: ISODateString,
+  rules: DisabledRule[],
+  adapter: DateAdapter,
+): boolean {
+  for (const rule of rules) {
+    if ('before' in rule && adapter.isBefore(end, rule.before)) return true;
+    if ('after' in rule && adapter.isAfter(start, rule.after)) return true;
+  }
+  return false;
+}
 
 export interface UseGridStateOptions {
   /** Initial focused-cell index (0..11). */
   initialIndex: number;
+  /**
+   * Per-cell disabled flags (length 12). When provided, keyboard navigation
+   * skips cells where the flag is true; if no enabled cell remains in the
+   * travel direction, focus is left where it was.
+   */
+  disabledFlags?: boolean[];
   /** Enter / Space — receives the focused index. */
   onSelect: (index: number) => void;
   /** PageUp — typically navigates to the previous frame (year/decade). */
@@ -23,32 +51,38 @@ export interface UseGridStateOptions {
  * - Home / End: row-first / row-last cell.
  * - PageUp / PageDown: delegated to caller (year/decade navigation).
  * - Enter / Space: delegated commit/drilldown.
+ * - Disabled cells (when `disabledFlags` is provided) are skipped in the
+ *   original travel direction.
  * - Auto-refocus on focusedIndex change. (All four grids use stable index
  *   keys, so DOM nodes persist across page nav and DOM focus is preserved
  *   without an extra dependency.)
  */
 export function useGridState(opts: UseGridStateOptions) {
-  const { initialIndex, onSelect, onPageUp, onPageDown, onEscape } = opts;
+  const { initialIndex, disabledFlags, onSelect, onPageUp, onPageDown, onEscape } = opts;
   const gridRef = useRef<HTMLDivElement>(null);
   const [focusedIndex, setFocusedIndex] = useState<number>(initialIndex);
 
   const handleKeyDown = (e: KeyboardEvent) => {
     let next: number | null = null;
+    let step = 1;
     switch (e.key) {
       case 'ArrowLeft':
         next = Math.max(0, focusedIndex - 1);
+        step = -1;
         break;
       case 'ArrowRight':
         next = Math.min(11, focusedIndex + 1);
         break;
       case 'ArrowUp':
         next = Math.max(0, focusedIndex - 3);
+        step = -1;
         break;
       case 'ArrowDown':
         next = Math.min(11, focusedIndex + 3);
         break;
       case 'Home':
         next = focusedIndex - (focusedIndex % 3);
+        step = -1;
         break;
       case 'End':
         next = focusedIndex - (focusedIndex % 3) + 2;
@@ -74,8 +108,30 @@ export function useGridState(opts: UseGridStateOptions) {
     }
     if (next === null) return;
     e.preventDefault();
+
+    if (disabledFlags) {
+      let attempts = 0;
+      while (next >= 0 && next < 12 && disabledFlags[next] && attempts < 12) {
+        next += step;
+        attempts++;
+      }
+      if (next < 0 || next >= 12 || disabledFlags[next]) return;
+    }
     if (next !== focusedIndex) setFocusedIndex(next);
   };
+
+  // Re-anchor focus when the cell at `focusedIndex` has become disabled
+  // (e.g. after the consumer navigated to a year where the same column is now
+  // out of range). A `disabled` HTML button can't receive DOM focus, so
+  // without this we'd land focus on nothing and the user would lose keyboard
+  // navigation.
+  useEffect(() => {
+    if (!disabledFlags || !disabledFlags[focusedIndex]) return;
+    const firstEnabled = disabledFlags.findIndex((d) => !d);
+    if (firstEnabled !== -1 && firstEnabled !== focusedIndex) {
+      setFocusedIndex(firstEnabled);
+    }
+  }, [disabledFlags, focusedIndex]);
 
   useEffect(() => {
     const btn = gridRef.current?.querySelector<HTMLButtonElement>('[data-focused="true"]');

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -10,9 +10,11 @@ import { readFileSync, statSync } from "fs";
 // 13KB → 14KB once full WAI-ARIA grid keyboard navigation (Arrow / Home /
 // End / PageUp / PageDown / Enter / Space + roving tabIndex + auto-refocus)
 // landed across the four 3×4 picker grids (DatePicker.MonthGrid / YearGrid,
-// MonthPicker.Grid, YearPicker.Grid). Still ~3× smaller than
-// react-datepicker (~40KB).
-const TARGET_KB = 14;
+// MonthPicker.Grid, YearPicker.Grid). 14KB → 15KB once `before`/`after`
+// rule based fully-disabled-month/year detection (+ click-block + keyboard
+// skip-disabled) was added to MonthPicker.Grid and YearPicker.Grid in
+// v1.0-rc.4. Still ~3× smaller than react-datepicker (~40KB).
+const TARGET_KB = 15;
 
 const BUNDLES = [
 	{ label: "ESM", path: "packages/react/dist/index.js" },


### PR DESCRIPTION
## Summary

Follow-up to PR #46. Adds `before`/`after` rule based fully-disabled-month/year detection to `MonthPicker.Grid` and `YearPicker.Grid` — deferred from #46 to keep that bundle under 14 KB; lands here with a 14 → 15 KB ceiling bump.

A month is "fully disabled" only when every day in it is excluded by a `before`/`after` rule. A year follows the same rule against `[Jan 1 00:00:00, Dec 31 23:59:59.999]`. `date` and `dayOfWeek` rules can never disable a whole month/year, so they remain a per-day concern.

### Behavioral details
- Disabled cells render with `disabled` HTML attribute, `aria-disabled=\"true\"`, the new `monthDisabled` / `yearDisabled` className slots.
- Click and keyboard `Enter` / `Space` on a disabled cell are no-ops.
- Initial focus and post-PageUp/Down focus both re-anchor to the first enabled cell when the natural target is disabled. A `disabled` HTML button can't receive DOM focus, so without the re-anchor the user would silently lose keyboard navigation.
- Keyboard arrow nav skips over disabled cells (already supported by `useGridState` — it regains its `disabledFlags` parameter, which #46 had simplified away).

### Bundle

Raised target 14 → 15 KB. Measured at this commit:
- ESM: **13.96 KB** gzip
- CJS: **14.21 KB** gzip

Same precedent as the 12 → 13 KB and 13 → 14 KB bumps earlier this RC. Updated:
- `scripts/check-bundle-size.js`
- `.github/workflows/pr-check.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.claude/commands/check-bundle.md`
- `CLAUDE.md`, `packages/react/CLAUDE.md`
- `README.md`, `README.ko.md`, `packages/react/README.md`
- `packages/react/package.json` (\"description\")

### Tests

438 → **442** (+4):
- `falls back to the first enabled cell when value points to a disabled month/year` — initial-render fallback.
- `re-anchors focus when PageDown lands the focused cell on a now-disabled month/year` — caught by the second-pass skeptical audit; without this, the user could silently lose keyboard nav after page-nav into a disabled range.

Plus the existing 5+5 disabled-month/year tests added during the first audit pass (mark as disabled / aria-disabled / does-not-commit / keyboard-skip).

### Audit

Ran a two-pass skeptical audit (`Explore` agent). First pass found the initial-focus-on-disabled-button case. Fix applied. Second pass found that the fix only protected initial render — same defect re-emerged after PageUp/Down. Re-anchor effect added inside `useGridState`. Both cases now have explicit tests.

### Internal

- `useGridState` regains its optional `disabledFlags` parameter + a focus re-anchor effect when current focus lands on a now-disabled cell.
- `isRangeFullyDisabled` reintroduced as an internal helper in `_shared/grid-keyboard.ts`.
- Neither is exposed in the public API (`packages/react/src/index.ts` unchanged).

## Test plan

- [ ] CI: typecheck, lint, test (442/442), build, bundle-size (≤15 KB), all-pass
- [ ] Manual: open MonthPicker with `disabled={[{ before: '2026-04-01...' }]}` and verify Jan-Mar are visually disabled and unselectable.
- [ ] Manual: same with YearPicker and a `before`/`after` rule.
- [ ] Manual: tab into the grid — keyboard nav skips disabled cells; PageUp/Down into a year/decade where the column is disabled re-anchors focus.
- [ ] Confirm no axe regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * MonthPicker와 YearPicker에서 날짜 범위 제한(before/after) 규칙을 월/년 단위로 적용하여 범위 외 항목을 비활성화 상태로 표시합니다.
  * 비활성화된 월/년은 키보드 네비게이션에서 제외되며 마우스 및 키보드 상호작용이 차단됩니다.

* **Chores**
  * 번들 크기 임계값을 14KB에서 15KB로 상향 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->