### PR TITLE
chore(ci): upgrade JS-based actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/e2e-and-docs.yml
+++ b/.github/workflows/e2e-and-docs.yml
@@ -21,9 +21,9 @@ jobs:
         browser: [chromium, firefox, webkit]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -42,7 +42,7 @@ jobs:
 
       - name: 실패 리포트 업로드
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ matrix.browser }}
           path: playwright-report/

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,9 +14,9 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -27,9 +27,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -44,9 +44,9 @@ jobs:
         node: [20, 22]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -64,16 +64,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: dist 아티팩트 보관 (bundle-size job 공유)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ github.run_id }}
           path: packages/react/dist/
@@ -87,9 +87,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: dist 다운로드
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-${{ github.run_id }}
           path: packages/react/dist/
@@ -108,7 +108,7 @@ jobs:
           fi
       - name: PR 코멘트
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const kb   = '${{ steps.check.outputs.gzip_kb }}';
@@ -138,9 +138,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -164,9 +164,9 @@ jobs:
     name: Docs Site Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,17 @@ jobs:
       pull-requests: write  # Version PR 생성·업데이트
       id-token: write       # npm provenance (공급망 보안)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Changesets가 전체 git 히스토리 필요
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       # Node 24 ships with npm 11.x which is required for Trusted Publishing
       # (OIDC-based publish without NPM_TOKEN). Node 22 ships with npm 10.x
       # which only supports provenance signing, not actual OIDC publish.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,9 +41,9 @@ jobs:
     name: License Compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -66,7 +66,7 @@ jobs:
     if: failure() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## Summary

GitHub announced that JS-based actions running on Node.js 20 will be force-flipped to Node.js 24 on **2026-06-02**, and every CI run currently emits a deprecation warning for our `@v4` and `@v7` pins. This PR bumps to the latest stable majors (all Node 24).

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `pnpm/action-setup` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `actions/github-script` | `@v7` | `@v9` |

### No usage changes

- Artifact names are already unique (`dist-${{ github.run_id }}`, `playwright-report-${{ matrix.browser }}`, `SARIF file`) — survives the v4 → v7/v8 stricter-name requirement.
- `setup-node` reads `packageManager` from `package.json` (pinned `pnpm@10.10.0`) — same syntax across v4 → v6.
- `pnpm/action-setup` is used without a `version:` arg, so the `packageManager` auto-discovery in v6 picks up the same value.
- `github-script` `script:` input is unchanged across v7 → v9.

### Not in scope

The reusable `google/osv-scanner-action` workflow we call from `security.yml` pins its own internal `actions/checkout` / `actions/upload-artifact` / `codeql-action` versions — those Node 20 warnings will only clear once Google upgrades that workflow. Not actionable here.

## Test plan

- [x] All 4 workflow files updated in lockstep (`pr-check.yml`, `release.yml`, `e2e-and-docs.yml`, `security.yml`).
- [x] No matching `@v4` / `@v7` entries remain (verified with `grep`).
- [ ] CI on this PR exercises the new versions end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)