### PR TITLE
chore(deps): upgrade @floating-ui/react 0.26 → 0.27 + vitest lockfile sync

### DIFF
--- a/.changeset/floating-ui-0-27.md
+++ b/.changeset/floating-ui-0-27.md
@@ -1,0 +1,5 @@
+---
+"@kalyx/react": patch
+---
+
+Bump `@floating-ui/react` from `^0.26.0` to `^0.27.0`. No public API change — popover positioning, focus-out behaviour, and SSR safety are unaffected. Tests (497/497) and bundle size (15.76 KB CJS / 15.63 KB ESM gzip, ≤ 16 KB ceiling) hold.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
 		"clean": "rm -rf dist"
 	},
 	"dependencies": {
-		"@floating-ui/react": "^0.26.0",
+		"@floating-ui/react": "^0.27.0",
 		"@kalyx/adapter-date-fns": "workspace:*",
 		"@kalyx/core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,8 +194,8 @@ importers:
   packages/react:
     dependencies:
       '@floating-ui/react':
-        specifier: ^0.26.0
-        version: 0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^0.27.0
+        version: 0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@kalyx/adapter-date-fns':
         specifier: workspace:*
         version: link:../adapter-date-fns
@@ -1871,11 +1871,11 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.28':
-    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -10079,7 +10079,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@floating-ui/react@0.26.28(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@floating-ui/react@0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@floating-ui/utils': 0.2.11


### PR DESCRIPTION
## Summary

Two related dependency updates landing in one PR.

### 1. \`@floating-ui/react\` 0.26 → 0.27

prod dependency of \`@kalyx/react\`. Minor bump on 0.x — Kalyx's \`usePopover\` consumes only the stable surface (\`useFloating\`, \`useInteractions\`, \`useDismiss\`, \`autoUpdate\`, middleware), unaffected by 0.27 changes.

### 2. vitest lockfile drift sync (side-effect)

\`pnpm install\` synced vitest / \`@vitest/coverage-v8\` to 4.1.8 across all workspaces — \`package.json\` was already at \`^4.1.8\` since #89, but the lockfile lagged for some entries. Now consistent.

## Verification

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test:run\` — **497/497 pass**
- [x] \`pnpm build\` — core → adapter-date-fns → react chain OK
- [x] \`pnpm check-bundle\` — ESM 15.63 KB / CJS 15.76 KB gzip (≤ 16 KB ceiling, unchanged from main)
- [x] No public API change
- [ ] CI: full PR check + e2e (3 browsers)

## Changeset

\`@kalyx/react: patch\` — pulls a refreshed peer transitively. No consumer-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)