### PR TITLE
feat(core): add programmatic filter variant to DisabledRule

### DIFF
--- a/.changeset/disabled-rule-filter.md
+++ b/.changeset/disabled-rule-filter.md
@@ -1,0 +1,24 @@
+---
+"@kalyx/react": minor
+"@kalyx/core": minor
+---
+
+`DisabledRule` gains a programmatic `filter` variant — pass any predicate `(iso: ISODateString) => boolean` to disable arbitrary days that don't fit the declarative `before` / `after` / `dayOfWeek` / `date` rules.
+
+```tsx
+const holidays = new Set([
+  '2026-01-01T00:00:00.000Z',
+  '2026-12-25T00:00:00.000Z',
+]);
+
+<DatePicker
+  disabled={[
+    { dayOfWeek: [0, 6] },                 // weekends
+    { filter: (iso) => holidays.has(iso) } // holidays
+  ]}
+>
+  …
+</DatePicker>
+```
+
+The new variant slots into the existing `isDateDisabled` evaluation (short-circuits on first match) and works with keyboard-navigation disabled-skip in `DatePicker.Calendar` / `RangePicker.Calendar` with no further changes. Equivalent to `react-datepicker`'s `filterDate` prop and MUI X DatePicker's `shouldDisableDate`. Bundle impact: 0 KB (still 13.96 KB ESM gzip).

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -126,6 +126,39 @@ describe('isDateDisabled — combined rules', () => {
   it('treats an empty rules array as all dates enabled', () => {
     expect(isDateDisabled('2026-01-15T00:00:00.000Z', [], adapter)).toBe(false);
   });
+
+  it('honors a programmatic filter rule', () => {
+    const holidays = new Set(['2026-01-01T00:00:00.000Z', '2026-12-25T00:00:00.000Z']);
+    const rules = [{ filter: (iso: string) => holidays.has(iso) }];
+    expect(isDateDisabled('2026-01-01T00:00:00.000Z', rules, adapter)).toBe(true);
+    expect(isDateDisabled('2026-12-25T00:00:00.000Z', rules, adapter)).toBe(true);
+    expect(isDateDisabled('2026-01-02T00:00:00.000Z', rules, adapter)).toBe(false);
+  });
+
+  it('combines filter with other rules (any match disables)', () => {
+    const rules = [{ dayOfWeek: [0, 6] }, { filter: (iso: string) => iso.startsWith('2026-07') }];
+    // 2026-07-15 = Wednesday — passes dayOfWeek, caught by filter
+    expect(isDateDisabled('2026-07-15T00:00:00.000Z', rules, adapter)).toBe(true);
+    // 2026-01-11 = Sunday — caught by dayOfWeek
+    expect(isDateDisabled('2026-01-11T00:00:00.000Z', rules, adapter)).toBe(true);
+    // 2026-01-12 = Monday, not July — neither rule matches
+    expect(isDateDisabled('2026-01-12T00:00:00.000Z', rules, adapter)).toBe(false);
+  });
+
+  it('flags filter-disabled cells in the calendar grid', () => {
+    // Disable every odd day of the month
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      disabled: [{ filter: (iso) => adapter.getDate(iso) % 2 === 1 }],
+    });
+    const currentMonthDays = weeks.flat().filter((d) => d.isCurrentMonth);
+    for (const day of currentMonthDays) {
+      if (day.dayNumber % 2 === 1) {
+        expect(day.isDisabled).toBe(true);
+      } else {
+        expect(day.isDisabled).toBe(false);
+      }
+    }
+  });
 });
 
 describe('minDate / maxDate', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,7 +17,8 @@ export type ISODateString = string;
  *   { before: '2026-01-01T00:00:00.000Z' }, // disable before Jan 1
  *   { after: '2026-12-31T00:00:00.000Z' },  // disable after Dec 31
  *   { date: '2026-06-15T00:00:00.000Z' },   // disable a specific date
- *   { dayOfWeek: [0, 6] },                   // disable weekends
+ *   { dayOfWeek: [0, 6] },                  // disable weekends
+ *   { filter: (iso) => holidays.has(iso) }, // programmatic filter
  * ];
  * ```
  */
@@ -25,7 +26,8 @@ export type DisabledRule =
   | { date: ISODateString }
   | { before: ISODateString }
   | { after: ISODateString }
-  | { dayOfWeek: number[] };
+  | { dayOfWeek: number[] }
+  | { filter: (iso: ISODateString) => boolean };
 
 /** Date range (RangePicker) */
 export interface DateRange {

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -176,6 +176,8 @@ export function isDateDisabled(iso: string, rules: DisabledRule[], adapter: Date
       if (adapter.isAfter(iso, rule.after)) return true;
     } else if ('dayOfWeek' in rule) {
       if (rule.dayOfWeek.includes(adapter.getDay(iso))) return true;
+    } else if ('filter' in rule) {
+      if (rule.filter(iso)) return true;
     }
   }
   return false;


### PR DESCRIPTION
## Summary

Adds a programmatic `{ filter: (iso) => boolean }` variant to `DisabledRule`, covering cases the declarative `before` / `after` / `dayOfWeek` / `date` rules can't express (holiday lists, business calendars, computed restrictions). Equivalent to:

- `react-datepicker` — [`filterDate`](https://github.com/Hacker0x01/react-datepicker/blob/main/docs/datepicker.md)
- MUI X DatePicker — [`shouldDisableDate`](https://mui.com/x/react-date-pickers/validation/)

## API

```tsx
const holidays = new Set([
  '2026-01-01T00:00:00.000Z',
  '2026-12-25T00:00:00.000Z',
]);

<DatePicker
  disabled={[
    { dayOfWeek: [0, 6] },                  // weekends (declarative)
    { filter: (iso) => holidays.has(iso) }  // holidays (programmatic)
  ]}
>
  <DatePicker.Input />
  <DatePicker.Popover>
    <DatePicker.Calendar />
  </DatePicker.Popover>
</DatePicker>
```

The filter is just another branch in the existing `isDateDisabled` evaluation (short-circuits on first match), so it composes with the other rules and inherits all downstream behavior — calendar grid `isDisabled` flag, click no-op, keyboard navigation skip in `DatePicker.Calendar` / `RangePicker.Calendar`, ARIA `aria-disabled`.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm test:run` ✅ (445/445 — +3 new filter cases)
- [x] `pnpm build` ✅
- [x] `pnpm check-bundle` ✅ (13.96 KB ESM gzip — unchanged)

New tests:
- `isDateDisabled — combined rules > honors a programmatic filter rule`
- `isDateDisabled — combined rules > combines filter with other rules (any match disables)`
- `isDateDisabled — combined rules > flags filter-disabled cells in the calendar grid`

## Migration

None — this is additive. Existing `DisabledRule[]` values continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)