### PR TITLE
fix(input): drop stale typed text when parent re-sets value externally

### DIFF
--- a/.changeset/input-stale-external-value-fix.md
+++ b/.changeset/input-stale-external-value-fix.md
@@ -1,0 +1,13 @@
+---
+'@kalyx/react': patch
+---
+
+fix(input): drop stale typed text when the parent re-sets value externally
+
+`<DatePicker.Input>` and `<TimePicker.Input>` keep half-typed text in a local `inputText` state while the user is editing — without it, parse-failed input would vanish on every keystroke. The state was reset only when the user committed via blur/Enter, which left a real gap:
+
+If the value changed from anywhere else (parent re-rendered with a new `value`, a calendar click, a `Preset`, a custom-Hook `setRange`, an HourList option), the Input kept rendering the user's stale text. Source-of-truth and visible value diverged silently.
+
+A `useEffect` keyed on `ctx.value` now resets `inputText` whenever the source-of-truth changes. The Input goes back to formatting the new value normally. For DatePicker the reset is skipped while an IME composition is in flight (Korean/Japanese/Chinese), so an in-flight character is never wiped mid-stroke.
+
+Impact: `DatePicker`, `MonthPicker`, `YearPicker` (the last two reuse `DatePickerInput`), and `TimePicker` all get the fix. `RangePicker`/`WeekPicker`/`DateTimePicker` Inputs are read-only or non-editable and already track context directly, so they were never affected.

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
@@ -105,6 +106,38 @@ describe('DatePicker — controlled / uncontrolled modes', () => {
   it('shows defaultValue as the initial value in uncontrolled mode', () => {
     renderDatePicker({ defaultValue: '2026-03-20T00:00:00.000Z' });
     expect(screen.getByRole('combobox')).toHaveValue('2026-03-20');
+  });
+
+  it('drops stale typed text when the parent re-sets value externally', async () => {
+    const user = userEvent.setup();
+
+    function ExternalUpdater() {
+      const [value, setValue] = useState<string | null>('2026-01-15T00:00:00.000Z');
+      return (
+        <>
+          <DatePicker value={value} onChange={setValue}>
+            <DatePicker.Input aria-label="날짜 선택" />
+          </DatePicker>
+          <button onClick={() => setValue('2026-12-25T00:00:00.000Z')}>jump-to-dec-25</button>
+        </>
+      );
+    }
+
+    render(<ExternalUpdater />);
+    const input = screen.getByRole('combobox');
+
+    // User types invalid text — parse fails, inputText holds the half-typed string.
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, '2026-01');
+    expect(input).toHaveValue('2026-01');
+
+    // Parent re-sets value externally (e.g. preset button, calendar callback).
+    await user.click(screen.getByRole('button', { name: 'jump-to-dec-25' }));
+
+    // Without the fix the input still shows "2026-01"; with the fix it reflects
+    // the new value so source-of-truth and display agree.
+    expect(input).toHaveValue('2026-12-25');
   });
 });
 

--- a/packages/react/src/components/DatePicker/Input.tsx
+++ b/packages/react/src/components/DatePicker/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import type { InputHTMLAttributes } from 'react';
 import { parseInputValue } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
@@ -37,6 +37,15 @@ export const DatePickerInput = forwardRef<HTMLInputElement, DatePickerInputProps
     // change events for in-progress composition characters. Parsing those mid-stream
     // throws away the user's input. Defer parsing until composition completes.
     const isComposingRef = useRef(false);
+
+    // Drop stale typed text when the value changes from outside (parent re-sets,
+    // calendar selection, preset click, etc.) so the input doesn't keep displaying
+    // an old half-typed string while the source-of-truth has already moved.
+    // Skip during IME composition so we don't wipe an in-flight character.
+    useEffect(() => {
+      if (isComposingRef.current) return;
+      setInputText(null);
+    }, [ctx.value]);
 
     let formattedValue = '';
     if (ctx.value) {

--- a/packages/react/src/components/TimePicker/Input.tsx
+++ b/packages/react/src/components/TimePicker/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useState } from 'react';
 import type { InputHTMLAttributes } from 'react';
 import { formatTimeString, parseTimeString } from '@kalyx/core';
 import { useTimePickerContext } from '../../context/TimePickerContext.js';
@@ -16,6 +16,14 @@ export const TimePickerInput = forwardRef<HTMLInputElement, TimePickerInputProps
   function TimePickerInput({ onBlur, onKeyDown, ...props }, ref) {
     const ctx = useTimePickerContext('TimePicker.Input');
     const [inputText, setInputText] = useState<string | null>(null);
+
+    // Drop stale typed text when the value changes from outside (parent re-sets,
+    // HourList/MinuteList click, AM/PM toggle) so the input reflects the new time
+    // instead of holding the user's earlier half-typed string. Time inputs are
+    // numeric — no IME composition to worry about.
+    useEffect(() => {
+      setInputText(null);
+    }, [ctx.value]);
 
     const displayValue =
       inputText !== null ? inputText : formatTimeString(ctx.currentTime, ctx.withSeconds);

--- a/packages/react/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.test.tsx
@@ -331,6 +331,37 @@ describe('TimePicker — interactions', () => {
       expect(lastCall[0]).toMatch(/T10:00:/);
     }
   });
+
+  it('drops stale typed text when the parent re-sets value externally', async () => {
+    const user = userEvent.setup();
+
+    function ExternalUpdater() {
+      const [value, setValue] = useState<string | null>('2026-01-15T10:00:00.000Z');
+      return (
+        <>
+          <TimePicker value={value} onChange={setValue}>
+            <TimePicker.Input />
+          </TimePicker>
+          <button onClick={() => setValue('2026-01-15T22:30:00.000Z')}>jump-to-22-30</button>
+        </>
+      );
+    }
+
+    render(<ExternalUpdater />);
+    const input = screen.getByLabelText('Time');
+
+    // User types an incomplete time — parse fails, inputText holds the half-typed string.
+    await user.click(input);
+    await user.clear(input);
+    await user.type(input, '14:');
+    expect(input).toHaveValue('14:');
+
+    // Parent re-sets value externally (e.g. another control commits a time).
+    await user.click(screen.getByRole('button', { name: 'jump-to-22-30' }));
+
+    // Without the fix the input still shows "14:"; with the fix it reflects the new time.
+    expect(input).toHaveValue('22:30');
+  });
 });
 
 describe('TimePicker — keyboard navigation', () => {


### PR DESCRIPTION
## Summary

`<DatePicker.Input>` and `<TimePicker.Input>` kept a local `inputText` state so half-typed text doesn't vanish on every keystroke. That state was reset only when the user committed (blur / Enter), which left a real gap: if the value changed from anywhere else — parent re-render, calendar click, preset, custom-hook `setRange`, HourList option — the Input kept rendering the user's stale text. Source-of-truth and display silently diverged.

Confirmed by verification audit:

```tsx
<DatePicker value={date} onChange={setDate}>
  <DatePicker.Input />
</DatePicker>
<button onClick={() => setDate('2026-12-25T00:00:00.000Z')}>Jump</button>
```

1. User types `2026-01` → input shows `2026-01` (parse fails, inputText held)
2. User clicks "Jump" → `date` becomes 2026-12-25 in parent state
3. **Before:** Input still shows `2026-01`
4. **After:** Input shows `2026-12-25`

## What this changes

- `DatePicker/Input.tsx`: `useEffect` keyed on `ctx.value` resets `inputText` whenever source-of-truth moves. Skipped during IME composition (`isComposingRef`) so Korean/Japanese/Chinese characters mid-syllable are never wiped.
- `TimePicker/Input.tsx`: same `useEffect` pattern keyed on `ctx.value`. No IME guard — time inputs are numeric.
- Regression tests in `DatePicker.test.tsx` (`describe('controlled / uncontrolled modes')`) and `TimePicker.test.tsx` (`describe('interactions')`) cover the external-update path.

## Impact map

| Component | Input source | Affected | Now fixed |
|---|---|---|---|
| DatePicker | own `Input.tsx` | yes | ✅ |
| MonthPicker | reuses `DatePickerInput` | yes | ✅ (transitive) |
| YearPicker | reuses `DatePickerInput` | yes | ✅ (transitive) |
| TimePicker | own `Input.tsx` | yes | ✅ |
| DateTimePicker | own readOnly Input | no | — |
| RangePicker | own Input (no inputText state) | no | — |
| WeekPicker | reuses `RangePickerInput` | no | — |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 477 / 477 pass (DatePicker 74 + TimePicker 47 incl. 2 new regression tests)
- [x] `pnpm --filter @kalyx/react build` — success
- [x] `pnpm check-bundle` — ESM 15.11 KB / CJS 15.29 KB (≤ 16 KB)
- [x] IME composition path — verified the `isComposingRef.current` guard short-circuits the reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)