### PR TITLE
fix(security): resolve fast-uri & babel systemjs plugin CVEs (closes #51)

### DIFF
--- a/.changeset/security-fast-uri-babel-systemjs.md
+++ b/.changeset/security-fast-uri-babel-systemjs.md
@@ -1,0 +1,14 @@
+---
+"@kalyx/react": patch
+"@kalyx/core": patch
+---
+
+Security: pin transitive `fast-uri` to `>=3.1.2` and `@babel/plugin-transform-modules-systemjs` to `>=7.29.4` via `pnpm.overrides`.
+
+Resolves three Code Scanning alerts on `pnpm-lock.yaml`:
+
+- `fast-uri@3.1.0` — [GHSA-v39h-62p7-jpjc](https://osv.dev/GHSA-v39h-62p7-jpjc) (CVE-2026-6322), first patched in `3.1.2`.
+- `fast-uri@3.1.0` — [GHSA-q3j6-qgpj-74h6](https://osv.dev/GHSA-q3j6-qgpj-74h6) (CVE-2026-6321), first patched in `3.1.1`.
+- `@babel/plugin-transform-modules-systemjs@7.29.0` — [GHSA-fv7c-fp4j-7gwp](https://osv.dev/GHSA-fv7c-fp4j-7gwp) (CVE-2026-44728), first patched in `7.29.4` on the 7.x line.
+
+All three packages are transitive build-time dependencies (ajv → fast-uri, Babel preset-env → systemjs plugin); no public API impact.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
 		"overrides": {
 			"serialize-javascript": ">=7.0.3",
 			"uuid": ">=14.0.0",
-			"postcss": ">=8.5.10"
+			"postcss": ">=8.5.10",
+			"fast-uri": ">=3.1.2",
+			"@babel/plugin-transform-modules-systemjs": ">=7.29.4"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   serialize-javascript: '>=7.0.3'
   uuid: '>=14.0.0'
   postcss: '>=8.5.10'
+  fast-uri: '>=3.1.2'
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
 
 importers:
 
@@ -631,8 +633,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4357,8 +4359,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -8207,7 +8209,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -8480,7 +8482,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -11591,7 +11593,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12808,7 +12810,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves all three open **Code Scanning** alerts on `pnpm-lock.yaml` and closes the automated audit issue #51.

| Package | Vulnerable | Fixed via override | Advisory |
|---|---|---|---|
| `fast-uri` | `3.1.0` | `>=3.1.2` | [GHSA-v39h-62p7-jpjc](https://osv.dev/GHSA-v39h-62p7-jpjc) (CVE-2026-6322) |
| `fast-uri` | `3.1.0` | `>=3.1.2` | [GHSA-q3j6-qgpj-74h6](https://osv.dev/GHSA-q3j6-qgpj-74h6) (CVE-2026-6321) |
| `@babel/plugin-transform-modules-systemjs` | `7.29.0` | `>=7.29.4` | [GHSA-fv7c-fp4j-7gwp](https://osv.dev/GHSA-fv7c-fp4j-7gwp) (CVE-2026-44728) |

All three are transitive build-time dependencies (`ajv → fast-uri`, Babel `preset-env → systemjs plugin`). No public API impact — changeset is a `patch` bump on both packages, consistent with the prior `security-postcss` pattern.

## Test plan

- [x] `pnpm install` — lockfile refreshed, both packages bumped (`fast-uri@3.1.2`, `@babel/plugin-transform-modules-systemjs@7.29.4`)
- [x] `pnpm typecheck` — green
- [x] `pnpm test:run` — 442 / 442 passing
- [x] `pnpm build` — green
- [x] `pnpm check-bundle` — 13.96 KB gzip (≤ 15 KB)
- [x] `pnpm exec osv-scanner --lockfile=pnpm-lock.yaml` — **No issues found**
- [ ] Confirm Code Scanning alerts auto-close once `release.yml` re-scans `main` after merge

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 보안 취약점을 해결하기 위해 빌드 시스템 종속성을 업데이트했습니다. 공개 API 및 사용자 대면 기능에는 변화가 없습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->