### PR TITLE
feat(calendar): add showWeekNumber + fixedWeeks props

### DIFF
--- a/.changeset/calendar-week-number-fixed-weeks.md
+++ b/.changeset/calendar-week-number-fixed-weeks.md
@@ -1,0 +1,24 @@
+---
+"@kalyx/react": minor
+"@kalyx/core": minor
+---
+
+Two new `DatePicker.Calendar` / `RangePicker.Calendar` props plus an ISO-week utility:
+
+- **`showWeekNumber`** — render an ISO 8601 week-number column (1–53) on the left of the grid. The column uses `<th scope="row" aria-hidden="true">` so it doesn't participate in the WAI-ARIA grid data region; keyboard navigation across date cells is unchanged. New className slots: `weekNumberHeader`, `weekNumber`.
+- **`fixedWeeks`** — when true, always render 6 rows (42 cells) regardless of the month. Useful for popover layouts that need a stable height across month navigation.
+
+Both also accepted on `CalendarOptions` (the `getCalendarDays` core util gains `fixedWeeks`).
+
+New core export: **`getISOWeekNumber(iso)`** — pure UTC computation, no date-fns dep. Anchored to the Thursday of the week (so the same week always returns the same number regardless of `weekStartsOn`).
+
+```tsx
+<DatePicker value={date} onChange={setDate}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar showWeekNumber fixedWeeks />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+Bundle impact: +0.46 KB ESM gzip (13.96 → 14.42 KB). Still well under the 15 KB ceiling.

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getCalendarDays, isDateDisabled, minDate, maxDate } from '../utils/calendar.js';
+import {
+  getCalendarDays,
+  getISOWeekNumber,
+  isDateDisabled,
+  minDate,
+  maxDate,
+} from '../utils/calendar.js';
 import { DateFnsAdapter } from '../adapters/date-fns.js';
 
 const adapter = DateFnsAdapter;
@@ -77,6 +83,55 @@ describe('getCalendarDays — basic month grid', () => {
     const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter);
     const outsideDays = weeks.flat().filter((d) => !d.isCurrentMonth);
     expect(outsideDays.length).toBeGreaterThan(0);
+  });
+
+  it('returns 4–6 weeks depending on the month', () => {
+    // February 2026 (28 days, Sun start) fits in 5 weeks
+    const feb2026 = getCalendarDays('2026-02-01T00:00:00.000Z', adapter);
+    expect(feb2026.length).toBeGreaterThanOrEqual(4);
+    expect(feb2026.length).toBeLessThanOrEqual(5);
+  });
+
+  it('always emits 6 weeks when fixedWeeks is true', () => {
+    const fixed = getCalendarDays('2026-02-01T00:00:00.000Z', adapter, { fixedWeeks: true });
+    expect(fixed).toHaveLength(6);
+    for (const week of fixed) {
+      expect(week).toHaveLength(7);
+    }
+  });
+
+  it('fixedWeeks=true keeps total cell count at 42 even for short months', () => {
+    const fixed = getCalendarDays('2026-02-01T00:00:00.000Z', adapter, { fixedWeeks: true });
+    const totalCells = fixed.flat().length;
+    expect(totalCells).toBe(42);
+  });
+});
+
+describe('getISOWeekNumber', () => {
+  // ISO 8601 week semantics: weeks start Monday; week 1 is the week containing
+  // the year's first Thursday (equivalently, the week containing Jan 4).
+  it('returns 1 for Jan 1 2026 (Thursday, in ISO week 1 of 2026)', () => {
+    expect(getISOWeekNumber('2026-01-01T00:00:00.000Z')).toBe(1);
+  });
+
+  it('returns 53 for Dec 28 2026 (last full ISO week of 2026)', () => {
+    expect(getISOWeekNumber('2026-12-28T00:00:00.000Z')).toBe(53);
+  });
+
+  it('returns 52 of the prior year for Jan 1 2023 (Sunday, anchored to 2022-W52)', () => {
+    // Jan 1 2023 is a Sunday; the Thursday of its week is Dec 29 2022 → ISO week 52 of 2022
+    expect(getISOWeekNumber('2023-01-01T00:00:00.000Z')).toBe(52);
+  });
+
+  it('returns 1 for Jan 4 of any year (Jan 4 is always in ISO week 1)', () => {
+    expect(getISOWeekNumber('2024-01-04T00:00:00.000Z')).toBe(1);
+    expect(getISOWeekNumber('2025-01-04T00:00:00.000Z')).toBe(1);
+    expect(getISOWeekNumber('2026-01-04T00:00:00.000Z')).toBe(1);
+  });
+
+  it('handles the Feb 29 leap-day edge', () => {
+    // Feb 29 2024 is a Thursday → ISO week 9 of 2024
+    expect(getISOWeekNumber('2024-02-29T00:00:00.000Z')).toBe(9);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,13 @@ export type {
 
 export { DateFnsAdapter } from './adapters/date-fns.js';
 
-export { getCalendarDays, isDateDisabled, minDate, maxDate } from './utils/calendar.js';
+export {
+  getCalendarDays,
+  getISOWeekNumber,
+  isDateDisabled,
+  minDate,
+  maxDate,
+} from './utils/calendar.js';
 export { normalizeISO, parseInputValue } from './utils/date.js';
 export {
   setTime,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -119,4 +119,10 @@ export interface CalendarOptions {
    * midnight form while the grid iterates in UTC.
    */
   timezone?: string;
+  /**
+   * Always emit exactly six weeks (42 days). The default (`false`) emits 4–6 weeks
+   * depending on the month, breaking after the last week containing a current-month day.
+   * Setting `true` is useful for layouts that need a fixed-height grid.
+   */
+  fixedWeeks?: boolean;
 }

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -42,6 +42,7 @@ export function getCalendarDays(
     range,
     rangeHover,
     timezone,
+    fixedWeeks = false,
   } = options;
 
   const todayISO = today ?? adapter.today(timezone);
@@ -85,13 +86,34 @@ export function getCalendarDays(
 
     weeks.push(days);
 
-    // Stop if the next week has already moved into the next month
-    if (!adapter.isSameMonth(current, monthISO) && week >= 3) {
+    // Stop if the next week has already moved into the next month.
+    // `fixedWeeks` overrides this so the grid always renders 6 rows (42 cells).
+    if (!fixedWeeks && !adapter.isSameMonth(current, monthISO) && week >= 3) {
       break;
     }
   }
 
   return weeks;
+}
+
+/**
+ * Returns the ISO 8601 week number (1-53) of the given date. ISO weeks start on Monday;
+ * week 1 is the week containing the year's first Thursday. The computation works in UTC
+ * to match the calendar grid's iteration semantics.
+ *
+ * @example
+ * getISOWeekNumber('2026-01-01T00:00:00.000Z'); // 1 (Jan 1 2026 is a Thursday → ISO week 1)
+ * getISOWeekNumber('2026-12-31T00:00:00.000Z'); // 53
+ */
+export function getISOWeekNumber(iso: ISODateString): number {
+  const d = new Date(iso);
+  // Anchor to the Thursday of the same ISO week, which always falls in the "owning" year.
+  // ISO day numbering: Mon=1..Sun=7 (treat UTC Sunday's 0 as 7).
+  const utc = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const isoDay = utc.getUTCDay() || 7;
+  utc.setUTCDate(utc.getUTCDate() + 4 - isoDay);
+  const yearStart = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
+  return Math.ceil(((utc.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
 }
 
 /**

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
+  getISOWeekNumber,
   isDateDisabled,
   getWeekdayNames,
   formatMonthYear,
@@ -24,12 +25,27 @@ export interface DatePickerCalendarClassNames {
   dayDisabled?: string;
   dayOutsideMonth?: string;
   weekdayHeader?: string;
+  /** Header cell at the top of the week-number column. Rendered only when `showWeekNumber` is set. */
+  weekNumberHeader?: string;
+  /** Each row's week-number cell. Rendered only when `showWeekNumber` is set. */
+  weekNumber?: string;
 }
 
 export interface DatePickerCalendarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
   classNames?: DatePickerCalendarClassNames;
   /** Called when the title ("January 2026") is clicked. Useful for switching to Month/Year views. */
   onTitleClick?: () => void;
+  /**
+   * Render an ISO 8601 week-number column on the left of the grid (1–53).
+   * The column is a `<th scope="row">`; it doesn't participate in the WAI-ARIA grid
+   * data region, so keyboard navigation across the date cells is unaffected.
+   */
+  showWeekNumber?: boolean;
+  /**
+   * Always render 6 weeks (42 cells), even when the month fits in 4 or 5 rows. Useful for
+   * popover layouts that need a fixed height across month navigation.
+   */
+  fixedWeeks?: boolean;
 }
 
 /** Safe wrapper for formatFullDate — falls back to ISO string on error */
@@ -57,6 +73,8 @@ const srOnly: React.CSSProperties = {
 export function DatePickerCalendar({
   classNames,
   onTitleClick,
+  showWeekNumber = false,
+  fixedWeeks = false,
   ...props
 }: DatePickerCalendarProps) {
   const ctx = useDatePickerContext('DatePicker.Calendar');
@@ -78,9 +96,24 @@ export function DatePickerCalendar({
         focusedDate,
         disabled,
         timezone: displayTimezone,
+        fixedWeeks,
       }),
-    [viewMonth, adapter, weekStartsOn, ctx.value, focusedDate, disabled, displayTimezone],
+    [
+      viewMonth,
+      adapter,
+      weekStartsOn,
+      ctx.value,
+      focusedDate,
+      disabled,
+      displayTimezone,
+      fixedWeeks,
+    ],
   );
+
+  // For each row, derive the ISO week number from the Thursday cell — Thursday is always
+  // in the row's "owning" ISO week regardless of weekStartsOn, so this is stable across
+  // week-start configurations.
+  const thursdayIndex = weekStartsOn === 0 ? 4 : 3;
 
   const year = adapter.getYear(viewMonth);
   const month = adapter.getMonth(viewMonth);
@@ -177,10 +210,7 @@ export function DatePickerCalendar({
         // enabled day, capped at 42 attempts (one full grid) to avoid infinite loops
         // when every day in range is disabled.
         const skipStep =
-          e.key === 'ArrowLeft' ||
-          e.key === 'ArrowUp' ||
-          e.key === 'PageUp' ||
-          e.key === 'Home'
+          e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp' || e.key === 'Home'
             ? -1
             : 1;
         let attempts = 0;
@@ -250,6 +280,11 @@ export function DatePickerCalendar({
       >
         <thead>
           <tr role="row" aria-rowindex={1}>
+            {showWeekNumber ? (
+              <th scope="col" aria-hidden="true" className={classNames?.weekNumberHeader}>
+                #
+              </th>
+            ) : null}
             {weekdays.map((day, colIndex) => (
               <th
                 key={day.short}
@@ -272,6 +307,16 @@ export function DatePickerCalendar({
               aria-rowindex={weekIndex + 2}
               className={classNames?.gridRow}
             >
+              {showWeekNumber ? (
+                <th
+                  scope="row"
+                  aria-hidden="true"
+                  className={classNames?.weekNumber}
+                  data-week-number
+                >
+                  {getISOWeekNumber(week[thursdayIndex]!.isoString)}
+                </th>
+              ) : null}
               {week.map((day, colIndex) => {
                 const dayClasses =
                   [

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -698,6 +698,82 @@ describe('DatePicker — event callbacks', () => {
   });
 });
 
+describe('DatePicker.Calendar — showWeekNumber', () => {
+  it('renders a week-number column when showWeekNumber is true', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value="2026-01-15T00:00:00.000Z" onChange={vi.fn()}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar showWeekNumber />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    // Each row should now expose a th[data-week-number] cell
+    const weekCells = document.querySelectorAll('th[data-week-number]');
+    expect(weekCells.length).toBeGreaterThanOrEqual(4);
+    expect(weekCells.length).toBeLessThanOrEqual(6);
+
+    // The week containing Jan 15 2026 is ISO week 3 (Jan 12–18 is week 3)
+    const labels = Array.from(weekCells).map((c) => c.textContent);
+    expect(labels).toContain('3');
+  });
+
+  it('omits the week-number column by default', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value="2026-01-15T00:00:00.000Z" onChange={vi.fn()}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    expect(document.querySelectorAll('th[data-week-number]').length).toBe(0);
+  });
+});
+
+describe('DatePicker.Calendar — fixedWeeks', () => {
+  it('always renders 6 rows when fixedWeeks is true', async () => {
+    const user = userEvent.setup();
+    // February 2026 normally fits in 4-5 weeks
+    render(
+      <DatePicker value="2026-02-15T00:00:00.000Z" onChange={vi.fn()}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar fixedWeeks />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    // role="row" includes the thead row, so 6 weeks + 1 header = 7 rows
+    expect(screen.getAllByRole('row')).toHaveLength(7);
+  });
+
+  it('still emits 4–6 rows when fixedWeeks is false (default)', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value="2026-02-15T00:00:00.000Z" onChange={vi.fn()}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    const rows = screen.getAllByRole('row');
+    // thead row + 4–5 weeks
+    expect(rows.length).toBeGreaterThanOrEqual(5);
+    expect(rows.length).toBeLessThanOrEqual(6);
+  });
+});
+
 describe('DatePicker — Presets', () => {
   it('renders preset buttons inside a group', () => {
     render(

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
+  getISOWeekNumber,
   isDateDisabled,
   getWeekdayNames,
   formatMonthYear,
@@ -27,6 +28,10 @@ export interface RangePickerCalendarClassNames {
   dayRangeEnd?: string;
   dayInRange?: string;
   weekdayHeader?: string;
+  /** Header cell at the top of the week-number column. Rendered only when `showWeekNumber` is set. */
+  weekNumberHeader?: string;
+  /** Each row's week-number cell. Rendered only when `showWeekNumber` is set. */
+  weekNumber?: string;
 }
 
 /**
@@ -40,6 +45,16 @@ export interface RangePickerCalendarProps extends Omit<HTMLAttributes<HTMLDivEle
   classNames?: RangePickerCalendarClassNames;
   /** @default 'range' */
   selectionMode?: RangePickerCalendarSelectionMode;
+  /**
+   * Render an ISO 8601 week-number column on the left of the grid (1–53).
+   * The column is a `<th scope="row">`; it doesn't participate in the WAI-ARIA grid
+   * data region, so keyboard navigation across the date cells is unaffected.
+   */
+  showWeekNumber?: boolean;
+  /**
+   * Always render 6 weeks (42 cells), even when the month fits in 4 or 5 rows.
+   */
+  fixedWeeks?: boolean;
 }
 
 /** Safe wrapper for formatFullDate — falls back to ISO string on error */
@@ -66,6 +81,8 @@ const srOnly: React.CSSProperties = {
 export function RangePickerCalendar({
   classNames,
   selectionMode = 'range',
+  showWeekNumber = false,
+  fixedWeeks = false,
   ...props
 }: RangePickerCalendarProps) {
   const ctx = useRangePickerContext('RangePicker.Calendar');
@@ -97,9 +114,23 @@ export function RangePickerCalendar({
         range: value,
         rangeHover: hoverDate,
         timezone: displayTimezone,
+        fixedWeeks,
       }),
-    [viewMonth, adapter, weekStartsOn, focusedDate, disabled, value, hoverDate, displayTimezone],
+    [
+      viewMonth,
+      adapter,
+      weekStartsOn,
+      focusedDate,
+      disabled,
+      value,
+      hoverDate,
+      displayTimezone,
+      fixedWeeks,
+    ],
   );
+
+  // ISO week number anchored to the row's Thursday — see DatePicker/Calendar.tsx for rationale.
+  const thursdayIndex = weekStartsOn === 0 ? 4 : 3;
 
   const year = adapter.getYear(viewMonth);
   const month = adapter.getMonth(viewMonth);
@@ -291,6 +322,11 @@ export function RangePickerCalendar({
       >
         <thead>
           <tr role="row" aria-rowindex={1}>
+            {showWeekNumber ? (
+              <th scope="col" aria-hidden="true" className={classNames?.weekNumberHeader}>
+                #
+              </th>
+            ) : null}
             {weekdays.map((day, colIndex) => (
               <th
                 key={day.short}
@@ -313,6 +349,16 @@ export function RangePickerCalendar({
               aria-rowindex={weekIndex + 2}
               className={classNames?.gridRow}
             >
+              {showWeekNumber ? (
+                <th
+                  scope="row"
+                  aria-hidden="true"
+                  className={classNames?.weekNumber}
+                  data-week-number
+                >
+                  {getISOWeekNumber(week[thursdayIndex]!.isoString)}
+                </th>
+              ) : null}
               {week.map((day, colIndex) => {
                 const dayClasses =
                   [


### PR DESCRIPTION
## Summary

Two new props on `DatePicker.Calendar` and `RangePicker.Calendar` that close gaps against react-day-picker / react-datepicker, plus an exported ISO-week utility.

### Props

| Prop | Default | Description |
|---|---|---|
| `showWeekNumber` | `false` | Render an ISO 8601 week-number column (1–53) on the left of the grid |
| `fixedWeeks` | `false` | Always render 6 rows (42 cells), regardless of the calendar month |

```tsx
<DatePicker value={date} onChange={setDate}>
  <DatePicker.Input />
  <DatePicker.Popover>
    <DatePicker.Calendar showWeekNumber fixedWeeks />
  </DatePicker.Popover>
</DatePicker>
```

New `classNames` slots: `weekNumberHeader` and `weekNumber`.

`CalendarOptions` (the `getCalendarDays` core util) gains the same `fixedWeeks` flag for headless hook consumers.

### New core export: `getISOWeekNumber(iso)`

Pure UTC computation, no date-fns dependency. Anchored on the Thursday of the row so the result is stable across `weekStartsOn=0` (Sunday) and `weekStartsOn=1` (Monday).

```ts
import { getISOWeekNumber } from '@kalyx/core';
getISOWeekNumber('2026-01-01T00:00:00.000Z'); // 1
getISOWeekNumber('2023-01-01T00:00:00.000Z'); // 52  (anchored to 2022-W52)
```

### Accessibility

The week-number column renders as `<th scope="row" aria-hidden="true">` outside the WAI-ARIA grid data region:
- `aria-colcount` on the table remains `7`.
- `aria-colindex` on date cells remains `1`–`7`.
- Keyboard navigation across date cells is unchanged.

### Bundle impact

13.96 → 14.42 KB ESM gzip (+0.46 KB). 0.58 KB headroom remaining vs the 15 KB ceiling.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm test:run` ✅ (454/454 — +12 new cases)
- [x] `pnpm build` ✅
- [x] `pnpm check-bundle` ✅ (14.42 KB ESM gzip)

New tests:
- `getISOWeekNumber` — 5 cases (Jan 1 2026 = W1, Dec 28 2026 = W53, Jan 1 2023 → 2022-W52, Jan 4 anchor, leap-day Feb 29 2024 = W9)
- `getCalendarDays` — `fixedWeeks` row count + total-cell-count cases
- `DatePicker.Calendar` — `showWeekNumber` column presence, default-off, `fixedWeeks` row count

## Migration

None — both props default to `false` so existing usage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)