### PR TITLE
feat(timepicker): add filterTime callback prop

### DIFF
--- a/.changeset/timepicker-filter-time.md
+++ b/.changeset/timepicker-filter-time.md
@@ -1,0 +1,29 @@
+---
+"@kalyx/react": minor
+---
+
+`TimePicker.Root` gains a programmatic **`filterTime`** prop — `(hours: number, minutes: number) => boolean` returning `true` for any slot that should be unselectable. Equivalent to `react-datepicker`'s `filterTime` and MUI X's `shouldDisableTime`, covering use cases the static `step` prop can't (business-hours-only, lunch breaks, blackout slots, per-day variations).
+
+```tsx
+<TimePicker
+  value={time}
+  onChange={setTime}
+  step={15}
+  // Business hours only: 09:00–11:45 and 13:00–17:45 (no lunch slot)
+  filterTime={(h, m) => h < 9 || h >= 18 || (h === 12)}
+>
+  <TimePicker.Input />
+  <TimePicker.HourList />
+  <TimePicker.MinuteList />
+</TimePicker>
+```
+
+Behavior:
+
+- **`MinuteList`** — minutes for which `filterTime(currentHour, minute)` returns `true` get `aria-disabled="true"` and reject click/Enter.
+- **`HourList`** — an hour is marked `aria-disabled="true"` only when `filterTime` returns `true` for **every** step minute within it. Hours with at least one open minute remain selectable.
+- 12-hour mode — the predicate always receives 24-hour values (`0`–`23`) regardless of the picker's display format.
+
+**Note**: `DateTimePicker` does not yet wire this through — combine `DatePicker.Root` + `TimePicker.Root` manually if you need both date and time-slot filtering in the same picker.
+
+Bundle ceiling raised 15 → 16 KB (PR #N follows the 12→13→14→15 cadence — each raise tied to a documented feature; CLAUDE.md §2 records the chain). Measured 15.01 KB ESM / 15.16 KB CJS at this commit, ~4× smaller than react-datepicker.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -80,7 +80,7 @@ jobs:
           retention-days: 1
 
   bundle-size:
-    name: Bundle Size (≤15KB gzip)
+    name: Bundle Size (≤16KB gzip)
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -98,7 +98,7 @@ jobs:
         run: |
           BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
           KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=15
+          MAX=16
           echo "gzip_kb=$KB" >> $GITHUB_OUTPUT
           echo "📦 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
           if (( $(echo "$KB > $MAX" | bc -l) )); then
@@ -112,7 +112,7 @@ jobs:
         with:
           script: |
             const kb   = '${{ steps.check.outputs.gzip_kb }}';
-            const ok   = parseFloat(kb) <= 15;
+            const ok   = parseFloat(kb) <= 16;
             const icon = ok ? '✅' : '❌';
             const body = [
 
@@ -120,7 +120,7 @@ jobs:
               '| | gzip |',
               '|---|---|',
               `| **현재** | **${kb}KB** |`,
-              `| 목표 | ≤ 15KB |`,
+              `| 목표 | ≤ 16KB |`,
               '',
               ok
                 ? '번들 크기가 목표 이내입니다.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
           KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=15
+          MAX=16
           echo "📦 릴리즈 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
           if (( $(echo "$KB > $MAX" | bc -l) )); then
             echo "❌ 번들 크기 ${MAX}KB 초과 — 릴리즈 중단"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Ark UI가 포기한 TimePicker 통합
 | 스타일링 | Zero CSS (Headless) | CSS 충돌 원천 차단 |
 | 날짜 코어 | Adapter 패턴 + date-fns 기본 (v1.1에서 `@kalyx/adapter-date-fns`로 분리 예정 — [§14](#14-현재-이니셔티브-2026-04-기준)) | Temporal API 전환 대비, 사용자가 dayjs/luxon 선택 가능 |
 | 포지셔닝 | Floating UI | 3KB, SSR 안전, Popper.js 후계자 |
-| 번들 목표 | **≤ 15KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향 |
+| 번들 목표 | **≤ 16KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향, v1.0-rc.8 TimePicker `filterTime` 프로그래밍 콜백 추가하면서 15 → 16KB 상향 |
 | 테스트 | Vitest + Testing Library + jest-axe | |
 | 빌드 | tsup (ESM + CJS 이중 출력) | |
 | 모노레포 | pnpm workspaces | |

--- a/packages/react/src/components/TimePicker/HourList.tsx
+++ b/packages/react/src/components/TimePicker/HourList.tsx
@@ -26,7 +26,7 @@ export interface TimePickerHourListProps extends Omit<
  */
 export function TimePickerHourList({ classNames, ...props }: TimePickerHourListProps) {
   const ctx = useTimePickerContext('TimePicker.HourList');
-  const { format, currentTime, isDisabled, isReadOnly } = ctx;
+  const { format, step, currentTime, isDisabled, isReadOnly, filterTime } = ctx;
 
   // Stable across renders unless `format` changes — useListboxNavigation
   // identity-compares its `items` array internally.
@@ -37,14 +37,43 @@ export function TimePickerHourList({ classNames, ...props }: TimePickerHourListP
 
   const currentPeriod = format === '12h' ? to12Hour(currentTime.hours).period : null;
 
+  // An hour is fully disabled only when every step minute within it is rejected by `filterTime`.
+  // Pre-compute the 24-bit mask once per filterTime/step change; per-render hour lookups are O(1).
+  const fullyDisabledHours24 = useMemo(() => {
+    if (!filterTime) return null;
+    const disabled = new Set<number>();
+    for (let h = 0; h < 24; h++) {
+      let allRejected = true;
+      for (let m = 0; m < 60; m += step) {
+        if (!filterTime(h, m)) {
+          allRejected = false;
+          break;
+        }
+      }
+      if (allRejected) disabled.add(h);
+    }
+    return disabled;
+  }, [filterTime, step]);
+
+  const isHourDisabled = useCallback(
+    (hourDisplay: number) => {
+      if (!fullyDisabledHours24) return false;
+      const hours24 =
+        format === '12h' && currentPeriod ? to24Hour(hourDisplay, currentPeriod) : hourDisplay;
+      return fullyDisabledHours24.has(hours24);
+    },
+    [fullyDisabledHours24, format, currentPeriod],
+  );
+
   const handleSelect = useCallback(
     (hourDisplay: number) => {
       if (isDisabled || isReadOnly) return;
+      if (isHourDisabled(hourDisplay)) return;
       const hours24 =
         format === '12h' && currentPeriod ? to24Hour(hourDisplay, currentPeriod) : hourDisplay;
       ctx.setTime({ hours: hours24 });
     },
-    [format, currentPeriod, ctx, isDisabled, isReadOnly],
+    [format, currentPeriod, ctx, isDisabled, isReadOnly, isHourDisabled],
   );
 
   const { listRef, handleKeyDown } = useListboxNavigation({
@@ -64,6 +93,7 @@ export function TimePickerHourList({ classNames, ...props }: TimePickerHourListP
     >
       {hours.map((hour) => {
         const isSelected = hour === selectedHourDisplay;
+        const isHourFullyDisabled = isHourDisabled(hour);
         const optionClass =
           [classNames?.option, isSelected && classNames?.optionSelected]
             .filter(Boolean)
@@ -74,7 +104,7 @@ export function TimePickerHourList({ classNames, ...props }: TimePickerHourListP
             key={hour}
             role="option"
             aria-selected={isSelected}
-            aria-disabled={isDisabled || undefined}
+            aria-disabled={isDisabled || isHourFullyDisabled || undefined}
             aria-label={ctx.labels.hourOption(hour)}
             data-selected={isSelected || undefined}
             tabIndex={isSelected ? 0 : -1}

--- a/packages/react/src/components/TimePicker/MinuteList.tsx
+++ b/packages/react/src/components/TimePicker/MinuteList.tsx
@@ -23,18 +23,27 @@ export interface TimePickerMinuteListProps extends Omit<
  */
 export function TimePickerMinuteList({ classNames, ...props }: TimePickerMinuteListProps) {
   const ctx = useTimePickerContext('TimePicker.MinuteList');
-  const { step, currentTime, isDisabled, isReadOnly } = ctx;
+  const { step, currentTime, isDisabled, isReadOnly, filterTime } = ctx;
 
   // Stable across renders unless `step` changes — useListboxNavigation
   // identity-compares its `items` array internally.
   const minutes = useMemo(() => generateMinutes(step), [step]);
 
+  const isMinuteDisabled = useCallback(
+    (minute: number) => {
+      if (!filterTime) return false;
+      return filterTime(currentTime.hours, minute);
+    },
+    [filterTime, currentTime.hours],
+  );
+
   const handleSelect = useCallback(
     (minute: number) => {
       if (isDisabled || isReadOnly) return;
+      if (isMinuteDisabled(minute)) return;
       ctx.setTime({ minutes: minute });
     },
-    [ctx, isDisabled, isReadOnly],
+    [ctx, isDisabled, isReadOnly, isMinuteDisabled],
   );
 
   const { listRef, handleKeyDown } = useListboxNavigation({
@@ -54,6 +63,7 @@ export function TimePickerMinuteList({ classNames, ...props }: TimePickerMinuteL
     >
       {minutes.map((minute) => {
         const isSelected = minute === currentTime.minutes;
+        const isMinuteFullyDisabled = isMinuteDisabled(minute);
         const optionClass =
           [classNames?.option, isSelected && classNames?.optionSelected]
             .filter(Boolean)
@@ -64,7 +74,7 @@ export function TimePickerMinuteList({ classNames, ...props }: TimePickerMinuteL
             key={minute}
             role="option"
             aria-selected={isSelected}
-            aria-disabled={isDisabled || undefined}
+            aria-disabled={isDisabled || isMinuteFullyDisabled || undefined}
             aria-label={ctx.labels.minuteOption(minute)}
             data-selected={isSelected || undefined}
             tabIndex={isSelected ? 0 : -1}

--- a/packages/react/src/components/TimePicker/Root.tsx
+++ b/packages/react/src/components/TimePicker/Root.tsx
@@ -47,6 +47,13 @@ export interface TimePickerRootProps {
   disabled?: boolean;
   /** Read-only */
   readOnly?: boolean;
+  /**
+   * Programmatic per-slot disable predicate. Returns `true` for any `(hours, minutes)` pair
+   * that should be unselectable. Equivalent to react-datepicker's `filterTime`. Use cases:
+   * business hours, lunch breaks, blackout slots. Hours are disabled only when the predicate
+   * returns `true` for every step within the hour.
+   */
+  filterTime?: (hours: number, minutes: number) => boolean;
   /** Override ARIA labels (defaults to English) */
   labels?: Partial<TimePickerLabels>;
   /** Child components */
@@ -68,6 +75,7 @@ export function TimePickerRoot({
   displayTimezone,
   disabled = false,
   readOnly = false,
+  filterTime,
   labels: labelsProp,
   children,
 }: TimePickerRootProps) {
@@ -118,6 +126,7 @@ export function TimePickerRoot({
       currentTime,
       pickerId,
       labels: mergedLabels,
+      filterTime,
     }),
     [
       currentValue,
@@ -131,6 +140,7 @@ export function TimePickerRoot({
       currentTime,
       pickerId,
       mergedLabels,
+      filterTime,
     ],
   );
 

--- a/packages/react/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.test.tsx
@@ -363,6 +363,104 @@ describe('TimePicker — disabled state', () => {
   });
 });
 
+describe('TimePicker — filterTime', () => {
+  it('marks aria-disabled on minutes rejected by filterTime', () => {
+    // Disable minute 30 only — visible per-minute disable
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={vi.fn()}
+        filterTime={(_h, m) => m === 30}
+      >
+        <TimePicker.HourList />
+        <TimePicker.MinuteList />
+      </TimePicker>,
+    );
+
+    const minute30 = screen.getByRole('option', { name: '30 minutes' });
+    expect(minute30).toHaveAttribute('aria-disabled', 'true');
+    const minute0 = screen.getByRole('option', { name: '0 minutes' });
+    expect(minute0).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('blocks selection when a filtered minute is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={onChange}
+        filterTime={(_h, m) => m === 30}
+      >
+        <TimePicker.MinuteList />
+      </TimePicker>,
+    );
+
+    await user.click(screen.getByRole('option', { name: '30 minutes' }));
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('option', { name: '45 minutes' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks an hour as fully disabled when every step minute is rejected', () => {
+    // Block every minute of hour 12 (step=15 → minutes 0/15/30/45)
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={vi.fn()}
+        step={15}
+        filterTime={(h) => h === 12}
+      >
+        <TimePicker.HourList />
+      </TimePicker>,
+    );
+
+    const hour12 = screen.getByRole('option', { name: '12 hours' });
+    expect(hour12).toHaveAttribute('aria-disabled', 'true');
+    const hour11 = screen.getByRole('option', { name: '11 hours' });
+    expect(hour11).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('leaves an hour enabled when only some of its step minutes are blocked', () => {
+    // Block only minute 30 — hour 14 still has 0, 15, 45 available
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={vi.fn()}
+        step={15}
+        filterTime={(_h, m) => m === 30}
+      >
+        <TimePicker.HourList />
+      </TimePicker>,
+    );
+
+    const hour14 = screen.getByRole('option', { name: '14 hours' });
+    expect(hour14).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('blocks clicks on hours that are fully disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={onChange}
+        step={15}
+        filterTime={(h) => h === 12}
+      >
+        <TimePicker.HourList />
+      </TimePicker>,
+    );
+
+    await user.click(screen.getByRole('option', { name: '12 hours' }));
+    expect(onChange).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('option', { name: '11 hours' }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('TimePicker — context errors', () => {
   it('throws when Input is used without Root', () => {
     expect(() => {

--- a/packages/react/src/context/TimePickerContext.ts
+++ b/packages/react/src/context/TimePickerContext.ts
@@ -29,6 +29,13 @@ export interface TimePickerContextValue {
   pickerId: string;
   /** ARIA labels */
   labels: TimePickerLabels;
+  /**
+   * Programmatic per-slot disable predicate. Returns `true` for any (hour, minute) pair that
+   * should be unselectable. Equivalent to react-datepicker's `filterTime` prop. Use cases:
+   * business hours, lunch breaks, blackout slots. The hour-list disables a row only when the
+   * predicate returns `true` for *every* step in that hour.
+   */
+  filterTime?: (hours: number, minutes: number) => boolean;
 }
 
 export const TimePickerContext = createContext<TimePickerContextValue | null>(null);

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -22,9 +22,9 @@ export default defineConfig({
 		const { gzipSync } = await import("zlib");
 		const { readFileSync, writeFileSync } = await import("fs");
 		// Mirror scripts/check-bundle-size.js + .github/workflows/pr-check.yml + release.yml.
-		// Raised from 12 → 13 → 14 → 15 KB across RC milestones as features landed
+		// Raised from 12 → 13 → 14 → 15 → 16 KB across RC milestones as features landed
 		// (CLAUDE.md §2 records each bump's rationale). Keep all four sources in sync.
-		const TARGET_KB = 15;
+		const TARGET_KB = 16;
 		const outputs = [["ESM", "dist/index.js"], ["CJS", "dist/index.cjs"]] as const;
 		for (const [label, file] of outputs) {
 			try {

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -13,8 +13,12 @@ import { readFileSync, statSync } from "fs";
 // MonthPicker.Grid, YearPicker.Grid). 14KB → 15KB once `before`/`after`
 // rule based fully-disabled-month/year detection (+ click-block + keyboard
 // skip-disabled) was added to MonthPicker.Grid and YearPicker.Grid in
-// v1.0-rc.4. Still ~3× smaller than react-datepicker (~40KB).
-const TARGET_KB = 15;
+// v1.0-rc.4. 15KB → 16KB for `TimePicker.filterTime` — programmatic
+// per-slot disable predicate covering business-hours / lunch-break /
+// blackout-slot use cases, closing the gap with react-datepicker's
+// `filterTime` and MUI X's `shouldDisableTime` (PR following this comment).
+// Still ~4× smaller than react-datepicker (~40KB).
+const TARGET_KB = 16;
 
 const BUNDLES = [
 	{ label: "ESM", path: "packages/react/dist/index.js" },


### PR DESCRIPTION
> **Draft** — CI's Bundle Size gate (`.github/workflows/pr-check.yml`) still hard-codes `MAX=15` so this PR fails that single check until the gate is bumped to 16. The workflow file change requires a `workflow`-scoped PAT, which the automated session pushing this branch does not currently have. Two paths forward — see "How to land" below.

## Summary

Adds `TimePicker.Root#filterTime` — a programmatic `(hours: number, minutes: number) => boolean` predicate marking arbitrary slots unselectable. Closes the last P1 selection-control gap from the [2026-05-18 audit](https://github.com/jiji-hoon96/kalyx/blob/main) (mirrors react-datepicker's `filterTime` and MUI X's `shouldDisableTime`). Covers the cases the static `step` prop can't — business hours, lunch breaks, blackout slots, per-day variations.

```tsx
<TimePicker
  value={time}
  onChange={setTime}
  step={15}
  // 09:00–11:45 and 13:00–17:45; no noon hour
  filterTime={(h) => h < 9 || h >= 18 || h === 12}
>
  <TimePicker.Input />
  <TimePicker.HourList />
  <TimePicker.MinuteList />
</TimePicker>
```

### Behavior

- **`MinuteList`** — `aria-disabled="true"` on minutes the predicate rejects; click / Enter no-op.
- **`HourList`** — an hour is `aria-disabled` only when the predicate rejects **every** step-minute within it. Hours with at least one open minute remain selectable. (Pre-computed once per `filterTime`/`step` change → O(1) per render.)
- **12-hour mode** — the predicate always receives 24-hour values; the conversion is internal.
- **`DateTimePicker`** is intentionally not wired in this PR — see Trade-offs.

### Bundle

| | ESM gzip | CJS gzip |
|---|---|---|
| Before (rc.7) | 14.42 KB | 14.84 KB |
| After | 15.01 KB | 15.16 KB |
| Delta | **+0.59 KB** | +0.32 KB |

Continues the documented 12 → 13 → 14 → 15 → **16 KB** ceiling sequence (CLAUDE.md §2), each tied to a real capability. Still ~4× smaller than react-datepicker. Already updated in `scripts/check-bundle-size.js` and `packages/react/tsup.config.ts`; the matching change for `.github/workflows/pr-check.yml` and `.github/workflows/release.yml` is pending the workflow scope.

### Trade-offs

- `useListboxNavigation` keyboard-skip on disabled cells was prototyped (≈ 0.2 KB) but reverted — the user can still tab/arrow onto a disabled minute; click/Enter is then a no-op. Matches react-datepicker behavior. Will revisit when the tree-shake split lands and frees headroom.
- `DateTimePicker.Root` filterTime threading also reverted to stay within the 16 KB ceiling. Combine `DatePicker.Root` + `TimePicker.Root` manually for now.
- `data-disabled` attributes and an `optionDisabled` className slot were prototyped and removed for the same reason — style via `[aria-disabled="true"]` CSS selector instead.

### How to land

**A — bump the CI gate (recommended)**: refresh the GH PAT with the `workflow` scope (`gh auth refresh -s workflow`), then a one-line patch flipping `MAX=15` → `MAX=16` in `pr-check.yml` (line ~104) and `release.yml` (line ~52). This PR then turns green and merges normally.

**B — defer to v1.1**: close this draft, keep filterTime as a v1.1 task. Doc audit, README, and changelog already reflect it as a v1.0 gap; v1.1's adapter-extraction work will also include the tree-shake entry split, after which the 15 KB ceiling has natural headroom again.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm test:run` ✅ — 5 new TimePicker cases, 462 total
- [x] `pnpm build` ✅
- [x] `node scripts/check-bundle-size.js` ✅ (15.01 KB ≤ 16 KB target)
- [ ] CI Bundle Size gate — expected to fail until workflow gate is bumped to 16 (see "How to land")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **TimePicker에 시간 필터링 기능 추가**
  * `filterTime` 프로퍼티를 통해 특정 시간과 분의 조합을 프로그래밍 방식으로 선택 불가능하게 설정할 수 있습니다.
  * 한 시간의 모든 가능한 분이 필터링될 경우, 해당 시간 옵션도 자동으로 비활성화됩니다.

## 기타

* 번들 크기 제한 기준이 16KB(gzip)로 상향됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->