### PR TITLE
docs(readme): sync bundle size badge/section to v1.0.0-rc.7

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-13.60KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-14.42KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -87,7 +87,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` v1.0.0-rc.4 → **13.60 KB** gzip (ESM) / **14.07 KB** (CJS). CI 한계 ≤ 15 KB.
+`@kalyx/react` v1.0.0-rc.7 → **14.42 KB** gzip (ESM) / **14.84 KB** (CJS). CI 한계 ≤ 15 KB.
 
 ## 지원 환경
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-13.60KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-14.42KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -87,7 +87,7 @@ API reference, recipes (Tailwind / shadcn / React Hook Form), and migration guid
 
 ## Bundle
 
-`@kalyx/react` v1.0.0-rc.4 → **13.60 KB** gzip (ESM) / **14.07 KB** (CJS). CI gate: ≤ 15 KB.
+`@kalyx/react` v1.0.0-rc.7 → **14.42 KB** gzip (ESM) / **14.84 KB** (CJS). CI gate: ≤ 15 KB.
 
 ## Browser support
 


### PR DESCRIPTION
## Summary

The badge and bundle section in `README.md` / `README.ko.md` were stuck on rc.4 numbers (13.60 KB / 14.07 KB). Update to the rc.7 measurements: **14.42 KB ESM** / **14.84 KB CJS** gzip.

The increase is from features that landed during RC:
- **rc.3** — WAI-ARIA grid keyboard navigation across the four 3×4 picker grids (+1.4 KB)
- **rc.4** — MonthPicker / YearPicker disabled-by-`before`/`after` rules
- **rc.7** — `showWeekNumber` + `fixedWeeks` + `getISOWeekNumber` (+0.46 KB; PR #57)

All still well within the 15 KB CI ceiling.

## Test plan

- [x] EN + KO READMEs updated in lockstep.
- [x] Numbers verified against the current `pnpm check-bundle` output on `main` (14.42 / 14.84 KB).
- [x] No source / API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)