### PR TITLE
feat: extract @kalyx/adapter-date-fns + remove date-fns from core (steps 1-2 of adapter neutralization)

### DIFF
--- a/.changeset/adapter-extraction-core-neutral.md
+++ b/.changeset/adapter-extraction-core-neutral.md
@@ -1,0 +1,30 @@
+---
+'@kalyx/core': major
+'@kalyx/react': minor
+'@kalyx/adapter-date-fns': major
+---
+
+Extract `@kalyx/adapter-date-fns` and make `@kalyx/core` neutral
+
+Step 1 + 2 of the four-step adapter-extraction plan (see `.claude/skills/adapter-extraction.md`). After this change, `@kalyx/core` no longer depends on `date-fns` or `date-fns-tz`; it ships only the platform-agnostic date logic (`getCalendarDays`, `isDateDisabled`, timezone helpers, labels, the `DateAdapter` contract). The DateFnsAdapter implementation now lives in its own publishable package so dayjs / luxon / Temporal adapters can be added later without forcing every Kalyx user to bundle two date libraries.
+
+### What changed
+
+- **`@kalyx/core`** — `DateFnsAdapter` is no longer exported and `date-fns` / `date-fns-tz` are no longer listed as dependencies. `utils/timezone.ts` was the lone leak and uses native `new Date(string)` now (every caller already routes through `normalizeISO` or `DateAdapter.parse`, so the input subset is fully spec-defined).
+- **`@kalyx/adapter-date-fns`** — new package with the full `DateFnsAdapter` implementation moved verbatim. Same UTC semantics, same timezone-aware paths, same 35 adapter tests.
+- **`@kalyx/react`** — imports `DateFnsAdapter` from `@kalyx/adapter-date-fns` now. The default adapter is still wired up automatically — anyone using `import { DatePicker } from '@kalyx/react'` keeps the previous behaviour with zero changes. The adapter package is a direct dependency so consumers installing just `@kalyx/react` continue to get a working default.
+
+### Migration
+
+If you imported `DateFnsAdapter` directly from `@kalyx/core`:
+
+```diff
+- import { DateFnsAdapter } from '@kalyx/core';
++ import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+```
+
+`@kalyx/react` consumers don't need to change anything — the adapter is still re-exported from `@kalyx/react`.
+
+### Next (separate PR)
+
+The `/headless` entry point (`@kalyx/react/headless`) that lets dayjs/luxon users tree-shake date-fns out is a follow-up. The component Roots still default to the date-fns adapter inline; the entry split requires moving that fallback out of each Root and into the entry boundary.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -52,6 +52,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @kalyx/core build
+      - run: pnpm --filter @kalyx/adapter-date-fns build
       - run: pnpm test:run --coverage
       - name: 커버리지 업로드 (Node 22만)
         if: matrix.node == 22
@@ -172,6 +173,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @kalyx/core build
+      - run: pnpm --filter @kalyx/adapter-date-fns build
       - run: pnpm --filter @kalyx/react build
       - run: pnpm --filter docs-site build
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
 		"url": "https://github.com/jiji-hoon96/kalyx/issues"
 	},
 	"scripts": {
-		"build": "pnpm -r build",
+		"build": "pnpm --filter @kalyx/core build && pnpm --filter @kalyx/adapter-date-fns build && pnpm --filter @kalyx/react build",
 		"build:core": "pnpm --filter @kalyx/core build",
+		"build:adapter-date-fns": "pnpm --filter @kalyx/adapter-date-fns build",
 		"build:react": "pnpm --filter @kalyx/react build",
 		"test": "vitest",
 		"test:run": "vitest run",

--- a/packages/adapter-date-fns/package.json
+++ b/packages/adapter-date-fns/package.json
@@ -1,35 +1,23 @@
 {
-	"name": "@kalyx/react",
-	"version": "1.0.0-rc.12",
-	"description": "Headless, SSR-safe React DatePicker / RangePicker / TimePicker / DateTimePicker — ISO 8601 UTC strings, IANA timezone support, ≤16 KB gzipped",
+	"name": "@kalyx/adapter-date-fns",
+	"version": "1.0.0-rc.0",
+	"description": "date-fns adapter for @kalyx/core — implements the DateAdapter contract using date-fns and date-fns-tz.",
 	"license": "MIT",
 	"author": "jiji-hoon96",
 	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/jiji-hoon96/kalyx.git",
-		"directory": "packages/react"
+		"directory": "packages/adapter-date-fns"
 	},
 	"bugs": {
 		"url": "https://github.com/jiji-hoon96/kalyx/issues"
 	},
 	"keywords": [
-		"react",
-		"datepicker",
-		"daterangepicker",
-		"timepicker",
-		"datetimepicker",
-		"calendar",
-		"headless",
-		"typescript",
-		"tailwind",
-		"accessible",
-		"a11y",
-		"SSR",
-		"timezone",
-		"iana",
-		"dst",
-		"date-fns"
+		"date-fns",
+		"adapter",
+		"kalyx",
+		"datepicker"
 	],
 	"type": "module",
 	"sideEffects": false,
@@ -54,30 +42,16 @@
 		"LICENSE"
 	],
 	"scripts": {
-		"build": "tsup",
+		"build": "tsup src/index.ts --format esm,cjs --dts --clean",
 		"typecheck": "tsc --noEmit",
 		"clean": "rm -rf dist"
 	},
 	"dependencies": {
-		"@floating-ui/react": "^0.26.0",
-		"@kalyx/adapter-date-fns": "workspace:*",
-		"@kalyx/core": "workspace:*"
+		"date-fns": "^4.0.0",
+		"date-fns-tz": "^3.0.0"
 	},
 	"peerDependencies": {
-		"react": "^19.0.0",
-		"react-dom": "^19.0.0"
-	},
-	"peerDependenciesMeta": {
-		"react": {
-			"optional": false
-		},
-		"react-dom": {
-			"optional": false
-		}
-	},
-	"devDependencies": {
-		"@types/react": "^19.0.0",
-		"@types/react-dom": "^19.0.0"
+		"@kalyx/core": "workspace:^"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/adapter-date-fns/package.json
+++ b/packages/adapter-date-fns/package.json
@@ -47,11 +47,17 @@
 		"clean": "rm -rf dist"
 	},
 	"dependencies": {
+		"@kalyx/core": "workspace:^",
 		"date-fns": "^4.0.0",
 		"date-fns-tz": "^3.0.0"
 	},
 	"peerDependencies": {
 		"@kalyx/core": "workspace:^"
+	},
+	"peerDependenciesMeta": {
+		"@kalyx/core": {
+			"optional": false
+		}
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/adapter-date-fns/src/__tests__/date-fns-adapter.test.ts
+++ b/packages/adapter-date-fns/src/__tests__/date-fns-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DateFnsAdapter } from '../adapters/date-fns.js';
+import { DateFnsAdapter } from '../index.js';
 
 const adapter = DateFnsAdapter;
 

--- a/packages/adapter-date-fns/src/index.ts
+++ b/packages/adapter-date-fns/src/index.ts
@@ -7,13 +7,13 @@ import {
   isAfter as dfIsAfter,
   isValid as dfIsValid,
 } from 'date-fns';
-import type { DateAdapter } from '../types.js';
+import type { DateAdapter } from '@kalyx/core';
 import {
   formatInTimezone,
   isSameDayInTimezone,
   startOfDayInTimezone,
   todayInTimezone,
-} from '../utils/timezone.js';
+} from '@kalyx/core';
 
 function toDate(iso: string): Date {
   return parseISO(iso);
@@ -67,7 +67,7 @@ function utcEndOfWeek(d: Date, weekStartsOn: 0 | 1): Date {
  *
  * @example
  * ```ts
- * import { DateFnsAdapter } from '@kalyx/core';
+ * import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
  *
  * DateFnsAdapter.format('2026-01-15T00:00:00.000Z', 'yyyy-MM-dd'); // "2026-01-15"
  * DateFnsAdapter.addDays('2026-01-15T00:00:00.000Z', 7);           // "2026-01-22T..."

--- a/packages/adapter-date-fns/tsconfig.json
+++ b/packages/adapter-date-fns/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
 		"dst",
 		"iso8601",
 		"utc",
-		"date-fns"
+		"adapter"
 	],
 	"type": "module",
 	"sideEffects": false,
@@ -51,9 +51,8 @@
 		"typecheck": "tsc --noEmit",
 		"clean": "rm -rf dist"
 	},
-	"dependencies": {
-		"date-fns": "^4.0.0",
-		"date-fns-tz": "^3.0.0"
+	"devDependencies": {
+		"@kalyx/adapter-date-fns": "workspace:*"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -6,7 +6,7 @@ import {
   minDate,
   maxDate,
 } from '../utils/calendar.js';
-import { DateFnsAdapter } from '../adapters/date-fns.js';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 
 const adapter = DateFnsAdapter;
 

--- a/packages/core/src/__tests__/date-utils.test.ts
+++ b/packages/core/src/__tests__/date-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { normalizeISO, parseInputValue } from '../utils/date.js';
-import { DateFnsAdapter } from '../adapters/date-fns.js';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 
 const adapter = DateFnsAdapter;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,14 @@ export type {
   WeekStartsOn,
 } from './types.js';
 
-export { DateFnsAdapter } from './adapters/date-fns.js';
+// DateFnsAdapter has been extracted to its own package (`@kalyx/adapter-date-fns`)
+// so `@kalyx/core` stays date-library-agnostic. Import the adapter from there:
+//
+//   import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+//
+// `@kalyx/react` continues to wire the date-fns adapter as the default — direct
+// consumers of `@kalyx/core` who held a reference to the previous re-export need
+// to switch their import path.
 
 export {
   getCalendarDays,

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -1,5 +1,9 @@
-import { parseISO } from 'date-fns';
 import type { ISODateString } from '../types.js';
+
+// Inputs reaching this module are already validated ISO 8601 UTC strings (every
+// caller routes through `normalizeISO` or `DateAdapter.parse`), so native
+// `new Date(string)` is fully spec-defined here. Dropping the `date-fns` import
+// keeps `@kalyx/core` adapter-agnostic — see `.claude/skills/adapter-extraction.md`.
 
 // ── Intl formatter cache ──
 const formatterCache = new Map<string, Intl.DateTimeFormat>();
@@ -58,7 +62,7 @@ function partsInTimezone(utc: Date, timeZone: string) {
  * // → '2026-03-08 03:30'   (post spring-forward EDT)
  */
 export function formatInTimezone(iso: ISODateString, formatStr: string, timeZone: string): string {
-  const p = partsInTimezone(parseISO(iso), timeZone);
+  const p = partsInTimezone(new Date(iso), timeZone);
   const tokens: Record<string, string> = {
     yyyy: String(p.year),
     MM: String(p.month).padStart(2, '0'),
@@ -84,7 +88,7 @@ export function formatInTimezone(iso: ISODateString, formatStr: string, timeZone
  * getTimezoneOffsetMinutes('2026-01-15T12:00:00.000Z', 'Asia/Seoul');       //  540 (UTC+9)
  */
 export function getTimezoneOffsetMinutes(iso: ISODateString, timeZone: string): number {
-  const utc = parseISO(iso);
+  const utc = new Date(iso);
   const p = partsInTimezone(utc, timeZone);
   const asUtcEpoch = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
   return Math.round((asUtcEpoch - utc.getTime()) / 60_000);
@@ -101,7 +105,7 @@ export function getTimezoneOffsetMinutes(iso: ISODateString, timeZone: string): 
  * startOfDayInTimezone('2026-03-09T12:00:00.000Z', 'America/New_York'); // '2026-03-09T04:00:00.000Z' (EDT)
  */
 export function startOfDayInTimezone(iso: ISODateString, timeZone: string): ISODateString {
-  const utc = parseISO(iso);
+  const utc = new Date(iso);
   const p = partsInTimezone(utc, timeZone);
   // Civil midnight as a UTC epoch (what it would be if the wall clock reading lived in UTC).
   const civilMidnightUtc = Date.UTC(p.year, p.month - 1, p.day, 0, 0, 0);
@@ -124,8 +128,8 @@ export function startOfDayInTimezone(iso: ISODateString, timeZone: string): ISOD
  * isSameDayInTimezone('2026-01-15T03:00:00.000Z', '2026-01-15T17:00:00.000Z', 'Asia/Seoul'); // false
  */
 export function isSameDayInTimezone(a: ISODateString, b: ISODateString, timeZone: string): boolean {
-  const pa = partsInTimezone(parseISO(a), timeZone);
-  const pb = partsInTimezone(parseISO(b), timeZone);
+  const pa = partsInTimezone(new Date(a), timeZone);
+  const pb = partsInTimezone(new Date(b), timeZone);
   return pa.year === pb.year && pa.month === pb.month && pa.day === pb.day;
 }
 
@@ -155,7 +159,7 @@ export function civilMidnightFromUtcDay(
   gridUtcIso: ISODateString,
   timeZone: string,
 ): ISODateString {
-  const utc = parseISO(gridUtcIso);
+  const utc = new Date(gridUtcIso);
   const probe = new Date(
     Date.UTC(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate(), 12, 0, 0),
   ).toISOString();
@@ -174,7 +178,7 @@ export function getTimeInTimezone(
   iso: ISODateString,
   timeZone: string,
 ): { hours: number; minutes: number; seconds: number } {
-  const p = partsInTimezone(parseISO(iso), timeZone);
+  const p = partsInTimezone(new Date(iso), timeZone);
   return { hours: p.hour, minutes: p.minute, seconds: p.second };
 }
 
@@ -197,7 +201,7 @@ export function setTimeInTimezone(
   partial: { hours?: number; minutes?: number; seconds?: number },
   timeZone: string,
 ): ISODateString {
-  const p = partsInTimezone(parseISO(iso), timeZone);
+  const p = partsInTimezone(new Date(iso), timeZone);
   const targetHours = partial.hours ?? p.hour;
   const targetMinutes = partial.minutes ?? p.minute;
   const targetSeconds = partial.seconds ?? p.second;

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { DateFnsAdapter, DEFAULT_DATEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
+import { DEFAULT_DATEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type {
   DateAdapter,
   DatePickerLabels,

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
-  DateFnsAdapter,
   DEFAULT_DATEPICKER_LABELS,
   DEFAULT_TIMEPICKER_LABELS,
   getTime,
@@ -10,6 +9,7 @@ import {
   setTimeInTimezone,
   civilMidnightFromUtcDay,
 } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type {
   DateAdapter,
   DateTimePickerLabels,

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
-import { DateFnsAdapter, DEFAULT_RANGEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
+import { DEFAULT_RANGEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type {
   DateAdapter,
   DateRange,

--- a/packages/react/src/components/TimePicker/Root.tsx
+++ b/packages/react/src/components/TimePicker/Root.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
-  DateFnsAdapter,
   DEFAULT_TIMEPICKER_LABELS,
   getTime,
   setTime as setTimeOnIso,
   getTimeInTimezone,
   setTimeInTimezone,
 } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type { ISODateString, TimePickerLabels, TimeValue } from '@kalyx/core';
 import { TimePickerContext } from '../../context/TimePickerContext.js';
 import type { TimePickerContextValue, TimePickerFormat } from '../../context/TimePickerContext.js';

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -1,5 +1,6 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { DateFnsAdapter, civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import { civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type {
   CalendarGrid,
   DateAdapter,

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -1,5 +1,6 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { DateFnsAdapter, civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import { civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type {
   CalendarGrid,
   DateAdapter,

--- a/packages/react/src/hooks/useTimePicker.ts
+++ b/packages/react/src/hooks/useTimePicker.ts
@@ -1,6 +1,5 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import {
-  DateFnsAdapter,
   generateHours,
   generateMinutes,
   getTime,
@@ -10,6 +9,7 @@ import {
   to12Hour,
   to24Hour,
 } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import type { ISODateString, TimeValue } from '@kalyx/core';
 import type { TimePickerFormat } from '../context/TimePickerContext.js';
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -91,8 +91,9 @@ export type { UseDatePickerOptions, UseDatePickerReturn } from './hooks/useDateP
 export type { UseRangePickerOptions, UseRangePickerReturn } from './hooks/useRangePicker.js';
 export type { UseTimePickerOptions, UseTimePickerReturn } from './hooks/useTimePicker.js';
 
-// Re-export from @kalyx/core for convenience
-export { DateFnsAdapter } from '@kalyx/core';
+// Re-export the default adapter so consumers can `import { DateFnsAdapter } from '@kalyx/react'`
+// without pulling in the adapter package directly. Source lives in @kalyx/adapter-date-fns now.
+export { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 export type {
   ISODateString,
   DateRange,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,22 +173,10 @@ importers:
         specifier: ~6.0.2
         version: 6.0.2
 
-  packages/core:
+  packages/adapter-date-fns:
     dependencies:
-      date-fns:
-        specifier: ^4.0.0
-        version: 4.1.0
-      date-fns-tz:
-        specifier: ^3.0.0
-        version: 3.2.0(date-fns@4.1.0)
-
-  packages/react:
-    dependencies:
-      '@floating-ui/react':
-        specifier: ^0.26.0
-        version: 0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@kalyx/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       date-fns:
         specifier: ^4.0.0
@@ -196,6 +184,24 @@ importers:
       date-fns-tz:
         specifier: ^3.0.0
         version: 3.2.0(date-fns@4.1.0)
+
+  packages/core:
+    devDependencies:
+      '@kalyx/adapter-date-fns':
+        specifier: workspace:*
+        version: link:../adapter-date-fns
+
+  packages/react:
+    dependencies:
+      '@floating-ui/react':
+        specifier: ^0.26.0
+        version: 0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@kalyx/adapter-date-fns':
+        specifier: workspace:*
+        version: link:../adapter-date-fns
+      '@kalyx/core':
+        specifier: workspace:*
+        version: link:../core
       react:
         specifier: ^19.0.0
         version: 19.2.5

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,9 @@
 {
 	"files": [],
-	"references": [{ "path": "packages/core" }, { "path": "packages/react" }]
+	"references": [
+		{ "path": "packages/core" },
+		{ "path": "packages/adapter-date-fns" },
+		{ "path": "packages/react" }
+	]
 }
+


### PR DESCRIPTION
## Summary

Lands steps 1 + 2 of the four-step adapter-extraction plan (`.claude/skills/adapter-extraction.md`). After this PR, `@kalyx/core` is fully date-library-agnostic and the `date-fns` implementation lives in its own publishable workspace package. Foundation for shipping dayjs / luxon / Temporal adapters in v1.1+ without forcing every Kalyx user to bundle two date libraries.

## What's in this PR

### Commit 1 — `refactor(core): remove date-fns from timezone util`
`packages/core/src/utils/timezone.ts` was the lone "date-fns leak" found in the C1 diagnostic. Every caller reaches this module with an already-validated ISO 8601 UTC string (routes through `normalizeISO` or `DateAdapter.parse`), so native `new Date(string)` is fully spec-defined for that subset. Drop the `date-fns` import.

### Commit 2 — `feat: extract @kalyx/adapter-date-fns package`
- **New workspace package** `packages/adapter-date-fns/` with the full `DateFnsAdapter` moved verbatim. Same UTC semantics, same timezone-aware paths, same 35 adapter tests (moved alongside the implementation they cover).
- **`@kalyx/core`** — `DateFnsAdapter` is no longer exported. `date-fns` / `date-fns-tz` removed from `dependencies`. `@kalyx/adapter-date-fns` added as devDependency so 2 internal contract-driving tests (`calendar.test.ts`, `date-utils.test.ts`) still have a concrete adapter to test against. `date-fns` keyword dropped.
- **`@kalyx/react`** — `@kalyx/adapter-date-fns` is now a regular dependency so installing just `@kalyx/react` continues to get a working default. `date-fns` / `date-fns-tz` removed (react never imported them directly). 8 source files updated: `DateFnsAdapter` is now imported from `@kalyx/adapter-date-fns` instead of `@kalyx/core`.

## Surface impact

| Package | Change | Breaking? |
|---|---|---|
| `@kalyx/core` | `DateFnsAdapter` export removed | **Yes** (rc bump in pre-mode) — anyone importing it directly from `@kalyx/core` switches to `@kalyx/adapter-date-fns`. |
| `@kalyx/react` | None on the public surface. `DateFnsAdapter` is still re-exported and the default is still wired up. | **No** |
| `@kalyx/adapter-date-fns` | Brand-new package at `1.0.0-rc.0` | New |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:run` — 494 / 494 pass (35 adapter tests in the new package, 165 core tests including the 2 cross-package ones, 287 react tests including the 7 SSR-DST guards from #79)
- [x] `pnpm --filter @kalyx/adapter-date-fns build` — succeeds, dist gzip ~5KB
- [x] `pnpm --filter @kalyx/core build` — succeeds, no date-fns in output
- [x] `pnpm --filter @kalyx/react build` — succeeds
- [x] `pnpm check-bundle` — ESM 15.34 KB / CJS 15.54 KB (≤ 16 KB)

## Migration (for direct `@kalyx/core` users)

```diff
- import { DateFnsAdapter } from '@kalyx/core';
+ import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
```

`@kalyx/react` consumers don't need to change anything.

## Follow-up (separate PR)

Steps 3-4 of the plan — the `/headless` entry point that lets dayjs/luxon users tree-shake `date-fns` out — remain. They require moving the inline `adapter = DateFnsAdapter` fallback out of every Root + hook (8 files) and re-assembling the dot-notation components at the entry boundary, plus updating tests. That's a larger refactor with its own test churn, so it ships separately rather than getting bundled into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 날짜 처리 어댑터를 새로운 별도 패키지로 분리했습니다. `DateFnsAdapter`를 `@kalyx/core`에서 가져오던 사용자는 `@kalyx/adapter-date-fns`에서 가져오도록 import 경로를 변경해야 합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jiji-hoon96/kalyx/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->