### PR TITLE
docs(i18n): translate Korean intro + ignore demo workspaces

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": []
+	"ignore": ["@kalyx/docs", "docs-site"]
 }

--- a/.changeset/ko-intro-translation-and-changeset-ignore.md
+++ b/.changeset/ko-intro-translation-and-changeset-ignore.md
@@ -1,0 +1,8 @@
+---
+'@kalyx/react': patch
+---
+
+docs(i18n): translate Korean intro and stop bumping demo apps on every patch
+
+- `apps/docs-site/i18n/ko/.../intro.md` is now fully translated to Korean. Previously the file lived in the `i18n/ko/` tree but the body was the verbatim English copy, so Korean docs visitors saw English content on the landing page.
+- `.changeset/config.json` `ignore` now includes the two demo workspaces (`@kalyx/docs`, `docs-site`). Changesets used to bump them on every release because they depend on `@kalyx/react`, polluting their CHANGELOG with `Updated dependencies` entries and adding noise to release PRs. Demo apps aren't published — they don't need versioning.

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
@@ -1,13 +1,13 @@
 ---
 id: intro
-title: Introduction
+title: 소개
 sidebar_position: 1
 slug: /intro
 ---
 
 # Kalyx
 
-**Kalyx** is a headless React DatePicker library that ships *complete*. Seven composable pickers — **DatePicker**, **RangePicker**, **TimePicker**, **DateTimePicker**, **MonthPicker**, **YearPicker**, and **WeekPicker** — behind one consistent API.
+**Kalyx** 는 *완성된 상태로* 출시되는 headless React DatePicker 라이브러리다. 7개의 조합 가능한 picker — **DatePicker**, **RangePicker**, **TimePicker**, **DateTimePicker**, **MonthPicker**, **YearPicker**, **WeekPicker** — 가 하나의 일관된 API 뒤에 자리한다.
 
 ```tsx
 import { DatePicker } from '@kalyx/react';
@@ -21,33 +21,33 @@ import { DatePicker } from '@kalyx/react';
 </DatePicker>
 ```
 
-## Why Kalyx exists
+## Kalyx 가 존재하는 이유
 
-The React ecosystem in 2026 has two extremes — and nothing in between:
+2026년 React 생태계에는 두 극단만 존재하고 그 사이가 비어 있다:
 
-| Option | What it offers | What it doesn't |
+| 옵션 | 제공하는 것 | 부족한 것 |
 | --- | --- | --- |
-| **react-day-picker** | Headless, accessible calendar grid | No input, no time, no range out of the box |
-| **react-datepicker** | All-in-one features | 60 KB, required CSS, Date-object API, timezone pitfalls |
-| **Ark UI / React Aria** | Composition patterns | No TimePicker (Ark), heavy dependencies (Aria) |
+| **react-day-picker** | Headless, 접근성 갖춘 캘린더 그리드 | input, time, range 미포함 |
+| **react-datepicker** | 통합된 기능 | 60KB, CSS 강제, Date 객체 API, timezone 함정 |
+| **Ark UI / React Aria** | Composition 패턴 | TimePicker 미제공(Ark), 무거운 의존성(Aria) |
 
-Kalyx fills the gap:
+Kalyx 는 그 공백을 채운다:
 
-- **Headless philosophy** — no stylesheets, no classes you must override.
-- **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
-- **Composition first** — Radix-style dot notation. No 100-prop monoliths.
-- **~15 KB gzip (≤ 16 KB ceiling)** — measured, enforced in CI.
-- **SSR-safe** — tested with Next.js App Router.
-- **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
-- **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone).
+- **Headless 철학** — 스타일시트 없음, 덮어써야 할 클래스 없음.
+- **통합된 primitive** — 7개의 picker (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) 가 하나의 컨텍스트 모델을 공유한다.
+- **Composition 우선** — Radix 스타일의 dot notation. 100개짜리 prop 덩어리 없음.
+- **~15 KB gzip (≤ 16 KB 한계)** — 측정된 값, CI 에서 강제된다.
+- **SSR 안전** — Next.js App Router 환경에서 검증됨.
+- **ISO 8601 UTC 문자열** 을 값 계약으로 사용 — Date 객체로 인한 함정 없음.
+- **Timezone 인지** — opt-in `displayTimezone` prop 이 UTC 저장 계약을 유지한 채 DST 와 civil-day 의미론을 처리한다. [Timezone 컨셉 페이지](./concepts/timezone) 참고.
 
-## Who it's for
+## 누구를 위한 것인가
 
-- Teams already using **Tailwind**, **shadcn/ui**, **Chakra**, or their own design system, who want date UI that obeys their tokens.
-- Apps that care about **bundle size** and **tree-shaking**.
-- Anything running on **Next.js**, **Remix**, or other SSR/RSC environments.
+- 이미 **Tailwind**, **shadcn/ui**, **Chakra**, 또는 자체 디자인 시스템을 쓰고 있고, 그 토큰을 따르는 date UI 가 필요한 팀.
+- **번들 크기** 와 **tree-shaking** 을 신경 쓰는 앱.
+- **Next.js**, **Remix**, 또는 다른 SSR/RSC 환경에서 동작하는 것.
 
-## What's in the box
+## 패키지 구성
 
 ```
 @kalyx/react                @kalyx/core
@@ -61,12 +61,12 @@ Kalyx fills the gap:
 <WeekPicker>                parseInputValue
 useDatePicker               normalizeISO
 useRangePicker              DEFAULT_*_LABELS
-useTimePicker               …and more
+useTimePicker               …외 다수
 ```
 
-## Next steps
+## 다음 단계
 
-- [Install the package →](./getting-started/installation)
-- [Quick Start (5 min) →](./getting-started/quick-start)
+- [패키지 설치 →](./getting-started/installation)
+- [퀵 스타트 (5분) →](./getting-started/quick-start)
 - [Composition API →](./concepts/composition)
-- [Components →](./components/datepicker)
+- [컴포넌트 →](./components/datepicker)


### PR DESCRIPTION
## Summary

Two unrelated docs/monorepo cleanups bundled because both are one-liner config / single-file diffs.

**Korean intro page was English-only.** `apps/docs-site/i18n/ko/.../intro.md` sat in the `i18n/ko/` tree but its body was the verbatim English copy. Korean docs visitors landed on an English page even though Docusaurus correctly routed them to `/ko/intro`. Now fully translated in the same direct voice the rest of CLAUDE.md uses.

**Changesets re-bumped two non-published demo apps on every release.** `@kalyx/docs` (Next.js demo) and `docs-site` (Docusaurus site) depend on `@kalyx/react`, so Changesets gave them transitive patch bumps on every `@kalyx/react` release and stacked `Updated dependencies` lines into their CHANGELOG. Neither is published — they don't need versioning. They're now in `.changeset/config.json`'s `ignore` array.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter docs-site build` — both `en` and `ko` locales build successfully
- [x] Korean intro renders proper Korean text (verified in built output)
- [x] Existing `apps/docs/CHANGELOG.md` and `apps/docs-site/CHANGELOG.md` left untouched — only future bumps are suppressed
- [x] `@kalyx/react: patch` changeset to nudge Changesets into producing a release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 한국어 소개 문서를 완전히 번역하고 추가했습니다. 소개, Kalyx의 필요성, 대상 사용자, 포함 사항 등 주요 섹션을 한국어로 제공하며, 비교 표와 다음 단계 안내도 함께 번역되었습니다.

* **기타**
  * 릴리스 설정을 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->