### PR TITLE
docs: stable release prep — fix stale bundle size copy + adapter import paths

### DIFF
--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~15.01 KB** (v1.0.0-rc.8, 7 components, CI ceiling 16 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~15.63 KB** (v1.0.0-rc.14, 7 components, CI ceiling 16 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -91,7 +91,7 @@ const config: Config = {
     announcementBar: {
       id: 'v1-rc',
       content:
-        'Kalyx v1.0 RC is out — try <code>pnpm add @kalyx/react@next</code> and share feedback on <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/issues">GitHub</a>.',
+        'Kalyx v1.0 RC is out — try <code>pnpm add @kalyx/react@rc</code> and share feedback on <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/issues">GitHub</a>.',
       backgroundColor: '#5b4fe1',
       textColor: '#ffffff',
       isCloseable: true,
@@ -102,7 +102,7 @@ const config: Config = {
     },
     metadata: [
       {name: 'keywords', content: 'react, datepicker, headless, typescript, tailwind, accessible, ssr, calendar, timepicker, rangepicker'},
-      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~12 KB (≤ 13 KB ceiling).'},
+      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~15.63 KB (≤ 16 KB ceiling).'},
     ],
     navbar: {
       title: 'Kalyx',

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -184,7 +184,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~15.01 KB** (v1.0.0-rc.8, 7 components, CI ceiling 16 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~15.63 KB** (v1.0.0-rc.14, 7 components, CI ceiling 16 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,10 +35,14 @@ import type {
 
 ### Adapter
 
+`@kalyx/core` defines the `DateAdapter` interface but ships no implementation — the package is date-library-agnostic. Install a separate adapter package:
+
 ```ts
-import { DateFnsAdapter } from '@kalyx/core';
-// UTC-safe default adapter, built on date-fns v4.
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+// UTC-safe adapter built on date-fns v4.
 ```
+
+Bring your own adapter by implementing the `DateAdapter` interface from `@kalyx/core` against any date library (dayjs, luxon, Temporal, etc.).
 
 ### Calendar utilities
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,9 @@
 # @kalyx/react
 
-> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~14 KB gzip (≤ 15 KB ceiling).
+> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~15.63 KB gzip (≤ 16 KB ceiling).
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-13.60KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.63KB-brightgreen)](https://kalyx-docs.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 


### PR DESCRIPTION
## Summary

v1.0 stable 졸업 전 사용자 노출 카피의 stale 흔적 정리. 점검 4(RC 졸업 점검)에서 발견한 차단 사항 #1~#4 해결.

## Changes (5 files, +12 / -8)

| 파일 | 변경 |
|---|---|
| `packages/react/README.md` | 헤더 `~14 KB (≤ 15 KB ceiling)` + 배지 `gzip-13.60KB` → `~15.63 KB (≤ 16 KB ceiling)` + `gzip-15.63KB` |
| `packages/core/README.md` | `DateFnsAdapter` import 위치 정정 (`@kalyx/core` → `@kalyx/adapter-date-fns`) + adapter neutralization 안내 추가 |
| `apps/docs-site/docusaurus.config.ts` (announcementBar) | `pnpm add @kalyx/react@next` → `@rc` (dist-tag `next`는 존재하지 않음) |
| `apps/docs-site/docusaurus.config.ts` (metadata description) | `~12 KB (≤ 13 KB ceiling)` → `~15.63 KB (≤ 16 KB ceiling)` |
| `apps/docs-site/docs/api/react.md` (en + ko) | `~15.01 KB (v1.0.0-rc.8)` → `~15.63 KB (v1.0.0-rc.14)` |

## Why now

stable 1.0.0 publish 전에 정리해두지 않으면 npm package page, docusaurus 사이트, SEO/소셜 카드에 잘못된 정보가 그대로 노출됨. `@next` 안내는 클릭 시 설치 실패까지 유발.

## Test plan

- [x] 변경은 텍스트 only — 빌드/타입/테스트 영향 없음 (CI가 자동 검증)
- [x] changeset 없음 (publish surface 영향 없는 docs/README 변경)
- [ ] docs-site 빌드 통과 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 번들 크기 정보를 최신 버전 기준으로 업데이트했습니다.
  * 배포 버전 표기를 최신 릴리스 버전으로 갱신했습니다.
  * 어댑터 설명을 명확히 하여 올바른 패키지 설치 경로를 안내합니다.
  * 다국어 문서를 동기화하여 일관성 있는 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->