### PR TITLE
fix(e2e): build apps/docs in webServer command before serving

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,10 +26,11 @@ export default defineConfig({
 	],
 
 	webServer: {
-		// 빌드 후 정적 export(out/)를 로컬 서버로 서빙
-		command: 'pnpm build && npx serve apps/docs/out -l 3000',
+		// packages (core → adapter-date-fns → react) 빌드 후 데모 앱(apps/docs)
+		// `next build` (output: 'export')로 out/ 정적 export 생성 → serve로 띄움
+		command: 'pnpm build && pnpm --filter docs build && npx serve apps/docs/out -l 3000',
 		url: 'http://localhost:3000',
 		reuseExistingServer: !process.env.CI,
-		timeout: 120_000,
+		timeout: 240_000,
 	},
 });


### PR DESCRIPTION
## Summary

Playwright e2e workflow has been failing on every main push (5+ consecutive failures, all browsers) with \`Error: Timed out waiting 120000ms from config.webServer\`.

## Root cause

\`playwright.config.ts\` webServer command was:

\`\`\`
pnpm build && npx serve apps/docs/out -l 3000
\`\`\`

But root \`pnpm build\` only builds packages (\`core → adapter-date-fns → react\`). It does NOT invoke \`next build\` for the demo app at \`apps/docs\`. So:

1. \`apps/docs/out\` is in \`.gitignore\` — fresh CI checkouts have no \`out/\` directory.
2. \`npx serve apps/docs/out -l 3000\` starts but serves a missing/empty directory.
3. \`http://localhost:3000\` never returns the expected demo pages.
4. Playwright times out after 120s, all three browsers fail.

Local runs passed because \`apps/docs/out\` was a stale build from a previous local session (May 11).

## Fix

Chain \`pnpm --filter docs build\` into the webServer command so the demo app is built before serving:

\`\`\`diff
- command: 'pnpm build && npx serve apps/docs/out -l 3000',
+ command: 'pnpm build && pnpm --filter docs build && npx serve apps/docs/out -l 3000',
- timeout: 120_000,
+ timeout: 240_000,
\`\`\`

Timeout raised to 240s because \`next build\` adds ~30–60s on cold CI.

## Test plan

- [ ] CI: chromium / firefox / webkit jobs all pass on this PR
- [ ] Demo pages load (\`/datepicker\`, \`/rangepicker\`, etc.) under the served output
- [ ] No regression in local \`pnpm test:e2e\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)