### PR TITLE
fix(security): bump next to resolve 13 OSV alerts (closes #54)

### DIFF
--- a/.changeset/security-next-16.md
+++ b/.changeset/security-next-16.md
@@ -1,0 +1,25 @@
+---
+"@kalyx/docs": patch
+---
+
+Security: bump `next` to `>=15.5.18` via `pnpm.overrides`, resolving 13 OSV alerts on the docs app's transitive `next@15.5.15` lockfile entry.
+
+OSV-detected advisories resolved (all on `next@15.5.15`):
+
+- GHSA-c4j6-fc7j-m34r (8.6)
+- GHSA-492v-c6pp-mqqv (8.1)
+- GHSA-267c-6grr-h53f (7.5)
+- GHSA-26hh-7cqf-hhc6 (7.5)
+- GHSA-36qx-fr4f-26g5 (7.5)
+- GHSA-8h8q-6873-q5fj (7.5)
+- GHSA-mg66-mrh9-m8jx (7.5)
+- GHSA-gx5p-jg67-6x7h (6.1)
+- GHSA-h64f-5h5j-jqjh (5.9)
+- GHSA-wfc6-r584-vfw7 (5.4)
+- GHSA-ffhc-5mcf-pf4q (4.7)
+- GHSA-3g8h-86w9-wvmq (3.7)
+- GHSA-vfv6-92ff-j949 (3.7)
+
+The override resolves to `next@16.2.6` (current latest) since the override is a lower bound. `apps/docs` peer declaration bumped to `^16.0.0` to reflect the actual resolved version. The `jsx` compiler option in `apps/docs/tsconfig.json` is updated to `react-jsx` and the `.next/dev/types/**/*.ts` include added — both required by Next 16's automatic typed-routes setup; `next-env.d.ts` is auto-regenerated to the v16 form.
+
+`@kalyx/react` / `@kalyx/core` are unaffected — `next` is a docs-app-only dependency. No public API change.

--- a/.changeset/security-next-16.md
+++ b/.changeset/security-next-16.md
@@ -22,9 +22,9 @@ OSV-detected advisories resolved on `next@15.5.15` (overridden to `>=15.5.18`, r
 
 Three additional dev-tree advisories surfaced after the Next 16 bump and are also pinned:
 
-- `brace-expansion@5.0.5` → `>=5.0.6` — [GHSA-jxxr-4gwj-5jf2](https://osv.dev/GHSA-jxxr-4gwj-5jf2) (6.5, DoS via untrimmed `max` option)
+- `brace-expansion@5.0.5` → `>=5.0.6` — [GHSA-jxxr-4gwj-5jf2](https://osv.dev/GHSA-jxxr-4gwj-5jf2) (6.5, DoS via untrimmed `max` option). Targeted to major 5 only (`"brace-expansion@5": ">=5.0.6"`) — the v1 / v2 lines coexist in the dep graph for older tooling and have a different, incompatible API.
 - `webpack-dev-server@5.2.3` → `>=5.2.4` — [GHSA-79cf-xcqc-c78w](https://osv.dev/GHSA-79cf-xcqc-c78w) (5.3, cross-origin source code exposure)
-- `ws@8.20.0` → `>=8.20.1` — [GHSA-58qx-3vcg-4xpx](https://osv.dev/GHSA-58qx-3vcg-4xpx) (4.4, `close()` implementation)
+- `ws@8.20.0` → `>=8.20.1` — [GHSA-58qx-3vcg-4xpx](https://osv.dev/GHSA-58qx-3vcg-4xpx) (4.4, `close()` implementation). Targeted to major 8 only (`"ws@8": ">=8.20.1"`) — the v7 line is unaffected and stays in place.
 
 All four packages are dev-time dependencies of the docs app (Next's webpack dev server and its transitives). `@kalyx/react` / `@kalyx/core` are unaffected. Next 16 also requires `apps/docs/tsconfig.json` `jsx` → `react-jsx` and the `.next/dev/types/**/*.ts` include; `next-env.d.ts` is auto-regenerated.
 

--- a/.changeset/security-next-16.md
+++ b/.changeset/security-next-16.md
@@ -2,9 +2,9 @@
 "@kalyx/docs": patch
 ---
 
-Security: bump `next` to `>=15.5.18` via `pnpm.overrides`, resolving 13 OSV alerts on the docs app's transitive `next@15.5.15` lockfile entry.
+Security: pin transitive `next`, `brace-expansion`, `webpack-dev-server`, and `ws` via `pnpm.overrides`, resolving the OSV alerts raised against the docs app's dev-server tree.
 
-OSV-detected advisories resolved (all on `next@15.5.15`):
+OSV-detected advisories resolved on `next@15.5.15` (overridden to `>=15.5.18`, resolves to `16.2.6`):
 
 - GHSA-c4j6-fc7j-m34r (8.6)
 - GHSA-492v-c6pp-mqqv (8.1)
@@ -20,6 +20,12 @@ OSV-detected advisories resolved (all on `next@15.5.15`):
 - GHSA-3g8h-86w9-wvmq (3.7)
 - GHSA-vfv6-92ff-j949 (3.7)
 
-The override resolves to `next@16.2.6` (current latest) since the override is a lower bound. `apps/docs` peer declaration bumped to `^16.0.0` to reflect the actual resolved version. The `jsx` compiler option in `apps/docs/tsconfig.json` is updated to `react-jsx` and the `.next/dev/types/**/*.ts` include added — both required by Next 16's automatic typed-routes setup; `next-env.d.ts` is auto-regenerated to the v16 form.
+Three additional dev-tree advisories surfaced after the Next 16 bump and are also pinned:
 
-`@kalyx/react` / `@kalyx/core` are unaffected — `next` is a docs-app-only dependency. No public API change.
+- `brace-expansion@5.0.5` → `>=5.0.6` — [GHSA-jxxr-4gwj-5jf2](https://osv.dev/GHSA-jxxr-4gwj-5jf2) (6.5, DoS via untrimmed `max` option)
+- `webpack-dev-server@5.2.3` → `>=5.2.4` — [GHSA-79cf-xcqc-c78w](https://osv.dev/GHSA-79cf-xcqc-c78w) (5.3, cross-origin source code exposure)
+- `ws@8.20.0` → `>=8.20.1` — [GHSA-58qx-3vcg-4xpx](https://osv.dev/GHSA-58qx-3vcg-4xpx) (4.4, `close()` implementation)
+
+All four packages are dev-time dependencies of the docs app (Next's webpack dev server and its transitives). `@kalyx/react` / `@kalyx/core` are unaffected. Next 16 also requires `apps/docs/tsconfig.json` `jsx` → `react-jsx` and the `.next/dev/types/**/*.ts` include; `next-env.d.ts` is auto-regenerated.
+
+No public API change.

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
 	},
 	"dependencies": {
 		"@kalyx/react": "workspace:*",
-		"next": "^15.0.0",
+		"next": "^16.0.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"
 	},

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -11,13 +11,13 @@
 		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"jsx": "preserve",
+		"jsx": "react-jsx",
 		"incremental": true,
 		"plugins": [{ "name": "next" }],
 		"paths": {
 			"@/*": ["./*"]
 		}
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
 	"exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -76,9 +76,9 @@
 			"fast-uri": ">=3.1.2",
 			"@babel/plugin-transform-modules-systemjs": ">=7.29.4",
 			"next": ">=15.5.18",
-			"brace-expansion": ">=5.0.6",
+			"brace-expansion@5": ">=5.0.6",
 			"webpack-dev-server": ">=5.2.4",
-			"ws": ">=8.20.1"
+			"ws@8": ">=8.20.1"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
 			"uuid": ">=14.0.0",
 			"postcss": ">=8.5.10",
 			"fast-uri": ">=3.1.2",
-			"@babel/plugin-transform-modules-systemjs": ">=7.29.4"
+			"@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+			"next": ">=15.5.18"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,10 @@
 			"postcss": ">=8.5.10",
 			"fast-uri": ">=3.1.2",
 			"@babel/plugin-transform-modules-systemjs": ">=7.29.4",
-			"next": ">=15.5.18"
+			"next": ">=15.5.18",
+			"brace-expansion": ">=5.0.6",
+			"webpack-dev-server": ">=5.2.4",
+			"ws": ">=8.20.1"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ overrides:
   fast-uri: '>=3.1.2'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   next: '>=15.5.18'
-  brace-expansion: '>=5.0.6'
+  brace-expansion@5: '>=5.0.6'
   webpack-dev-server: '>=5.2.4'
-  ws: '>=8.20.1'
+  ws@8: '>=8.20.1'
 
 importers:
 
@@ -3401,6 +3401,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3441,6 +3444,12 @@ packages:
   boxen@7.1.1:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -3695,6 +3704,9 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -7595,6 +7607,18 @@ packages:
 
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
@@ -11730,6 +11754,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.17: {}
@@ -11789,6 +11815,15 @@ snapshots:
       type-fest: 2.19.0
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -12040,6 +12075,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -14340,11 +14377,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 1.1.14
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 
@@ -16424,7 +16461,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 8.20.1
+      ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16603,6 +16640,8 @@ snapshots:
       is-typedarray: 1.0.0
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
+
+  ws@7.5.10: {}
 
   ws@8.20.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   postcss: '>=8.5.10'
   fast-uri: '>=3.1.2'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
+  next: '>=15.5.18'
 
 importers:
 
@@ -97,8 +98,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react
       next:
-        specifier: ^15.0.0
-        version: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: '>=15.5.18'
+        version: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -2218,53 +2219,53 @@ packages:
   '@napi-rs/wasm-runtime@1.0.7':
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
 
-  '@next/env@15.5.15':
-    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@15.5.15':
-    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.15':
-    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
-    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.5.15':
-    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.5.15':
-    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.5.15':
-    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
-    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.15':
-    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5636,9 +5637,9 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next@15.5.15:
-    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -10499,30 +10500,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.5.15': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@15.5.15':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.15':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.15':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.15':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.15':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.15':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.15':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.15':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/hashes@1.4.0': {}
@@ -14419,24 +14420,25 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.5.15(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 15.5.15
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
       postcss: 8.5.12
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.15
-      '@next/swc-darwin-x64': 15.5.15
-      '@next/swc-linux-arm64-gnu': 15.5.15
-      '@next/swc-linux-arm64-musl': 15.5.15
-      '@next/swc-linux-x64-gnu': 15.5.15
-      '@next/swc-linux-x64-musl': 15.5.15
-      '@next/swc-win32-arm64-msvc': 15.5.15
-      '@next/swc-win32-x64-msvc': 15.5.15
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ overrides:
   fast-uri: '>=3.1.2'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   next: '>=15.5.18'
+  brace-expansion: '>=5.0.6'
+  webpack-dev-server: '>=5.2.4'
+  ws: '>=8.20.1'
 
 importers:
 
@@ -3398,9 +3401,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3442,14 +3442,8 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
-
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3701,9 +3695,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -7504,8 +7495,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.3:
-    resolution: {integrity: sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==}
+  webpack-dev-server@5.2.4:
+    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -7605,20 +7596,8 @@ packages:
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9182,7 +9161,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0))
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@swc/helpers@0.5.15)(esbuild@0.28.0)
@@ -11751,8 +11730,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.17: {}
@@ -11813,16 +11790,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.13:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12059,7 +12027,7 @@ snapshots:
 
   compressible@2.0.18:
     dependencies:
-      mime-db: 1.52.0
+      mime-db: 1.54.0
 
   compression@1.8.1:
     dependencies:
@@ -12072,8 +12040,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -13591,7 +13557,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.0
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -14370,15 +14336,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 5.0.6
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -16458,7 +16424,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.10
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16476,7 +16442,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0)):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16505,7 +16471,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0))
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       webpack: 5.106.2(@swc/core@1.15.26(@swc/helpers@0.5.15))(esbuild@0.28.0)
     transitivePeerDependencies:
@@ -16638,9 +16604,7 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.10: {}
-
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

The 2026-05-18 weekly OSV scan ([Issue #54](https://github.com/jiji-hoon96/kalyx/issues/54)) flagged 13 CVE advisories against the docs app's transitive `next@15.5.15` lockfile entry. This PR pins `next` via `pnpm.overrides` so the lockfile picks up the latest patched release.

### Resolved advisories (all on `next@15.5.15`)

| OSV | CVSS |
|---|---|
| [GHSA-c4j6-fc7j-m34r](https://osv.dev/GHSA-c4j6-fc7j-m34r) | 8.6 |
| [GHSA-492v-c6pp-mqqv](https://osv.dev/GHSA-492v-c6pp-mqqv) | 8.1 |
| [GHSA-267c-6grr-h53f](https://osv.dev/GHSA-267c-6grr-h53f) | 7.5 |
| [GHSA-26hh-7cqf-hhc6](https://osv.dev/GHSA-26hh-7cqf-hhc6) | 7.5 |
| [GHSA-36qx-fr4f-26g5](https://osv.dev/GHSA-36qx-fr4f-26g5) | 7.5 |
| [GHSA-8h8q-6873-q5fj](https://osv.dev/GHSA-8h8q-6873-q5fj) | 7.5 |
| [GHSA-mg66-mrh9-m8jx](https://osv.dev/GHSA-mg66-mrh9-m8jx) | 7.5 |
| [GHSA-gx5p-jg67-6x7h](https://osv.dev/GHSA-gx5p-jg67-6x7h) | 6.1 |
| [GHSA-h64f-5h5j-jqjh](https://osv.dev/GHSA-h64f-5h5j-jqjh) | 5.9 |
| [GHSA-wfc6-r584-vfw7](https://osv.dev/GHSA-wfc6-r584-vfw7) | 5.4 |
| [GHSA-ffhc-5mcf-pf4q](https://osv.dev/GHSA-ffhc-5mcf-pf4q) | 4.7 |
| [GHSA-3g8h-86w9-wvmq](https://osv.dev/GHSA-3g8h-86w9-wvmq) | 3.7 |
| [GHSA-vfv6-92ff-j949](https://osv.dev/GHSA-vfv6-92ff-j949) | 3.7 |

### Changes

- `package.json`: add `"next": ">=15.5.18"` to `pnpm.overrides`. Resolves to `next@16.2.6` (current latest).
- `apps/docs/package.json`: bump `next` peer `^15.0.0` → `^16.0.0` to match the resolved version.
- `apps/docs/tsconfig.json`: set `jsx` → `react-jsx` and add `.next/dev/types/**/*.ts` to `include` (required by Next 16's auto-typed-routes).
- `apps/docs/next-env.d.ts`: auto-regenerated to the Next 16 form (file is marked "should not be edited").
- `.changeset/security-next-16.md`: patch bump for `@kalyx/docs` (private; no consumer impact).

### Impact

`next` is a docs-app-only dependency. `@kalyx/react` and `@kalyx/core` are **unaffected** — no public API change, no `peerDependencies` shift.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm test:run` ✅ (442/442)
- [x] `pnpm build` ✅ (apps/docs static export, apps/docs-site EN + KO)
- [x] `pnpm check-bundle` ✅ (13.96 KB ESM, 14.21 KB CJS — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 차세대 웹 프레임워크 의존성을 업데이트하여 공개된 보안 취약점 13개가 모두 해결되었습니다.
  * TypeScript 컴파일 설정을 최적화하여 개발 환경의 타입 생성 및 검증 정확성이 개선되었습니다.
  * 프로젝트 의존성 관리 설정을 강화하여 보안 및 버전 일관성이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->