### PR TITLE
fix(ci): bump release.yml bundle gate 13 → 15 KB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
           KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=13
+          MAX=15
           echo "📦 릴리즈 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
           if (( $(echo "$KB > $MAX" | bc -l) )); then
             echo "❌ 번들 크기 ${MAX}KB 초과 — 릴리즈 중단"


### PR DESCRIPTION
## Summary

`release.yml` has its own bundle size guard (separate from `pr-check.yml` and `scripts/check-bundle-size.js`) that was missed when the limit moved 13 → 14 → 15 KB during PR #46 / PR #48. The release run for PR #48 failed against this stale 13 KB limit (measured 13.97 KB), blocking the rc.5 publish.

This bumps the release-time gate to match the rest of the project.

## Why this matters

PR #48 just merged with the new disabled-month/year feature. The Changesets release PR (#47) couldn't be auto-updated because the post-merge `release.yml` run errored out. Without this fix, the rc.5 publish stays blocked.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, the next release.yml run on main passes the bundle gate
- [ ] PR #47 gets auto-refreshed by the Changesets bot to include the rc.4 → rc.5 bump with both #46 and #48 changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)