### PR TITLE
fix(datetimepicker): add withSeconds/filterTime + hydration-safe currentTime + complete type surface

### DIFF
--- a/.changeset/datetimepicker-composition-api.md
+++ b/.changeset/datetimepicker-composition-api.md
@@ -1,0 +1,9 @@
+---
+'@kalyx/react': patch
+---
+
+fix(datetimepicker): close composition-API gap and expose missing public types
+
+- `<DateTimePicker.Root>` now accepts `withSeconds` and `filterTime` props (was silently hard-coded to `withSeconds: false`, `filterTime: undefined`)
+- `currentTime` no longer calls `DateFnsAdapter.today()` during render when `value` is null — eliminates the UTC-midnight hydration mismatch risk
+- Public API now re-exports `CalendarWeek`, `CalendarGrid`, `CalendarOptions`, `WeekStartsOn`, `WeekdayInfo`, every `{Picker}Labels` type, and the four `DEFAULT_*_LABELS` runtime constants per CLAUDE.md §6

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { DateTimePicker } from './index.js';
+import { useTimePickerContext } from '../../context/TimePickerContext.js';
 
 function renderDateTimePicker(
   props: {
@@ -450,5 +451,122 @@ describe('DateTimePicker — SSR safety', () => {
         </DateTimePicker>,
       );
     }).not.toThrow();
+  });
+});
+
+/**
+ * Test-only probe that exposes TimePickerContext for verification. Renders nothing visible —
+ * just emits a hidden span with the relevant fields serialized so assertions can read them.
+ */
+function TimeContextProbe({ id }: { id: string }) {
+  const ctx = useTimePickerContext('TimeContextProbe');
+  return (
+    <span
+      data-testid={id}
+      data-with-seconds={String(ctx.withSeconds)}
+      data-current-hours={String(ctx.currentTime.hours)}
+      data-current-minutes={String(ctx.currentTime.minutes)}
+      data-current-seconds={String(ctx.currentTime.seconds)}
+      data-has-filter-time={String(typeof ctx.filterTime === 'function')}
+    />
+  );
+}
+
+describe('DateTimePicker — composition API forwarding to TimePickerContext', () => {
+  it('forwards withSeconds=true through to TimePickerContext', () => {
+    render(
+      <DateTimePicker value="2026-01-15T14:30:45.000Z" onChange={vi.fn()} withSeconds>
+        <TimeContextProbe id="probe" />
+      </DateTimePicker>,
+    );
+    const probe = screen.getByTestId('probe');
+    expect(probe.getAttribute('data-with-seconds')).toBe('true');
+  });
+
+  it('defaults withSeconds to false when the prop is omitted', () => {
+    render(
+      <DateTimePicker value="2026-01-15T14:30:00.000Z" onChange={vi.fn()}>
+        <TimeContextProbe id="probe" />
+      </DateTimePicker>,
+    );
+    expect(screen.getByTestId('probe').getAttribute('data-with-seconds')).toBe('false');
+  });
+
+  it('forwards filterTime through to TimePickerContext (HourList reflects disabled hour)', async () => {
+    const user = userEvent.setup();
+    const filterTime = (h: number) => h === 12;
+    render(
+      <DateTimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={vi.fn()}
+        step={15}
+        filterTime={filterTime}
+      >
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePicker.HourList />
+        </DateTimePicker.Popover>
+      </DateTimePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    const hour12 = screen.getByRole('option', { name: '12 hours' });
+    expect(hour12).toHaveAttribute('aria-disabled', 'true');
+    const hour11 = screen.getByRole('option', { name: '11 hours' });
+    expect(hour11).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('blocks click on a filterTime-disabled hour and never fires onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DateTimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={onChange}
+        step={15}
+        filterTime={(h) => h === 12}
+      >
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePicker.HourList />
+        </DateTimePicker.Popover>
+      </DateTimePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: '12 hours' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('DateTimePicker — hydration-safe currentTime fallback', () => {
+  it('exposes a deterministic {0,0,0} time fallback when value is null', () => {
+    render(
+      <DateTimePicker value={null} onChange={vi.fn()}>
+        <TimeContextProbe id="probe" />
+      </DateTimePicker>,
+    );
+    const probe = screen.getByTestId('probe');
+    expect(probe.getAttribute('data-current-hours')).toBe('0');
+    expect(probe.getAttribute('data-current-minutes')).toBe('0');
+    expect(probe.getAttribute('data-current-seconds')).toBe('0');
+  });
+
+  it('produces identical render output across two independent renders when value is null', () => {
+    // The render-path no longer calls adapter.today(), so two renders must agree on the
+    // currentTime even if a day boundary were to pass between them.
+    const first = render(
+      <DateTimePicker value={null} onChange={vi.fn()}>
+        <TimeContextProbe id="probe" />
+      </DateTimePicker>,
+    );
+    const firstHtml = first.container.innerHTML;
+    first.unmount();
+
+    const second = render(
+      <DateTimePicker value={null} onChange={vi.fn()}>
+        <TimeContextProbe id="probe" />
+      </DateTimePicker>,
+    );
+    expect(second.container.innerHTML).toBe(firstHtml);
   });
 });

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -58,6 +58,15 @@ export interface DateTimePickerRootProps {
   format?: TimePickerFormat;
   /** Minute step (e.g., 1, 5, 15, 30) */
   step?: number;
+  /** Whether to display seconds in the time controls */
+  withSeconds?: boolean;
+  /**
+   * Programmatic per-slot disable predicate for the time controls. Returns `true` for any
+   * `(hours, minutes)` pair that should be unselectable — same polarity as MUI X's
+   * `shouldDisableTime`, and the **inverse** of react-datepicker's `filterTime`. Always
+   * receives 24-hour values.
+   */
+  filterTime?: (hours: number, minutes: number) => boolean;
   /** Disabled rules (applied to dates) */
   disabled?: DisabledRule[] | boolean;
   /** Read-only */
@@ -82,11 +91,6 @@ export interface DateTimePickerRootProps {
   children: ReactNode;
 }
 
-/** Fallback ISO used when value is null (today at 00:00:00 UTC) */
-function getDefaultIso(): ISODateString {
-  return DateFnsAdapter.today();
-}
-
 /**
  * DateTimePicker.Root — Combined DatePicker + TimePicker component.
  *
@@ -107,6 +111,8 @@ export function DateTimePickerRoot({
   onCalendarNavigate,
   format = '24h',
   step = 1,
+  withSeconds = false,
+  filterTime,
   disabled = false,
   readOnly = false,
   weekStartsOn = 0,
@@ -154,12 +160,14 @@ export function DateTimePickerRoot({
     [disabled],
   );
 
-  // When value is null, use a fallback for time extraction
-  const baseIso = currentValue ?? getDefaultIso();
-  const currentTime: TimeValue = useMemo(
-    () => (displayTimezone ? getTimeInTimezone(baseIso, displayTimezone) : getTime(baseIso)),
-    [baseIso, displayTimezone],
-  );
+  // When value is null, use a stable {0,0,0} fallback for hydration safety —
+  // avoid invoking adapter.today() during render to keep server/client output deterministic.
+  const currentTime: TimeValue = useMemo(() => {
+    if (!currentValue) return { hours: 0, minutes: 0, seconds: 0 };
+    return displayTimezone
+      ? getTimeInTimezone(currentValue, displayTimezone)
+      : getTime(currentValue);
+  }, [currentValue, displayTimezone]);
 
   const updateValue = useCallback(
     (next: ISODateString | null) => {
@@ -205,14 +213,15 @@ export function DateTimePickerRoot({
    */
   const setTime = useCallback(
     (partial: Partial<TimeValue>) => {
-      // If no date yet, start from today at midnight (tz-aware)
-      const base = currentValue ?? getDefaultIso();
+      // If no date yet, start from today at midnight (tz-aware). today() is resolved at
+      // event time (not during render) so SSR hydration output stays stable.
+      const base = currentValue ?? adapter.today(displayTimezone);
       const merged = displayTimezone
         ? setTimeInTimezone(base, partial, displayTimezone)
         : setTimeOnIso(base, partial);
       updateValue(merged);
     },
-    [currentValue, updateValue, displayTimezone],
+    [currentValue, updateValue, displayTimezone, adapter],
   );
 
   const open = useCallback(() => {
@@ -286,25 +295,28 @@ export function DateTimePickerRoot({
       setTime,
       format,
       step,
-      withSeconds: false,
+      withSeconds,
       displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
       currentTime,
       pickerId,
       labels: mergedTimeLabels,
+      filterTime,
     }),
     [
       currentValue,
       setTime,
       format,
       step,
+      withSeconds,
       displayTimezone,
       isDisabled,
       readOnly,
       currentTime,
       pickerId,
       mergedTimeLabels,
+      filterTime,
     ],
   );
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -99,5 +99,20 @@ export type {
   DisabledRule,
   DateAdapter,
   CalendarDay,
+  CalendarWeek,
+  CalendarGrid,
+  CalendarOptions,
+  WeekStartsOn,
   TimeValue,
+  WeekdayInfo,
+  DatePickerLabels,
+  RangePickerLabels,
+  TimePickerLabels,
+  DateTimePickerLabels,
+} from '@kalyx/core';
+export {
+  DEFAULT_DATEPICKER_LABELS,
+  DEFAULT_RANGEPICKER_LABELS,
+  DEFAULT_TIMEPICKER_LABELS,
+  DEFAULT_DATETIMEPICKER_LABELS,
 } from '@kalyx/core';


### PR DESCRIPTION
## Summary

- `<DateTimePicker.Root>` now accepts `withSeconds` and `filterTime` props and forwards them to `TimePickerContext`. Previously these were silently hard-coded to `withSeconds: false` and `filterTime: undefined`, violating the composition-API principle that DateTimePicker reuses the TimePicker surface fully.
- `currentTime` no longer calls `DateFnsAdapter.today()` during render when `value` is null — it falls back to a stable `{hours: 0, minutes: 0, seconds: 0}`. `setTime` resolves `today()` lazily at event time via `adapter.today(displayTimezone)`. Removes the SSR/hydration mismatch risk that arose from a UTC-midnight day boundary crossing between server render and client hydration.
- Public API now re-exports the missing `CalendarWeek`, `CalendarGrid`, `CalendarOptions`, `WeekStartsOn`, `WeekdayInfo` types, every `{Picker}Labels` type, and the four `DEFAULT_*_LABELS` runtime constants — bringing `@kalyx/react`'s entry point into compliance with CLAUDE.md §6.

Bundle gzip: 15.09 KB ESM / 15.26 KB CJS (≤ 16 KB target met).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test:run` — 473 tests pass (18 files); 32 DateTimePicker tests, 6 new (withSeconds default + true, filterTime forwarding + click block, null hydration stability x2)
- [x] `pnpm --filter @kalyx/react build` — succeeds
- [x] `pnpm check-bundle` — ESM 15.09 KB / CJS 15.26 KB, both ≤ 16 KB
- [x] `pnpm lint` — passes
- [x] No breaking changes: every new prop is optional with the prior implicit default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>