### PR TITLE
fix(vercel): use root `pnpm build` so adapter-date-fns is included

### DIFF
--- a/apps/docs-site/vercel.json
+++ b/apps/docs-site/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "docusaurus-2",
-  "buildCommand": "cd ../.. && pnpm install --frozen-lockfile && pnpm --filter @kalyx/core build && pnpm --filter @kalyx/react build && pnpm --filter docs-site build",
+  "buildCommand": "cd ../.. && pnpm install --frozen-lockfile && pnpm build && pnpm --filter docs-site build",
   "outputDirectory": "build",
   "installCommand": "echo skip",
   "cleanUrls": true,


### PR DESCRIPTION
## Summary

Vercel docs-site deploys have been failing since PR #82 merged with:

\`\`\`
src/index.ts(96,32): error TS2307: Cannot find module '@kalyx/adapter-date-fns' or its corresponding type declarations.
\`\`\`

The Vercel \`buildCommand\` in \`apps/docs-site/vercel.json\` was hardcoded to:

\`\`\`
cd ../.. && pnpm install --frozen-lockfile
  && pnpm --filter @kalyx/core build
  && pnpm --filter @kalyx/react build
  && pnpm --filter docs-site build
\`\`\`

When \`@kalyx/adapter-date-fns\` was extracted from core, this chain skipped the new package. \`@kalyx/react\` imports \`DateFnsAdapter\` from \`@kalyx/adapter-date-fns\`, so tsup's DTS step can't resolve it.

## Fix

The root \`pnpm build\` script is already the canonical sequential chain (\`core → adapter-date-fns → react\`) — landed alongside PR #82's CI fix. Point Vercel at \`pnpm build\` so:

1. The fix takes effect immediately.
2. Any future \`@kalyx/*\` package added to the root chain (e.g., \`@kalyx/adapter-dayjs\` in v1.1) flows through Vercel without another \`vercel.json\` edit.

New buildCommand:

\`\`\`
cd ../.. && pnpm install --frozen-lockfile && pnpm build && pnpm --filter docs-site build
\`\`\`

## Test plan

- [x] Local: \`cd apps/docs-site && cd ../.. && pnpm install --frozen-lockfile && pnpm build && pnpm --filter docs-site build\` succeeds.
- Vercel preview deploy on this PR will verify the live fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)