### PR TITLE
chore(oss): unify engines, add repo metadata, sync PR template

### DIFF
--- a/.changeset/oss-metadata-and-engines.md
+++ b/.changeset/oss-metadata-and-engines.md
@@ -1,0 +1,11 @@
+---
+'@kalyx/react': minor
+'@kalyx/core': minor
+---
+
+chore(oss): unify node engines to >=20 and add public repository metadata
+
+- `@kalyx/react` and `@kalyx/core` now require Node `>=20`, matching the root workspace and CI. This was the de-facto requirement; only the published manifests still claimed `>=18`.
+- Root `package.json` now exposes `homepage`, `repository`, and `bugs` so `npm info` and the npm registry page link back to the GitHub repo.
+- `.github/PULL_REQUEST_TEMPLATE.md` bundle ceiling updated `15KB → 16 KB` to match the post-rc.8 limit advertised in README and CI.
+- `.gitignore` ignores `.codegraph/`, `.serena/`, and `.tmp-*/` (MCP server caches and worktree scratchpads).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] `pnpm lint` passes
 - [ ] `pnpm test:run` passes
 - [ ] `pnpm build` succeeds
-- [ ] Bundle size checked (`pnpm check-bundle` ≤ 15KB)
+- [ ] Bundle size checked (`pnpm check-bundle` ≤ 16 KB)
 - [ ] Changeset added (if public API changed)
 - [ ] New public APIs have JSDoc comments
 - [ ] Accessibility: axe passes, keyboard navigation works

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ test-results
 .next
 out
 scheduled_tasks.lock
+
+# MCP server caches
+.codegraph/
+.serena/
+
+# Temporary worktrees
+.tmp-*/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
 	"type": "module",
 	"packageManager": "pnpm@10.10.0",
 	"description": "Headless, SSR-safe React DatePicker",
+	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jiji-hoon96/kalyx.git"
+	},
+	"bugs": {
+		"url": "https://github.com/jiji-hoon96/kalyx/issues"
+	},
 	"scripts": {
 		"build": "pnpm -r build",
 		"build:core": "pnpm --filter @kalyx/core build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
 		"date-fns-tz": "^3.0.0"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=20.0.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -81,7 +81,7 @@
 		"@types/react-dom": "^19.0.0"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=20.0.0"
 	},
 	"publishConfig": {
 		"access": "public",


### PR DESCRIPTION
## Summary

OSS hygiene cleanup. No runtime code changed.

- **Node engines unified to `>=20`** in `@kalyx/react` and `@kalyx/core`. The root workspace and CI already require Node 20; only the published manifests still claimed `>=18`, which was misleading.
- **Root `package.json` now exposes `homepage`, `repository`, `bugs`** so `npm info kalyx` (the private workspace root) and any future tooling can resolve the repo. Format matches the existing fields in `packages/react/package.json` and `packages/core/package.json`.
- **PR template bundle ceiling updated `15KB → 16 KB`** to match the post-rc.8 limit advertised in README, CI, and CLAUDE.md §2. The 15 in `scripts/check-bundle-size.js` and `README.md` are historical/measurement values and intentionally preserved.
- **`.gitignore` ignores `.codegraph/`, `.serena/`, and `.tmp-*/`** — MCP server caches and worktree scratchpads that were leaking into `git status`.

Changeset is `minor` for both packages because raising `engines.node` is technically observable for Node 18 consumers (npm will warn or refuse to install).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @kalyx/react build` succeeds (gzip 15.01 KB ESM / 15.16 KB CJS, well within 16 KB)
- [x] Changeset added at `.changeset/oss-metadata-and-engines.md`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Node.js 최소 버전 요구사항을 20으로 업데이트
  * 번들 크기 제한을 16KB로 조정
  * 프로젝트 메타데이터 정보 추가
  * 개발 환경 설정 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->