### PR TITLE
docs(skill): refresh rc-announcement to v1.3 (rc.13 + adapter-date-fns)

### DIFF
--- a/.claude/skills/rc-announcement.md
+++ b/.claude/skills/rc-announcement.md
@@ -1,6 +1,6 @@
 ---
 name: rc-announcement
-version: 1.2.0
+version: 1.3.0
 description: |
   v1.0.0 Release Candidate 배포·공지 플레이북.
   npm publish 검증, GitHub Release, docs 배너, README 배지, 소셜 초안까지 한 흐름으로 다룬다.
@@ -17,14 +17,15 @@ triggers:
 
 ---
 
-## 전제 상태 (2026-05-27 기준 handoff 시점)
+## 전제 상태 (2026-06-08 기준 handoff 시점)
 
 - `.changeset/pre.json`: `mode: pre`, `tag: rc`
-- npm 게시 버전: `@kalyx/react@1.0.0-rc.12`, `@kalyx/core@1.0.0-rc.12`
+- npm 게시 버전: `@kalyx/react@1.0.0-rc.13`, `@kalyx/core@1.0.0-rc.13`
+- **`@kalyx/adapter-date-fns@1.0.0-rc.1` publish 실패** — 404 (npm trusted publisher 미설정 / 신규 scoped 패키지 첫 publish 권한 부재). 사용자 액션 대기 중. core+react publish는 정상이므로 RC 배지/안내는 그대로 유효.
 - dist-tag: `rc` (확정). `latest`는 여전히 stable 시점의 `0.4.0` — pre-mode 의도된 상태
-- 번들 한계: **16 KB** gzip (rc.8에서 13→15→16 단계적 상향). 현재 측정 ESM ~15.33 KB / CJS ~15.51 KB
-- 누적 changeset 0개 (rc.12 publish 시 모두 소비). 다음 changeset이 들어오면 release 봇이 rc.13 PR 생성
-- rc.0 → rc.12 누적 주요 변경:
+- 번들 한계: **16 KB** gzip (rc.8에서 13→15→16 단계적 상향). 직전 측정값 유지 (rc.13에서 core 내부 timezone 유틸이 date-fns 의존을 떼면서 native Date로 전환 — 재측정 필요)
+- 누적 changeset 0개 (rc.13 publish 시 모두 소비). 다음 changeset이 들어오면 release 봇이 rc.14 PR 생성
+- rc.0 → rc.13 누적 주요 변경:
   - **컴포넌트 표면 확정**: 7 picker (Date/Range/Time/DateTime/Month/Year/Week) + 3 hook 모두 시리즈 내 안정화
   - **WAI-ARIA grid 키보드 내비**: Arrow/Home/End/PageUp/Down/Enter/Space + roving tabIndex (#46)
   - **MonthPicker/YearPicker disabled 셀**: before/after rule + 키보드 skip (#48)
@@ -45,6 +46,11 @@ triggers:
   - **rc.12**:
     - 7 컴포넌트 모두에 controlled value + DST 경계 + displayTimezone 결정성 테스트 추가 (#79)
     - to12Hour/to24Hour silent-wrong 차단 → RangeError로 명시화 (#80)
+  - **rc.13** (adapter neutralization steps 1+2 — #82):
+    - `@kalyx/core`에서 **date-fns 의존 제거**. `utils/timezone.ts`가 native `Date` + `Intl.DateTimeFormat` 기반으로 재작성됨 (DST/IANA timezone 동작 동등).
+    - 신규 워크스페이스 **`@kalyx/adapter-date-fns`** 추가. `DateFnsAdapter`는 이제 이 패키지에서만 export (core에서는 제거).
+    - `@kalyx/react` 사용자 surface 변화 **없음** — 기본 엔트리가 default adapter를 자동 주입하므로 기존 import 그대로 동작.
+    - vercel build 안정화 — 루트 `pnpm build`로 통일해 adapter-date-fns가 react보다 먼저 빌드되도록 보장 (#85).
 - 보안: 최근 패치 — `qs >=6.15.2` (#67), `next` 13 OSV 해결 (#55), `fast-uri` (#52)
 
 > 이 상태는 시점 스냅샷. 새 세션에서 먼저 "작업 전 검증"으로 실제 상태를 확인한다.
@@ -86,15 +92,51 @@ pnpm --filter @kalyx/react build 2>&1 | grep -E "gzip|KB"
 mkdir -p /tmp/kalyx-rc-test && cd /tmp/kalyx-rc-test
 pnpm init && pnpm add @kalyx/react@rc react@19 react-dom@19
 node -e "const k=require('@kalyx/react'); console.log(Object.keys(k));"
+
+# 신규 패키지(adapter-date-fns)도 별도로 검증
+npm view @kalyx/adapter-date-fns dist-tags  # 404가 나오면 publish 실패 상태
 ```
 
 **누락 시**: CI (`release.yml`)는 changesets가 pre-mode이면 자동으로 `pre.json.tag` 값을 dist-tag로 사용 (별도 `--tag` 옵션 불필요). 실패 근인은 주로 `NPM_TOKEN` 권한 또는 OIDC trusted publishing 설정. 최근 release.yml은 `npm >= 11.5.1` 검증 단계 포함.
+
+> ⚠️ **신규 워크스페이스 첫 publish — trusted publisher 별도 등록 필요**
+>
+> rc.13에서 `@kalyx/adapter-date-fns@1.0.0-rc.1` publish가 **404로 실패**했다. core/react는 이미 OIDC trusted publisher가 등록돼 있어 통과하지만, **신규 scoped 패키지는 npm 레지스트리에 처음 등장하는 순간 등록된 publisher가 없으면 404**가 난다.
+>
+> 두 가지 해결 경로 중 하나:
+>
+> 1. **권장 — npmjs.com OIDC 등록** (영구 해결, 사용자 액션 필요):
+>    - npmjs.com → Account Settings → **OIDC Trusted Publishers** → Add publisher
+>    - Repository: `jiji-hoon96/kalyx`
+>    - Workflow file: `.github/workflows/release.yml`
+>    - Package name: `@kalyx/adapter-date-fns`
+>    - 이후 release.yml 재실행하면 자동 publish
+>
+> 2. **1회 수동 publish** (임시 우회):
+>    ```bash
+>    cd packages/adapter-date-fns
+>    npm publish --access public --tag rc
+>    ```
+>    이후에도 다음 release부터는 OIDC 등록을 마쳐야 CI가 자동으로 처리.
 
 **`@next` 잔존 검사**: 과거 docs/README가 `@next`로 안내했다면 모두 `@rc`로 정정. `pre.json.tag: rc`가 source of truth.
 
 ```bash
 grep -rn "@kalyx/react@next\|@kalyx/core@next" README.md README.ko.md apps/docs-site/ 2>/dev/null | grep -v node_modules
 ```
+
+---
+
+#### 신규 워크스페이스 추가 체크리스트
+
+`packages/<new-package>/` 를 새로 추가했다면 다음을 모두 통과시켜야 release.yml이 깔끔하게 돈다 (rc.13 → adapter-date-fns 분리에서 학습한 항목):
+
+- [ ] **tsconfig.json `references`** — 루트 + 의존하는 패키지(`packages/react/tsconfig.json` 등)에 신규 패키지 path 추가
+- [ ] **루트 `package.json` build 스크립트 순차 chain** — 의존 순서대로 직렬화. 예: `core → adapter-date-fns → react` (병렬 시 race로 react 빌드가 adapter 산출물을 못 찾음)
+- [ ] **CI workflow 모든 단계 점검** — `pr-check.yml`의 test/build/docs-site 잡, `release.yml`의 build 잡, `e2e-and-docs.yml` 까지 새 패키지가 빌드 산출물에 포함되는지
+- [ ] **`apps/docs-site/vercel.json` `buildCommand`** — 루트 `pnpm build`로 통일 (#85 회귀 방지)
+- [ ] **npm trusted publisher 별도 등록** — 위 ⚠️ 박스 참조. 신규 scoped 패키지는 첫 publish 직전에 OIDC 등록이 끝나 있어야 함
+- [ ] **changeset entry에 신규 패키지 포함** — 첫 release시 `@kalyx/<new-package>: minor` (또는 `1.0.0-rc.1` 시작)을 명시
 
 ---
 
@@ -133,10 +175,10 @@ See [packages/react/CHANGELOG.md](./packages/react/CHANGELOG.md) and [packages/c
 **생성**:
 ```bash
 # 한 RC 본문은 .github/RELEASE_NOTES_RC_<N>.md 로 보관해두면 다음 RC 갱신이 쉽다
-gh release create v1.0.0-rc.12 \
+gh release create v1.0.0-rc.13 \
   --prerelease \
-  --title "v1.0.0-rc.12 — SSR determinism guards & boundary validation" \
-  --notes-file .github/RELEASE_NOTES_RC_12.md
+  --title "v1.0.0-rc.13 — adapter-date-fns extracted, core goes date-fns-free" \
+  --notes-file .github/RELEASE_NOTES_RC_13.md
 ```
 
 > **확인**: `release.yml`의 "릴리즈 알림" 단계가 changesets/action을 통해 release를 자동 생성하기도 한다. 자동 생성된 게 이미 있다면 `gh release edit` 으로 본문만 다듬는다.
@@ -152,9 +194,9 @@ gh release create v1.0.0-rc.12 \
 ```ts
 themeConfig: {
   announcementBar: {
-    id: 'v1-rc-12',                  // RC가 올라갈 때마다 id 변경 — 닫힘 상태 초기화
+    id: 'v1-rc-13',                  // RC가 올라갈 때마다 id 변경 — 닫힘 상태 초기화
     content:
-      'Kalyx v1.0 RC12 is out — try <code>pnpm add @kalyx/react@rc</code> and share feedback on <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/issues">GitHub</a>.',
+      'Kalyx v1.0 RC13 is out — try <code>pnpm add @kalyx/react@rc</code> and share feedback on <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/issues">GitHub</a>.',
     backgroundColor: '#5b4fe1',
     textColor: '#ffffff',
     isCloseable: true,
@@ -176,7 +218,7 @@ i18n: `apps/docs-site/i18n/ko/` 쪽 `code.json` 또는 별도 announcementBar �
 
 **변경 지점** (`README.md`, `README.ko.md` 둘 다):
 
-1. bundle 배지 gzip 수치를 현재 빌드 측정값으로 갱신. 예: `15.33KB` (ESM) / `15.51KB` (CJS). 한 수치만 표기한다면 ESM 값을 채택.
+1. bundle 배지 gzip 수치를 현재 빌드 측정값으로 갱신. (rc.13 시점은 직전 측정값 유지 — adapter 분리로 인한 재측정 필요. `pnpm --filter @kalyx/react build` 로 ESM/CJS 수치 확보 후 갱신. 한 수치만 표기한다면 ESM 값을 채택.)
 2. RC 배지가 이미 있는지 확인. 없으면 추가 — dist-tag는 반드시 `rc`:
    ```md
    [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
@@ -196,14 +238,14 @@ i18n: `apps/docs-site/i18n/ko/` 쪽 `code.json` 또는 별도 announcementBar �
 **업로드하지 말 것**. 초안만 `.github/RC_SOCIAL_DRAFT.md`에 저장하고 사용자가 확인 후 직접 게시. 1인칭 결정형 톤(라이브러리 오너 화법) 유지, AI 권유 톤 금지.
 
 X/Twitter (280자):
-> Kalyx v1.0-rc12 is out — the headless React DatePicker that ships complete. Date / Range / Time / DateTime / Month / Year / Week — ISO 8601 UTC, IANA timezone, ~15KB gzip.
+> Kalyx v1.0-rc13 is out — core is now date-fns-free. The headless React DatePicker that ships complete: Date / Range / Time / DateTime / Month / Year / Week — ISO 8601 UTC, IANA timezone, under 16KB gzip.
 >
 > `pnpm add @kalyx/react@rc`
 >
 > Feedback welcome.
 
 LinkedIn:
-> Kalyx v1.0 is in release candidate. One library covers Date, Range, Time, DateTime, Month, Year, Week pickers — zero CSS, SSR-safe, IANA timezone. Bundle holds at ~15KB gzipped under a 16KB ceiling.
+> Kalyx v1.0-rc13 is out. The core is now adapter-agnostic — date-fns has moved into `@kalyx/adapter-date-fns`, with the default React entry still injecting it automatically (zero migration for existing users). One library still covers Date, Range, Time, DateTime, Month, Year, Week pickers — zero CSS, SSR-safe, IANA timezone, under a 16KB gzipped ceiling.
 >
 > Trying the RC: `pnpm add @kalyx/react@rc`. Issues: https://github.com/jiji-hoon96/kalyx/issues (tag `v1-rc`).
 


### PR DESCRIPTION
## Summary

- `version: 1.2.0 → 1.3.0`, 전제 상태를 `@kalyx/core@1.0.0-rc.13` / `@kalyx/react@1.0.0-rc.13` 기준으로 갱신
- rc.13 누적 변경 항목 추가 — `@kalyx/core`에서 date-fns 의존 제거, 신규 워크스페이스 `@kalyx/adapter-date-fns` 분리 (#82), vercel build 안정화 (#85). `@kalyx/react` surface 변화 없음
- Step 1에 **신규 워크스페이스 trusted publisher 등록 경고 박스** 신설 — `@kalyx/adapter-date-fns@1.0.0-rc.1` publish 404 실패 케이스를 영구 사례로 박제 + 두 가지 해결 경로(OIDC 등록 권장 / 1회 수동 publish 우회) 안내
- "신규 워크스페이스 추가 체크리스트" 박스 신설 — tsconfig references, 루트 build 순차 chain, CI workflow 점검, vercel.json buildCommand, trusted publisher, changeset entry 6개 항목
- Step 2/3/5의 RC 번호(12 → 13) 및 헤드라인 갱신, 소셜 카피를 "core is now date-fns-free / adapter-agnostic" 메시지로 재작성

## Why now

- rc.13 publish 직후. adapter-date-fns 분리(#82, #84)가 main에 들어왔고 release.yml이 신규 패키지에서 404로 실패한 상태 — 이 학습 내용을 다음 세션이 잃지 않도록 skill에 박제
- core+react는 정상 publish됐으므로 RC 공지 자체는 그대로 진행 가능. adapter-date-fns 부분만 별도 사용자 액션 대기

## Notes

- 번들 수치(15.33 / 15.51 KB)는 갱신하지 않고 "직전 측정값 유지 — 재측정 필요" 코멘트 처리. core 내부 timezone 유틸이 native Date 기반으로 재작성되어 실측이 의미 있어졌으므로, 다음 PR에서 빌드 후 README 배지와 함께 일괄 갱신 권장
- **사용자 액션 필요**: npmjs.com Settings → OIDC Trusted Publishers에 `jiji-hoon96/kalyx` + `.github/workflows/release.yml` + package `@kalyx/adapter-date-fns` 등록. 등록 전까지는 다음 release.yml도 동일한 404로 실패. 임시로는 `cd packages/adapter-date-fns && npm publish --access public --tag rc` 로 우회 가능
- skill 파일 변경이므로 changeset 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * RC 배포 프로세스 문서를 rc.13 기준으로 업데이트했습니다. 핵심 변경 사항 검증 절차, 새로운 워크스페이스 추가 체크리스트, GitHub 릴리스 생성 명령, 문서 사이트 공지 내용이 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->