### PR TITLE
perf(docs-site): preload + fetchpriority hint on hero LCP image (partial #103 recovery)

### DIFF
--- a/apps/docs-site/src/components/Hero/StaticHero.tsx
+++ b/apps/docs-site/src/components/Hero/StaticHero.tsx
@@ -1,18 +1,37 @@
+import Head from '@docusaurus/Head';
 import styles from './Hero.module.css';
 
 /**
  * SSG-safe placeholder for the right column. Identical to the static
  * frame 0 of <HeroDemo>, so the lazy chunk swap is layout-stable.
+ *
+ * Injects a <link rel="preload"> for the hero WebP at <head> level so
+ * the browser kicks off the LCP image fetch before the rest of the body
+ * scripts. The <img> itself is also marked fetchpriority=high so browsers
+ * that ignore preload still treat the request as critical.
  */
 export default function StaticHero() {
   return (
-    <img
-      className={styles.staticHero}
-      src="/img/hero-light.webp"
-      alt="Kalyx — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker"
-      width={960}
-      height={540}
-      loading="eager"
-    />
+    <>
+      <Head>
+        <link
+          rel="preload"
+          as="image"
+          href="/img/hero-light.webp"
+          // @ts-expect-error fetchpriority is a valid HTML attribute but not yet in React's link types
+          fetchpriority="high"
+        />
+      </Head>
+      <img
+        className={styles.staticHero}
+        src="/img/hero-light.webp"
+        alt="Kalyx — DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker"
+        width={960}
+        height={540}
+        loading="eager"
+        // @ts-expect-error fetchpriority is valid HTML; React 19 types do not yet include it
+        fetchpriority="high"
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

First attempt at recovering the Lighthouse Performance regression introduced by PR-A2 ([#103](https://github.com/jiji-hoon96/kalyx/issues/103)).

This PR ships **Candidate 2** from the issue: `<link rel="preload" as="image" fetchpriority="high">` injected via Docusaurus `<Head>` + `fetchpriority="high"` attribute on the `<img>` itself.

## Honest measurement

**Localhost simulate (mobile + Slow 4G + 4× CPU)** — 3 runs each:

| Build | Performance | FCP | LCP |
|---|---|---|---|
| Pre-PR-A2 (baseline, main 2026-06-10) | **72** | n/a | n/a |
| PR-A2 (commit 7990348, no change) | **61** | 4.7 s | 7.6 s |
| **This PR (Candidate 2 applied)** | **61** | 4.7–4.9 s | 7.5–7.7 s |
| Δ vs PR-A2 | **0** | 0 | 0 |
| Δ vs baseline | **−11** | n/a | n/a |

**No measurable change on this metric in this environment.**

### Why preload didn't move the LCP needle

Lighthouse's `lcp-discovery-insight` audit identifies the LCP element as:

```
selector: "div.container > div.grid_Tiug > div.copy_FDNK > p.subtitle_KV87"
snippet: "<p class=\"subtitle_KV87\">"
```

The LCP element is the Hero **subtitle paragraph**, not the hero image. Preloading the WebP doesn't help when the largest contentful paint is a text node gated by render-blocking CSS + JS (Docusaurus theme + chunk hydration).

### Why merge it anyway

The preload + `fetchpriority` change is a **no-harm best practice**:

1. Zero bundle weight, zero runtime cost
2. Helps browsers that paint images concurrently with text (race condition, varies by viewport)
3. May matter on **real Vercel-deployed network** where image bytes compete with framework JS for bandwidth (different from localhost serve)
4. Locks in the LCP discovery hint should a future design change make the image the LCP element

## What this PR does NOT do

To recover the full Δ −11 on localhost simulate, the next round of work needs to be **architectural**, not parameter tuning. Tracked separately in #103:

- Defer below-the-fold sections (FeatureGrid / SameJsxBlock / PickerGrid / WhyKalyx / GetStarted) via IntersectionObserver until they scroll into view — reduces initial render work
- Consolidate per-section CSS modules into a shared landing token module — gzip already deduplicates so byte savings is small, but parsing cost matters
- Audit Docusaurus theme JS — defer color-mode toggle / announcement bar runtime until after FCP
- Inline critical hero CSS in `<head>` to skip stylesheet round-trip

## Recommendation for issue #103

1. Merge this PR for the best-practice baseline
2. Measure the Vercel preview deploy from this PR — real production network may show a smaller regression than localhost simulate (which is intentionally pessimistic)
3. If Vercel real-network Δ is still > −5, do an architectural round (deferred sections + critical CSS) as a separate PR

## Test plan

- [x] `pnpm test:run` — Hero test still passes (4/4)
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter docs-site build` succeeds
- [x] Built `index.html` contains `<link rel="preload" as="image" href="/img/hero-light.webp" fetchpriority="high">`
- [x] Built `index.html` contains `<img ... fetchpriority="high">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 초기 페이지 로딩 성능을 위해 이미지 사전 로드 및 로딩 우선순위 처리가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->