### PR TITLE
docs(readme): sync bundle size + ceiling to rc.8 / 16 KB

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-14.42KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.01KB-brightgreen)](https://kalyx-docs.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -19,7 +19,7 @@
 
 ---
 
-Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~14 KB (≤ 15 KB), CSS 없음, SSR 안전.
+Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~15 KB (≤ 16 KB), CSS 없음, SSR 안전.
 
 ```bash
 pnpm add @kalyx/react
@@ -87,7 +87,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` v1.0.0-rc.7 → **14.42 KB** gzip (ESM) / **14.84 KB** (CJS). CI 한계 ≤ 15 KB.
+`@kalyx/react` v1.0.0-rc.8 → **15.01 KB** gzip (ESM) / **15.16 KB** (CJS). CI 한계 ≤ 16 KB.
 
 ## 지원 환경
 
@@ -101,7 +101,7 @@ pnpm test            # 단위 + 컴포넌트
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle    # ≤ 15 KB
+pnpm check-bundle    # ≤ 16 KB
 ```
 
 아키텍처 원칙은 [CLAUDE.md](./CLAUDE.md) 참고.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-14.42KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.01KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -19,7 +19,7 @@
 
 ---
 
-Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~14 KB gzip (≤15 KB ceiling), zero CSS, SSR-safe.
+Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~15 KB gzip (≤16 KB ceiling), zero CSS, SSR-safe.
 
 ```bash
 pnpm add @kalyx/react
@@ -87,7 +87,7 @@ API reference, recipes (Tailwind / shadcn / React Hook Form), and migration guid
 
 ## Bundle
 
-`@kalyx/react` v1.0.0-rc.7 → **14.42 KB** gzip (ESM) / **14.84 KB** (CJS). CI gate: ≤ 15 KB.
+`@kalyx/react` v1.0.0-rc.8 → **15.01 KB** gzip (ESM) / **15.16 KB** (CJS). CI gate: ≤ 16 KB.
 
 ## Browser support
 
@@ -101,7 +101,7 @@ pnpm test            # unit + component
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle    # ≤ 15 KB
+pnpm check-bundle    # ≤ 16 KB
 ```
 
 See [CLAUDE.md](./CLAUDE.md) for architecture principles.


### PR DESCRIPTION
## Summary

rc.8 measurements:
- ESM gzip: **15.01 KB** (was 14.42 KB on rc.7)
- CJS gzip: **15.16 KB** (was 14.84 KB on rc.7)
- CI ceiling: **≤ 16 KB** (raised from ≤ 15 KB in PR #61 to accommodate `TimePicker.filterTime`)

EN + KO READMEs synced. Same one-line drift fix as PR #60 (rc.7 sync) — README badge/section that would otherwise look stale to new visitors landing on the repo.

## Test plan

- [x] EN + KO READMEs updated in lockstep.
- [x] No remaining `14.42` / `14.84` / `rc.7` / `≤ 15 KB` strings in either README (verified by `grep`).
- [x] No source / API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **문서**
  * 라이브러리 번들 크기 정보가 최신 릴리스(rc.8)에 맞게 업데이트되었습니다.
  * 번들 용량 기준이 15KB에서 16KB로 조정되었습니다.
  * 기여자를 위한 번들 체크 가이드가 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->