### PR TITLE
chore(tsup): sync onSuccess bundle target 13 → 15 KB to match CI gate

### DIFF
--- a/.changeset/tsup-target-sync-15kb.md
+++ b/.changeset/tsup-target-sync-15kb.md
@@ -1,0 +1,7 @@
+---
+"@kalyx/react": patch
+---
+
+Internal: sync the `tsup` onSuccess bundle-size budget from `13 KB` to `15 KB` so the per-build warning matches the actual CI gate (`scripts/check-bundle-size.js`, `pr-check.yml`, `release.yml`). No runtime change; the published artifact is byte-identical.
+
+This was a leftover from the 13 → 14 → 15 KB ceiling raises during RC (PR #46 / PR #48); only the tsup-side TARGET_KB was missed during those bumps, so local `pnpm build` printed a spurious `⚠️` even though CI passed.

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
 	async onSuccess() {
 		const { gzipSync } = await import("zlib");
 		const { readFileSync, writeFileSync } = await import("fs");
-		const TARGET_KB = 13;
+		// Mirror scripts/check-bundle-size.js + .github/workflows/pr-check.yml + release.yml.
+		// Raised from 12 → 13 → 14 → 15 KB across RC milestones as features landed
+		// (CLAUDE.md §2 records each bump's rationale). Keep all four sources in sync.
+		const TARGET_KB = 15;
 		const outputs = [["ESM", "dist/index.js"], ["CJS", "dist/index.cjs"]] as const;
 		for (const [label, file] of outputs) {
 			try {


### PR DESCRIPTION
## Summary

The bundle-size ceiling was raised from `12 → 13 → 14 → 15 KB` across the RC milestones (PR #46, PR #48), and the CI scripts plus workflows track it correctly:

- `scripts/check-bundle-size.js` — 15 KB
- `.github/workflows/pr-check.yml` (Bundle Size job) — 15 KB
- `.github/workflows/release.yml` (release gate) — 15 KB

But the tsup `onSuccess` hook's `TARGET_KB` constant was missed during those bumps, so local `pnpm build` printed a spurious `⚠️` even though CI was green:

```
⚠️ [ESM] gzip: 14.42KB (목표: ≤13KB)
⚠️ [CJS] gzip: 14.84KB (목표: ≤13KB)
```

This PR syncs `TARGET_KB` to 15 and adds an inline comment listing the four locations that must move in lockstep, so future ceiling moves don't drift again.

## Test plan

- [x] `pnpm --filter @kalyx/react build` ✅ — now prints `✅ [ESM] gzip: 14.42KB (목표: ≤15KB)` and `✅ [CJS] gzip: 14.84KB (목표: ≤15KB)`.
- [x] Published artifact byte-identical (this only changes the dev-time log string and a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)