### PR TITLE
fix(core): allow generateMinutes step values up to 60

### DIFF
--- a/.changeset/generate-minutes-step-range.md
+++ b/.changeset/generate-minutes-step-range.md
@@ -1,0 +1,8 @@
+---
+'@kalyx/core': patch
+'@kalyx/react': patch
+---
+
+fix(core): allow `generateMinutes` step values up to 60
+
+`generateMinutes(step)` rejected any step above 30, which prevented legitimate cases like `step=45` (quarter-and-three-quarters past the hour) and `step=60` (on-the-hour only). The slot-generation loop already works for any 1–60 integer, so the upper bound is now 60 with the same error message format. Steps `0`, `61+`, and negative values still throw. No callers in `@kalyx/react` relied on the previous narrower bound.

--- a/packages/core/src/__tests__/time.test.ts
+++ b/packages/core/src/__tests__/time.test.ts
@@ -170,9 +170,29 @@ describe('generateMinutes', () => {
     expect(generateMinutes(30)).toEqual([0, 30]);
   });
 
+  it('returns [0, 45] when step is 45 (quarter-and-three-quarters)', () => {
+    expect(generateMinutes(45)).toEqual([0, 45]);
+  });
+
+  it('returns [0] when step is 60 (on-the-hour only)', () => {
+    expect(generateMinutes(60)).toEqual([0]);
+  });
+
+  it('returns 30 entries when step is 2', () => {
+    const result = generateMinutes(2);
+    expect(result).toHaveLength(30);
+    expect(result[0]).toBe(0);
+    expect(result[29]).toBe(58);
+  });
+
+  it('returns [0, 7, 14, 21, 28, 35, 42, 49, 56] when step is 7 (uneven divisor)', () => {
+    expect(generateMinutes(7)).toEqual([0, 7, 14, 21, 28, 35, 42, 49, 56]);
+  });
+
   it('throws on invalid step values', () => {
     expect(() => generateMinutes(0)).toThrow();
     expect(() => generateMinutes(61)).toThrow();
+    expect(() => generateMinutes(-1)).toThrow();
   });
 });
 

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -97,13 +97,19 @@ export function generateHours(format: '12h' | '24h' = '24h'): number[] {
 
 /**
  * Builds a minutes list at the given step.
- * step=1 → [0, 1, 2, ..., 59]
- * step=15 → [0, 15, 30, 45]
- * step=5 → [0, 5, 10, ..., 55]
+ *
+ * - `step=1` → `[0, 1, 2, ..., 59]`
+ * - `step=15` → `[0, 15, 30, 45]`
+ * - `step=5` → `[0, 5, 10, ..., 55]`
+ * - `step=45` → `[0, 45]`
+ * - `step=60` → `[0]` (on-the-hour only)
+ *
+ * Steps above 60 are rejected because they always collapse to `[0]` — useful UX
+ * is impossible past that point.
  */
 export function generateMinutes(step = 1): number[] {
-  if (step < 1 || step > 30) {
-    throw new Error(`[generateMinutes] step must be between 1 and 30, got ${step}`);
+  if (step < 1 || step > 60) {
+    throw new Error(`[generateMinutes] step must be between 1 and 60, got ${step}`);
   }
   const result: number[] = [];
   for (let i = 0; i < 60; i += step) {


### PR DESCRIPTION
## Summary

`generateMinutes(step)` rejected any step above 30 with a runtime throw. That blocked two legitimate cases:

- `step=45` — "quarter past, three-quarters past" cadence used by some scheduling tools
- `step=60` — "on-the-hour only" picker (single `[0]` minute slot)

The generation loop itself (`for (let i = 0; i < 60; i += step)`) already produces correct output for any `1–60` integer step. Only the guard was overly tight.

## What this changes

- Upper bound raised from 30 → 60 in the range guard. Same error-message shape, same throws for `0`, `61+`, and negatives.
- JSDoc updated with the two new examples (`step=45 → [0, 45]`, `step=60 → [0]`).
- 5 new tests in `time.test.ts`:
  - `step=45` → `[0, 45]`
  - `step=60` → `[0]`
  - `step=2` → 30 entries
  - `step=7` → uneven divisor produces `[0, 7, 14, 21, 28, 35, 42, 49, 56]`
  - `step=-1` throws (the existing throw test only covered `0` and `61`)

## Caller impact

None negative. `HourList`'s `fullyDisabledHours24` pre-compute already uses `m += step` and handles any positive step, including 60 (single `m=0` check per hour). No `@kalyx/react` API was tied to the previous bound.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 479 / 479 pass (core: 165 / 165 incl. 5 new)
- [x] `pnpm --filter @kalyx/core build` — success
- [x] `pnpm --filter @kalyx/react build` — success
- [x] `pnpm check-bundle` — ESM 15.09 KB / CJS 15.26 KB (≤ 16 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)