### PR TITLE
fix(core): validate inputs to to12Hour and to24Hour

### DIFF
--- a/.changeset/to12hour-to24hour-input-validation.md
+++ b/.changeset/to12hour-to24hour-input-validation.md
@@ -1,0 +1,14 @@
+---
+'@kalyx/core': patch
+---
+
+fix(core): validate inputs to `to12Hour` and `to24Hour`
+
+`to12Hour(hours24)` and `to24Hour(hours12, period)` are public exports from `@kalyx/core` but had no input validation. The previous silent arithmetic mapped invalid inputs onto plausible-looking but wrong outputs and hid caller bugs:
+
+- `to12Hour(24)` returned `{ hours12: 12, period: 'PM' }` (because `24 % 12 = 0` → mapped to 12)
+- `to12Hour(-1)` returned `{ hours12: -1, period: 'AM' }`
+- `to24Hour(13, 'PM')` returned `25`
+- `to24Hour(0, 'AM')` returned `0` (but `0` is not a valid 12-hour clock value — midnight is `12 AM`)
+
+Both functions now throw `RangeError` with a clear message when the input is outside its valid integer range (`[0, 23]` for `to12Hour`, `[1, 12]` for `to24Hour`). `Number.isInteger` guards non-integers and `NaN`. No `@kalyx/react` callers ever passed invalid values, so the internal contracts are unchanged; only direct `@kalyx/core` users who relied on the silent-wrong behaviour see the new exception.

--- a/packages/core/src/__tests__/time.test.ts
+++ b/packages/core/src/__tests__/time.test.ts
@@ -132,6 +132,23 @@ describe('to12Hour / to24Hour', () => {
       expect(to24Hour(hours12, period)).toBe(h);
     }
   });
+
+  it('to12Hour rejects out-of-range and non-integer inputs', () => {
+    expect(() => to12Hour(24)).toThrow(RangeError);
+    expect(() => to12Hour(25)).toThrow(RangeError);
+    expect(() => to12Hour(-1)).toThrow(RangeError);
+    expect(() => to12Hour(1.5)).toThrow(RangeError);
+    expect(() => to12Hour(NaN)).toThrow(RangeError);
+  });
+
+  it('to24Hour rejects out-of-range and non-integer inputs', () => {
+    // hours12 = 0 is *not* a valid 12-hour value (midnight is 12 AM, not 0 AM).
+    expect(() => to24Hour(0, 'AM')).toThrow(RangeError);
+    expect(() => to24Hour(13, 'PM')).toThrow(RangeError);
+    expect(() => to24Hour(-1, 'AM')).toThrow(RangeError);
+    expect(() => to24Hour(1.5, 'AM')).toThrow(RangeError);
+    expect(() => to24Hour(NaN, 'PM')).toThrow(RangeError);
+  });
 });
 
 describe('generateHours', () => {

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -66,9 +66,18 @@ export function formatTimeString(time: TimeValue, withSeconds = false): string {
 
 /**
  * Converts a 24-hour value to 12-hour form.
- * 0 → 12 AM, 12 → 12 PM
+ *
+ * - `0` → `{ hours12: 12, period: 'AM' }` (midnight)
+ * - `12` → `{ hours12: 12, period: 'PM' }` (noon)
+ *
+ * Throws if `hours24` isn't an integer in `[0, 23]`. The previous silent
+ * modulo behaviour mapped invalid inputs (e.g. `24`, `25`, `-1`) onto
+ * arbitrary valid-looking outputs, which masked caller bugs.
  */
 export function to12Hour(hours24: number): { hours12: number; period: 'AM' | 'PM' } {
+  if (!Number.isInteger(hours24) || hours24 < 0 || hours24 > 23) {
+    throw new RangeError(`[to12Hour] hours24 must be an integer in [0, 23], got ${hours24}`);
+  }
   const period: 'AM' | 'PM' = hours24 >= 12 ? 'PM' : 'AM';
   let hours12 = hours24 % 12;
   if (hours12 === 0) hours12 = 12;
@@ -77,8 +86,15 @@ export function to12Hour(hours24: number): { hours12: number; period: 'AM' | 'PM
 
 /**
  * Converts a 12-hour value to 24-hour form.
+ *
+ * Throws if `hours12` isn't an integer in `[1, 12]`. The previous silent
+ * arithmetic produced out-of-range outputs (e.g. `to24Hour(13, 'PM')` → `25`).
+ * `period` is constrained at the type level to `'AM' | 'PM'`.
  */
 export function to24Hour(hours12: number, period: 'AM' | 'PM'): number {
+  if (!Number.isInteger(hours12) || hours12 < 1 || hours12 > 12) {
+    throw new RangeError(`[to24Hour] hours12 must be an integer in [1, 12], got ${hours12}`);
+  }
   if (period === 'AM') {
     return hours12 === 12 ? 0 : hours12;
   }


### PR DESCRIPTION
## Summary

Both `to12Hour` and `to24Hour` are public exports from `@kalyx/core` but had no input validation. The previous silent arithmetic mapped invalid inputs onto plausible-looking but wrong outputs and hid caller bugs:

| Call | Old behavior | New behavior |
|---|---|---|
| `to12Hour(24)` | `{ hours12: 12, period: 'PM' }` | throws `RangeError` |
| `to12Hour(-1)` | `{ hours12: -1, period: 'AM' }` | throws `RangeError` |
| `to12Hour(1.5)` | `{ hours12: 1.5, period: 'AM' }` | throws `RangeError` |
| `to12Hour(NaN)` | `{ hours12: NaN, period: 'AM' }` | throws `RangeError` |
| `to24Hour(0, 'AM')` | `0` (but `0` isn't a valid 12-hour value; midnight is `12 AM`) | throws `RangeError` |
| `to24Hour(13, 'PM')` | `25` | throws `RangeError` |
| `to24Hour(-1, 'AM')` | `-1` | throws `RangeError` |

Valid input ranges are now enforced at the API boundary:
- `to12Hour(hours24)`: integer in `[0, 23]`
- `to24Hour(hours12, period)`: integer in `[1, 12]`, `period` already type-constrained to `'AM' | 'PM'`

`Number.isInteger` catches non-integer numerics and `NaN`.

## Caller impact

None inside `@kalyx/react`. All internal call sites pass valid inputs:

- `HourList` uses `to12Hour(currentTime.hours)` where `currentTime.hours = getUTCHours(...)` → always `[0, 23]`
- `HourList` uses `to24Hour(hourDisplay, currentPeriod)` where `hourDisplay` comes from `generateHours('12h')` → always `[1, 12]`
- `formatTimeFromISO` uses `to12Hour(time.hours)` with the same `getUTCHours` source

Only direct `@kalyx/core` users who relied on the silent-wrong behaviour see the new exception.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 487 / 487 pass (core: 167 incl. 2 new validation tests covering 24/25/-1/1.5/NaN inputs)
- [x] `pnpm --filter @kalyx/react build` — success, ESM 15.33 KB / CJS 15.51 KB (≤ 16 KB)
- [x] Existing round-trip `to12Hour ↔ to24Hour` test still passes (it only iterates `[0, 23]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)