### PR TITLE
fix(rangepicker): announce next target + final range to screen readers

### DIFF
--- a/.changeset/rangepicker-selecting-target-announce.md
+++ b/.changeset/rangepicker-selecting-target-announce.md
@@ -1,0 +1,14 @@
+---
+'@kalyx/core': minor
+'@kalyx/react': patch
+---
+
+fix(rangepicker): announce next selection target and final range to screen readers
+
+`<RangePicker.Calendar>` now announces context-aware messages through its existing `role="status"` live region:
+
+- After the first click (start), it announces `<formatted-date>. Now select end date.` so screen-reader users know the next click commits the other endpoint.
+- After the second click (end), it announces `Range selected: <start> – <end>` instead of just the bare date — matching the swap-if-before behaviour so the announcement always reflects what was committed.
+- Week-mode commits now share the same `Range selected: ...` prefix for consistency.
+
+The two new strings are wired through `RangePickerLabels.selectingEnd` and `RangePickerLabels.rangeSelected` with English defaults, and they are fully overridable via the existing `labels` prop for i18n. `@kalyx/core` gets a `minor` bump because `RangePickerLabels` gained required fields (with defaults supplied by `DEFAULT_RANGEPICKER_LABELS`); any consumer constructing a literal `RangePickerLabels` from scratch will need to add the two keys.

--- a/packages/core/src/utils/labels.ts
+++ b/packages/core/src/utils/labels.ts
@@ -21,6 +21,16 @@ export interface RangePickerLabels extends DatePickerLabels {
   startInput: string;
   endInput: string;
   presetsGroup: string;
+  /**
+   * Screen-reader prompt appended after the start date is picked, telling the user
+   * the next click commits the end of the range.
+   */
+  selectingEnd: string;
+  /**
+   * Screen-reader prefix announced when both endpoints are committed, e.g.
+   * `"Range selected: Jan 5, 2026 – Jan 12, 2026"`.
+   */
+  rangeSelected: string;
 }
 
 export interface TimePickerLabels {
@@ -54,6 +64,8 @@ export const DEFAULT_RANGEPICKER_LABELS: RangePickerLabels = {
   startInput: 'Start date',
   endInput: 'End date',
   presetsGroup: 'Date range presets',
+  selectingEnd: 'Now select end date',
+  rangeSelected: 'Range selected',
 };
 
 export const DEFAULT_TIMEPICKER_LABELS: TimePickerLabels = {

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
@@ -66,18 +66,6 @@ function safeFormatFullDate(iso: string, locale: string): string {
   }
 }
 
-const srOnly: React.CSSProperties = {
-  position: 'absolute',
-  width: '1px',
-  height: '1px',
-  padding: 0,
-  margin: '-1px',
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  border: 0,
-};
-
 export function RangePickerCalendar({
   classNames,
   selectionMode = 'range',
@@ -87,7 +75,6 @@ export function RangePickerCalendar({
 }: RangePickerCalendarProps) {
   const ctx = useRangePickerContext('RangePicker.Calendar');
   const gridRef = useRef<HTMLTableElement>(null);
-  const [announcement, setAnnouncement] = useState('');
 
   const {
     adapter,
@@ -149,7 +136,7 @@ export function RangePickerCalendar({
       ctx.setFocusedDate(adapter.startOfMonth(newMonth));
       const y = adapter.getYear(newMonth);
       const m = adapter.getMonth(newMonth);
-      setAnnouncement(formatMonthYear(y, m, locale));
+      ctx.announce(formatMonthYear(y, m, locale));
     },
     [adapter, viewMonth, ctx, locale],
   );
@@ -162,15 +149,36 @@ export function RangePickerCalendar({
         const range: DateRange = { start: weekStart, end: weekEnd };
         ctx.setRange(range);
         ctx.close();
-        setAnnouncement(
-          `${safeFormatFullDate(weekStart, locale)} – ${safeFormatFullDate(weekEnd, locale)}`,
+        ctx.announce(
+          `${ctx.labels.rangeSelected}: ${safeFormatFullDate(weekStart, locale)} – ${safeFormatFullDate(weekEnd, locale)}`,
         );
       } else {
+        // Capture selectingTarget BEFORE selectDate flips it so we can announce
+        // the right state. "start" click prompts for the end; "end" click closes
+        // the range and announces the full span.
+        const wasPickingStart = selectingTarget === 'start';
+        const previousStart = value.start;
         ctx.selectDate(iso);
-        setAnnouncement(safeFormatFullDate(iso, locale));
+        const formatted = safeFormatFullDate(iso, locale);
+        if (wasPickingStart) {
+          ctx.announce(`${formatted}. ${ctx.labels.selectingEnd}`);
+        } else if (previousStart) {
+          // Mirror the swap-if-before logic from RangePickerRoot.selectDate so the
+          // announcement matches what will be committed.
+          const [start, end] = adapter.isBefore(iso, previousStart)
+            ? [iso, previousStart]
+            : [previousStart, iso];
+          ctx.announce(
+            `${ctx.labels.rangeSelected}: ${safeFormatFullDate(start, locale)} – ${safeFormatFullDate(end, locale)}`,
+          );
+        } else {
+          // Safety: no previous start (e.g. preset cleared mid-flow) — fall back
+          // to a simple per-day announcement so the user still hears something.
+          ctx.announce(formatted);
+        }
       }
     },
-    [selectionMode, adapter, weekStartsOn, ctx, locale],
+    [selectionMode, adapter, weekStartsOn, ctx, locale, selectingTarget, value.start],
   );
 
   const handleDayClick = useCallback(
@@ -412,10 +420,6 @@ export function RangePickerCalendar({
           ))}
         </tbody>
       </table>
-
-      <div role="status" aria-live="polite" aria-atomic="true" style={srOnly}>
-        {announcement}
-      </div>
     </div>
   );
 }

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -334,6 +334,84 @@ describe('RangePicker — accessibility', () => {
     });
     expect(results).toHaveNoViolations();
   });
+
+  it('announces the next selection target after picking start', async () => {
+    const user = userEvent.setup();
+    render(
+      <ControlledRangePicker
+        initialValue={{ start: '2026-01-01T00:00:00.000Z', end: '2026-01-31T00:00:00.000Z' }}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: /January 10, 2026/ }));
+
+    const live = screen.getByRole('status');
+    expect(live.textContent).toMatch(/January 10, 2026/);
+    expect(live.textContent).toMatch(/Now select end date/);
+  });
+
+  it('announces the full range when both endpoints commit', async () => {
+    const user = userEvent.setup();
+    render(
+      <ControlledRangePicker
+        initialValue={{ start: '2026-01-01T00:00:00.000Z', end: '2026-01-31T00:00:00.000Z' }}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: /January 10, 2026/ }));
+    await user.click(screen.getByRole('button', { name: /January 20, 2026/ }));
+
+    const live = screen.getByRole('status');
+    expect(live.textContent).toMatch(/Range selected/);
+    expect(live.textContent).toMatch(/January 10, 2026/);
+    expect(live.textContent).toMatch(/January 20, 2026/);
+  });
+
+  it('announces the swapped range when the second click precedes the first', async () => {
+    const user = userEvent.setup();
+    render(
+      <ControlledRangePicker
+        initialValue={{ start: '2026-01-01T00:00:00.000Z', end: '2026-01-31T00:00:00.000Z' }}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Start date'));
+    // First click Jan 20 (becomes start), second click Jan 10 swaps so the announcement
+    // must reflect Jan 10 – Jan 20, not the click order.
+    await user.click(screen.getByRole('button', { name: /January 20, 2026/ }));
+    await user.click(screen.getByRole('button', { name: /January 10, 2026/ }));
+
+    const live = screen.getByRole('status');
+    const text = live.textContent ?? '';
+    const startIdx = text.indexOf('January 10, 2026');
+    const endIdx = text.indexOf('January 20, 2026');
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+  });
+
+  it('respects the labels prop override for live-region announcements', async () => {
+    const user = userEvent.setup();
+    render(
+      <RangePicker
+        defaultValue={{ start: '2026-01-01T00:00:00.000Z', end: '2026-01-31T00:00:00.000Z' }}
+        labels={{ selectingEnd: '종료일을 선택하세요', rangeSelected: '범위 선택됨' }}
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: /January 10, 2026/ }));
+
+    const live = screen.getByRole('status');
+    expect(live.textContent).toMatch(/종료일을 선택하세요/);
+  });
 });
 
 describe('RangePicker — date rules and edge cases (CLAUDE.md §7)', () => {

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { DateFnsAdapter, DEFAULT_RANGEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
 import type {
   DateAdapter,
@@ -17,6 +17,18 @@ import type {
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
 
 const EMPTY_RANGE: DateRange = { start: null, end: null };
+
+const SR_ONLY: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
 
 /**
  * Props for the RangePicker Root component.
@@ -103,6 +115,10 @@ export function RangePickerRoot({
   const [selectingTarget, setSelectingTarget] = useState<RangeSelectingTarget>('start');
 
   const [hoverDate, setHoverDate] = useState<ISODateString | null>(null);
+
+  // Live-region announcement (mounted on Root so it survives Calendar unmount).
+  const [announcement, setAnnouncement] = useState('');
+  const announce = useCallback((message: string) => setAnnouncement(message), []);
 
   // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
   const [viewMonth, setViewMonth] = useState<ISODateString>(
@@ -231,6 +247,7 @@ export function RangePickerRoot({
       isReadOnly: readOnly,
       pickerId,
       labels: mergedLabels,
+      announce,
     }),
     [
       currentValue,
@@ -254,8 +271,16 @@ export function RangePickerRoot({
       readOnly,
       pickerId,
       mergedLabels,
+      announce,
     ],
   );
 
-  return <RangePickerContext.Provider value={contextValue}>{children}</RangePickerContext.Provider>;
+  return (
+    <RangePickerContext.Provider value={contextValue}>
+      {children}
+      <div role="status" aria-live="polite" aria-atomic="true" style={SR_ONLY}>
+        {announcement}
+      </div>
+    </RangePickerContext.Provider>
+  );
 }

--- a/packages/react/src/context/RangePickerContext.ts
+++ b/packages/react/src/context/RangePickerContext.ts
@@ -57,6 +57,13 @@ export interface RangePickerContextValue {
   pickerId: string;
   /** ARIA labels */
   labels: RangePickerLabels;
+  /**
+   * Push a transient message to the picker's `role="status"` live region.
+   * The live region lives on Root so it survives popover close/Calendar unmount
+   * — without that, announcements set on the commit click are silenced before
+   * screen readers can pick them up.
+   */
+  announce: (message: string) => void;
 }
 
 export const RangePickerContext = createContext<RangePickerContextValue | null>(null);


### PR DESCRIPTION
## Summary

The `RangePicker` live region now reflects the two-step selection flow it actually has — and survives the popover close that used to swallow the final announcement.

**What was wrong**

- After the first click (start), the live region announced just `Jan 10, 2026`. Screen-reader users had no cue that the next click commits the *end* of the range.
- On the second click the popover closes immediately. The live region used to live inside `<RangePicker.Calendar>`, so it unmounted in the same tick the announcement was set — assistive tech never heard it.

**What this changes**

- The live region is now mounted on `RangePickerRoot` via a new `ctx.announce(...)` exposed on `RangePickerContextValue`. It stays in the tree across popover open/close cycles.
- `RangePicker.Calendar` announces context-aware strings:
  - start click → `<date>. Now select end date.` (`labels.selectingEnd`)
  - end click → `Range selected: <start> – <end>` (`labels.rangeSelected`), correctly reflecting the swap when end precedes start
  - week-mode click → same `Range selected: ...` prefix for consistency
- Two new fields on `RangePickerLabels` (`selectingEnd`, `rangeSelected`) ship with English defaults in `DEFAULT_RANGEPICKER_LABELS`. The existing `labels` prop is `Partial<RangePickerLabels>`, so overrides remain additive.

**Why `@kalyx/core` is a minor**

`RangePickerLabels` gained required fields. Consumers using `Partial<RangePickerLabels>` (the normal labels-prop path) are unaffected. Consumers building a literal `RangePickerLabels` from scratch will need to add the two new keys — hence `minor`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 479 / 479 pass (RangePicker suite: 38 → 42, +4 new announcement tests including i18n override and swapped-order)
- [x] `pnpm lint` — clean
- [x] `pnpm --filter @kalyx/react build` — success
- [x] `pnpm check-bundle` — ESM 15.30 KB / CJS 15.49 KB (≤ 16 KB ceiling)
- [x] axe a11y check on open RangePicker — still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)