### PR TITLE
docs: Track 1 PR-B/C/D subset specs + implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-06-11-track1-pr-b-sandbox-infrastructure.md
+++ b/docs/superpowers/plans/2026-06-11-track1-pr-b-sandbox-infrastructure.md
@@ -1,0 +1,1008 @@
+# Track 1 PR-B — Per-Picker Sandbox Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every picker docs page a real interactive sandbox via inline `tsx live` blocks (Docusaurus ReactLiveScope extended) and full `<StackBlitzEmbed>` iframes backed by 7 new `examples/*` projects.
+
+**Architecture:** One ReactLiveScope edit unlocks live blocks repo-wide. One new `<StackBlitzEmbed>` React component renders the iframe + "Open in StackBlitz" link. Seven self-contained Vite-based example projects under `examples/` follow a uniform template (basic) or specialise it (RHF, Tailwind, shadcn). All 14 picker docs (7 en + 7 ko) get a live block and an embed added below the intro.
+
+**Tech Stack:** React 19, `@kalyx/react` (workspace), Vite 7, Docusaurus 3.10's `@docusaurus/theme-live-codeblock`, StackBlitz GitHub embed URLs (no SDK needed in this PR — that's PR-C's territory), existing vitest + jest-axe + shared `@docusaurus/*` stubs from PR-A2.
+
+**Scope:** Fifteen commits, ~1200 LoC across many files. The 7 example projects' boilerplate is the bulk; the docs-edits and the `<StackBlitzEmbed>` component are small.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-11-track1-pr-b-sandbox-infrastructure-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/docs-site/src/components/StackBlitzEmbed/index.tsx`
+- `apps/docs-site/src/components/StackBlitzEmbed/StackBlitzEmbed.module.css`
+- `apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx`
+- `examples/datepicker-basic/` (full Vite project)
+- `examples/datepicker-rhf/`
+- `examples/rangepicker-presets/`
+- `examples/timepicker-12h/`
+- `examples/datetimepicker-timezone/`
+- `examples/datepicker-tailwind/`
+- `examples/datepicker-shadcn/`
+- `scripts/check-stackblitz-urls.mjs`
+
+**Modify:**
+- `apps/docs-site/src/theme/ReactLiveScope/index.tsx` — expand to expose `@kalyx/react`
+- 7 × `apps/docs-site/docs/components/<picker>.md` — insert live block + embed below the intro
+- 7 × `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/<picker>.md` — same edits (Korean)
+- `pnpm-workspace.yaml` — ensure `examples/*` is part of the workspace if it isn't already
+
+**Delete:**
+- `examples/stackblitz-rc/` (stale RC-era artifact)
+
+---
+
+## Task list
+
+### Task 1: Verify env + audit workspace + remove stale example
+
+**Files:**
+- `pnpm-workspace.yaml` (read; possibly modify)
+- `examples/stackblitz-rc/` (delete)
+
+- [ ] **Step 1: Baseline tests**
+
+Run:
+```bash
+pnpm test:run
+```
+Expected: ≥ 535 tests pass.
+
+- [ ] **Step 2: Read the workspace config**
+
+```bash
+cat pnpm-workspace.yaml
+```
+
+If the file already lists `'examples/*'`, leave it alone. If not, add the line:
+
+```yaml
+packages:
+  - 'packages/*'
+  - 'apps/*'
+  - 'examples/*'
+```
+
+- [ ] **Step 3: Inspect stale example**
+
+```bash
+ls examples/
+```
+Confirm `stackblitz-rc/` exists (per the spec). If not, skip its removal.
+
+- [ ] **Step 4: Remove the stale example**
+
+```bash
+git rm -r examples/stackblitz-rc/
+```
+
+- [ ] **Step 5: Verify install still resolves**
+
+```bash
+pnpm install --frozen-lockfile
+```
+Expected: clean. If a dep elsewhere referenced `@kalyx-example/stackblitz-rc`, you'll see a workspace-resolve error — fix that reference (likely an unused `workspace:*` somewhere) before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pnpm-workspace.yaml pnpm-lock.yaml || true
+git commit -m "$(cat <<'EOF'
+chore(workspace): drop stale stackblitz-rc example
+
+Removes the RC-era example that's been orphaned since v1.0 stable.
+The new examples/* projects shipped in this PR replace its role.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Extend ReactLiveScope
+
+**Files:**
+- Modify: `apps/docs-site/src/theme/ReactLiveScope/index.tsx`
+
+- [ ] **Step 1: Read the current scope**
+
+```bash
+cat apps/docs-site/src/theme/ReactLiveScope/index.tsx
+```
+Confirm it's the simple Docusaurus default (React + a couple of exports). The file exists because `@docusaurus/theme-live-codeblock` swizzles to it.
+
+- [ ] **Step 2: Rewrite to expose `@kalyx/react`**
+
+Replace the file contents with:
+
+```tsx
+import * as React from 'react';
+import {
+  DatePicker,
+  RangePicker,
+  TimePicker,
+  DateTimePicker,
+  MonthPicker,
+  YearPicker,
+  WeekPicker,
+  useDatePicker,
+  useRangePicker,
+  useTimePicker,
+  DateFnsAdapter,
+} from '@kalyx/react';
+
+/**
+ * Live-codeblock scope. Anything in this object is available as a
+ * bare identifier inside `tsx live` MDX blocks. Keeping this surface
+ * small but useful — every kalyx public export plus React itself.
+ */
+const ReactLiveScope = {
+  React,
+  ...React,
+  DatePicker,
+  RangePicker,
+  TimePicker,
+  DateTimePicker,
+  MonthPicker,
+  YearPicker,
+  WeekPicker,
+  useDatePicker,
+  useRangePicker,
+  useTimePicker,
+  DateFnsAdapter,
+};
+
+export default ReactLiveScope;
+```
+
+- [ ] **Step 3: Verify docs-site build**
+
+```bash
+pnpm --filter docs-site build 2>&1 | tail -5
+```
+Expected: success. No `tsx live` blocks exist yet that use the new exports, so this is a no-op build for the user surface, but the scope is now wired.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/docs-site/src/theme/ReactLiveScope/index.tsx
+git commit -m "$(cat <<'EOF'
+feat(docs-site): expose @kalyx/react in ReactLiveScope
+
+Every public export from @kalyx/react is now available as a bare
+identifier inside MDX `tsx live` blocks. Lets docs pages embed
+interactive picker examples without per-file imports.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: `<StackBlitzEmbed>` component
+
+**Files:**
+- Create: `apps/docs-site/src/components/StackBlitzEmbed/index.tsx`
+- Create: `apps/docs-site/src/components/StackBlitzEmbed/StackBlitzEmbed.module.css`
+- Create: `apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import StackBlitzEmbed from '../index';
+
+describe('<StackBlitzEmbed>', () => {
+  it('renders an iframe with the correct StackBlitz URL', () => {
+    render(<StackBlitzEmbed id="datepicker-basic" />);
+    const iframe = screen.getByTitle(/kalyx example: datepicker-basic/i);
+    expect(iframe.getAttribute('src')).toContain('stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/datepicker-basic');
+    expect(iframe.getAttribute('src')).toContain('embed=1');
+    expect(iframe.getAttribute('src')).toContain('file=src/App.tsx');
+    expect(iframe.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('renders an "Open in StackBlitz" link to the same project', () => {
+    render(<StackBlitzEmbed id="datepicker-basic" />);
+    const link = screen.getByRole('link', { name: /open in stackblitz/i });
+    expect(link.getAttribute('href')).toBe(
+      'https://stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/datepicker-basic'
+    );
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toContain('noopener');
+  });
+
+  it('passes axe', async () => {
+    const { container } = render(<StackBlitzEmbed id="datepicker-basic" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Confirm fail**
+
+```bash
+pnpm test:run apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Implement**
+
+Create `apps/docs-site/src/components/StackBlitzEmbed/index.tsx`:
+
+```tsx
+import styles from './StackBlitzEmbed.module.css';
+
+export type StackBlitzEmbedProps = {
+  /** examples/<id> — must match a real directory in this repo. */
+  id: string;
+  /** File to open in the embed by default. Defaults to 'src/App.tsx'. */
+  file?: string;
+  /** Iframe height in pixels. Defaults to 600. */
+  height?: number;
+  /** StackBlitz UI theme. Defaults to 'dark'. */
+  theme?: 'dark' | 'light';
+};
+
+const REPO_PATH = 'jiji-hoon96/kalyx/tree/main/examples';
+
+export default function StackBlitzEmbed({
+  id,
+  file = 'src/App.tsx',
+  height = 600,
+  theme = 'dark',
+}: StackBlitzEmbedProps) {
+  const embedQuery = new URLSearchParams({
+    embed: '1',
+    file,
+    hideExplorer: '1',
+    theme,
+  });
+  const embedSrc = `https://stackblitz.com/github/${REPO_PATH}/${id}?${embedQuery.toString()}`;
+  const fullHref = `https://stackblitz.com/github/${REPO_PATH}/${id}`;
+
+  return (
+    <div className={styles.wrapper}>
+      <iframe
+        className={styles.iframe}
+        src={embedSrc}
+        title={`Kalyx example: ${id}`}
+        loading="lazy"
+        height={height}
+      />
+      <a
+        className={styles.openLink}
+        href={fullHref}
+        target="_blank"
+        rel="noopener noreferrer">
+        Open in StackBlitz ↗
+      </a>
+    </div>
+  );
+}
+```
+
+Create `apps/docs-site/src/components/StackBlitzEmbed/StackBlitzEmbed.module.css`:
+
+```css
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 1.5rem 0;
+}
+
+.iframe {
+  width: 100%;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+}
+
+.openLink {
+  align-self: flex-end;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+}
+
+.openLink:hover {
+  text-decoration: underline;
+}
+```
+
+- [ ] **Step 4: Tests pass + commit**
+
+```bash
+pnpm test:run apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx 2>&1 | tail -3
+git add apps/docs-site/src/components/StackBlitzEmbed/
+git commit -m "$(cat <<'EOF'
+feat(docs-site): add StackBlitzEmbed component
+
+iframe + "Open in StackBlitz" link wrapper. URL convention:
+stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/<id>.
+Lazy-loaded iframe; props for file/height/theme.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Scaffold `examples/datepicker-basic`
+
+**Files:** all under `examples/datepicker-basic/`
+
+The `-basic` example is the template all subsequent examples specialise. Write it carefully — the next 6 tasks reference its structure.
+
+- [ ] **Step 1: Create the directory tree**
+
+```bash
+mkdir -p examples/datepicker-basic/src
+```
+
+- [ ] **Step 2: `package.json`**
+
+`examples/datepicker-basic/package.json`:
+
+```json
+{
+  "name": "@kalyx-example/datepicker-basic",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit"
+  },
+  "dependencies": {
+    "@kalyx/react": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^7.0.0"
+  }
+}
+```
+
+- [ ] **Step 3: `tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 4: `vite.config.ts`**
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});
+```
+
+- [ ] **Step 5: `index.html`**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kalyx — DatePicker basic</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 6: `src/main.tsx`**
+
+```tsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+```
+
+- [ ] **Step 7: `src/App.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { DatePicker } from '@kalyx/react';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T00:00:00.000Z');
+  return (
+    <div style={{ padding: 32, fontFamily: 'sans-serif' }}>
+      <h1>Kalyx — DatePicker basic</h1>
+      <p>
+        A minimal headless DatePicker. Style each part by passing class
+        strings to <code>classNames</code>.
+      </p>
+      <DatePicker value={iso} onChange={setIso}>
+        <DatePicker.Input placeholder="Pick a date" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>
+      <pre style={{ marginTop: 16, padding: 12, background: '#f5f5f5', borderRadius: 6 }}>
+        {JSON.stringify({ iso }, null, 2)}
+      </pre>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8: Typecheck the example**
+
+```bash
+pnpm --filter @kalyx-example/datepicker-basic install
+pnpm --filter @kalyx-example/datepicker-basic typecheck
+```
+Expected: clean. If TypeScript flags an unresolved `@kalyx/react`, run `pnpm install` from the root first to wire workspace deps.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add examples/datepicker-basic/
+git commit -m "$(cat <<'EOF'
+feat(examples): add datepicker-basic
+
+Minimal Vite + React 19 + @kalyx/react template. Copy-paste foundation
+for the rest of the examples/* projects.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Tasks 5–10: Scaffold the 6 remaining examples
+
+Each follows the same `package.json` / `tsconfig.json` / `vite.config.ts` / `index.html` / `src/main.tsx` skeleton as Task 4. Only `src/App.tsx` (and sometimes `package.json` deps) differ.
+
+For each example below, repeat the Task 4 steps with these adjustments:
+
+#### Task 5: `examples/datepicker-rhf` — DatePicker with React Hook Form
+
+**package.json deps:** add `"react-hook-form": "^7.50.0"` under `dependencies`.
+
+**src/App.tsx:**
+
+```tsx
+import { useForm, Controller } from 'react-hook-form';
+import { DatePicker } from '@kalyx/react';
+
+type FormValues = { birthday: string | null };
+
+export default function App() {
+  const { control, handleSubmit, formState } = useForm<FormValues>({
+    defaultValues: { birthday: null },
+  });
+
+  const onSubmit = (values: FormValues) => {
+    alert(JSON.stringify(values, null, 2));
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} style={{ padding: 32, fontFamily: 'sans-serif' }}>
+      <h1>Kalyx — DatePicker × React Hook Form</h1>
+      <Controller
+        name="birthday"
+        control={control}
+        rules={{ required: 'Pick a birthday' }}
+        render={({ field, fieldState }) => (
+          <div>
+            <DatePicker value={field.value} onChange={field.onChange}>
+              <DatePicker.Input placeholder="Birthday" />
+              <DatePicker.Popover>
+                <DatePicker.Calendar />
+              </DatePicker.Popover>
+            </DatePicker>
+            {fieldState.error && (
+              <p style={{ color: 'crimson' }}>{fieldState.error.message}</p>
+            )}
+          </div>
+        )}
+      />
+      <button type="submit" style={{ marginTop: 16 }}>Submit</button>
+      <pre style={{ marginTop: 16 }}>{JSON.stringify(formState.dirtyFields, null, 2)}</pre>
+    </form>
+  );
+}
+```
+
+Commit message: `feat(examples): add datepicker-rhf` with body explaining the Controller pattern.
+
+#### Task 6: `examples/rangepicker-presets`
+
+**src/App.tsx:**
+
+```tsx
+import { useState } from 'react';
+import { RangePicker } from '@kalyx/react';
+
+const ISO_NOW = '2026-06-15T00:00:00.000Z';
+
+export default function App() {
+  const [range, setRange] = useState({ start: ISO_NOW, end: '2026-06-22T00:00:00.000Z' });
+
+  return (
+    <div style={{ padding: 32, fontFamily: 'sans-serif' }}>
+      <h1>Kalyx — RangePicker with presets</h1>
+      <RangePicker value={range} onChange={setRange}>
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover>
+          <RangePicker.Presets>
+            <RangePicker.Preset value="last7days">Last 7 days</RangePicker.Preset>
+            <RangePicker.Preset value="last30days">Last 30 days</RangePicker.Preset>
+            <RangePicker.Preset value="thisMonth">This month</RangePicker.Preset>
+          </RangePicker.Presets>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>
+      <pre style={{ marginTop: 16 }}>{JSON.stringify(range, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+Commit message: `feat(examples): add rangepicker-presets`.
+
+#### Task 7: `examples/timepicker-12h`
+
+**src/App.tsx:**
+
+```tsx
+import { useState } from 'react';
+import { TimePicker } from '@kalyx/react';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T14:30:00.000Z');
+
+  return (
+    <div style={{ padding: 32, fontFamily: 'sans-serif' }}>
+      <h1>Kalyx — TimePicker (12h)</h1>
+      <TimePicker value={iso} onChange={setIso} format="12h" step={15}>
+        <TimePicker.Input />
+        <div style={{ display: 'flex', gap: 12, marginTop: 8 }}>
+          <TimePicker.HourList />
+          <TimePicker.MinuteList />
+          <TimePicker.AmPmToggle />
+        </div>
+      </TimePicker>
+      <pre style={{ marginTop: 16 }}>{JSON.stringify({ iso }, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+Commit message: `feat(examples): add timepicker-12h`.
+
+#### Task 8: `examples/datetimepicker-timezone`
+
+**src/App.tsx:**
+
+```tsx
+import { useState } from 'react';
+import { DateTimePicker } from '@kalyx/react';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T14:30:00.000Z');
+  const [tz, setTz] = useState<string>('Asia/Seoul');
+
+  return (
+    <div style={{ padding: 32, fontFamily: 'sans-serif' }}>
+      <h1>Kalyx — DateTimePicker × timezone</h1>
+      <p>Stored ISO is always UTC; display shifts per timezone.</p>
+      <label style={{ display: 'block', marginBottom: 12 }}>
+        Timezone:&nbsp;
+        <select value={tz} onChange={e => setTz(e.target.value)}>
+          <option>UTC</option>
+          <option>Asia/Seoul</option>
+          <option>America/New_York</option>
+          <option>Europe/London</option>
+        </select>
+      </label>
+      <DateTimePicker value={iso} onChange={setIso} displayTimezone={tz}>
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePicker.Calendar />
+          <div style={{ display: 'flex', gap: 12 }}>
+            <DateTimePicker.HourList />
+            <DateTimePicker.MinuteList />
+          </div>
+        </DateTimePicker.Popover>
+      </DateTimePicker>
+      <pre style={{ marginTop: 16 }}>{JSON.stringify({ iso, displayTimezone: tz }, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+Commit message: `feat(examples): add datetimepicker-timezone`.
+
+#### Task 9: `examples/datepicker-tailwind`
+
+**package.json deps:** add `"tailwindcss": "^4.0.0"` and `"@tailwindcss/vite": "^4.0.0"` under `devDependencies`.
+
+**vite.config.ts:** import + use Tailwind's Vite plugin:
+
+```ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({ plugins: [react(), tailwindcss()] });
+```
+
+**src/index.css** (new file):
+
+```css
+@import "tailwindcss";
+```
+
+**src/main.tsx:** add `import './index.css';` at the top.
+
+**src/App.tsx:**
+
+```tsx
+import { useState } from 'react';
+import { DatePicker } from '@kalyx/react';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T00:00:00.000Z');
+  return (
+    <div className="p-8 font-sans">
+      <h1 className="text-2xl font-bold mb-4">Kalyx × Tailwind</h1>
+      <DatePicker value={iso} onChange={setIso}>
+        <DatePicker.Input className="border border-slate-300 rounded px-3 py-2 text-sm" />
+        <DatePicker.Popover className="bg-white border border-slate-200 rounded-lg shadow-lg p-3 mt-1">
+          <DatePicker.Calendar classNames={{
+            grid: 'border-collapse',
+            day: 'rounded hover:bg-slate-100 w-9 h-9',
+            daySelected: 'bg-indigo-600 text-white hover:bg-indigo-700',
+            dayToday: 'border border-indigo-400 font-semibold',
+            dayDisabled: 'text-slate-300 cursor-not-allowed',
+          }} />
+        </DatePicker.Popover>
+      </DatePicker>
+      <pre className="mt-4 p-3 bg-slate-100 rounded">{JSON.stringify({ iso }, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+Commit message: `feat(examples): add datepicker-tailwind`.
+
+#### Task 10: `examples/datepicker-shadcn`
+
+**package.json deps:** add `"clsx": "^2.1.0"` and `"tailwindcss": "^4.0.0"` (shadcn convention).
+
+**src/cn.ts** (a one-line helper):
+
+```ts
+import clsx, { type ClassValue } from 'clsx';
+export function cn(...args: ClassValue[]): string {
+  return clsx(args);
+}
+```
+
+**src/App.tsx:**
+
+```tsx
+import { useState } from 'react';
+import { DatePicker } from '@kalyx/react';
+import { cn } from './cn';
+
+const inputBase = 'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+const dayBase = 'h-9 w-9 p-0 font-normal aria-selected:opacity-100';
+const daySelected = 'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T00:00:00.000Z');
+  return (
+    <div className="p-8 font-sans">
+      <h1 className="text-2xl font-bold mb-4">Kalyx × shadcn-style classes</h1>
+      <DatePicker value={iso} onChange={setIso}>
+        <DatePicker.Input className={cn(inputBase)} />
+        <DatePicker.Popover>
+          <DatePicker.Calendar classNames={{
+            day: cn(dayBase),
+            daySelected: cn(dayBase, daySelected),
+          }} />
+        </DatePicker.Popover>
+      </DatePicker>
+      <pre className="mt-4 p-3 bg-slate-100 rounded">{JSON.stringify({ iso }, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+(No real shadcn install; this just demonstrates the `cn(base, variant)` pattern shadcn uses. Real shadcn integrations would install actual shadcn components.)
+
+Commit message: `feat(examples): add datepicker-shadcn`.
+
+---
+
+### Task 11: Workspace typecheck sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm all 7 examples typecheck**
+
+```bash
+pnpm install --frozen-lockfile=false
+pnpm -r --filter "@kalyx-example/*" typecheck 2>&1 | tail -20
+```
+
+Expected: every `@kalyx-example/*` package reports `tsc -b` success. If any fails, fix in place — most likely:
+- A missing `@types/*` dev dep (add it)
+- An older `@kalyx/react` typings expectation (audit the example's API usage against the actual public surface)
+
+- [ ] **Step 2: Sanity-build one example**
+
+```bash
+pnpm --filter @kalyx-example/datepicker-basic build
+```
+
+Expected: Vite builds in < 5s. Output in `examples/datepicker-basic/dist/`. No commit — verification only.
+
+---
+
+### Task 12: `scripts/check-stackblitz-urls.mjs`
+
+**Files:**
+- Create: `scripts/check-stackblitz-urls.mjs`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/check-stackblitz-urls.mjs`:
+
+```js
+#!/usr/bin/env node
+/**
+ * Verify every examples/* StackBlitz GitHub-embed URL returns HTTP 200.
+ * Manual-run; not wired into CI yet (planned: nightly job per parent spec).
+ *
+ * Exits 0 if all URLs OK, 1 if any returned >= 400.
+ */
+
+import { request } from 'undici';
+
+const EXAMPLES = [
+  'datepicker-basic',
+  'datepicker-rhf',
+  'rangepicker-presets',
+  'timepicker-12h',
+  'datetimepicker-timezone',
+  'datepicker-tailwind',
+  'datepicker-shadcn',
+];
+
+let fail = 0;
+for (const id of EXAMPLES) {
+  const url = `https://stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/${id}`;
+  try {
+    const res = await request(url, { method: 'HEAD' });
+    if (res.statusCode >= 400) {
+      console.error(`✗ ${id}: HTTP ${res.statusCode}`);
+      fail++;
+    } else {
+      console.log(`✓ ${id}: HTTP ${res.statusCode}`);
+    }
+  } catch (err) {
+    console.error(`✗ ${id}: ${err instanceof Error ? err.message : String(err)}`);
+    fail++;
+  }
+}
+
+process.exit(fail > 0 ? 1 : 0);
+```
+
+- [ ] **Step 2: Make executable + smoke-run**
+
+```bash
+chmod +x scripts/check-stackblitz-urls.mjs
+node scripts/check-stackblitz-urls.mjs
+```
+
+Expected: 7× `✓` lines, exit 0. StackBlitz returns 200 for GitHub-tree paths even before any user clicks the embed (the embed is rendered on demand), so the script confirms URL well-formedness more than embed liveness.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/check-stackblitz-urls.mjs
+git commit -m "$(cat <<'EOF'
+feat(scripts): add check-stackblitz-urls.mjs
+
+HEAD request against each of the 7 example StackBlitz URLs. Manual-run;
+nightly CI wiring is a follow-up per the parent spec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Tasks 13–15: Wire live blocks + embeds into picker docs
+
+7 picker docs pages × 2 locales = 14 markdown files to edit. Each edit is small (~15 LoC inserted below the existing intro). Bundle the 14 edits into 3 thematic commits:
+
+#### Task 13: DatePicker + RangePicker (en + ko)
+
+For each of `apps/docs-site/docs/components/datepicker.md`, `apps/docs-site/docs/components/rangepicker.md`, and their `i18n/ko/.../components/<picker>.md` mirrors:
+
+Insert this block immediately after the page-level `# <Heading>` and 1-2 paragraph intro, BEFORE the API docs / table:
+
+```mdx
+import StackBlitzEmbed from '@site/src/components/StackBlitzEmbed';
+
+## Try it
+
+```tsx live
+function Example() {
+  const [iso, setIso] = React.useState(null);
+  return (
+    <DatePicker value={iso} onChange={setIso}>
+      <DatePicker.Input placeholder="Pick a date" />
+      <DatePicker.Popover>
+        <DatePicker.Calendar />
+      </DatePicker.Popover>
+    </DatePicker>
+  );
+}
+```
+
+<StackBlitzEmbed id="datepicker-basic" />
+```
+
+For RangePicker, swap the live block to use `RangePicker` and the embed `id` to `rangepicker-presets`.
+
+For the Korean files, translate only the `## Try it` heading (e.g., `## 직접 사용해보기`); the code block content stays English (JSX identifiers are not localised).
+
+Verify the docs-site build still succeeds:
+```bash
+pnpm --filter docs-site build 2>&1 | tail -3
+```
+
+Commit:
+
+```bash
+git add apps/docs-site/docs/components/datepicker.md \
+        apps/docs-site/docs/components/rangepicker.md \
+        apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datepicker.md \
+        apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/rangepicker.md
+git commit -m "$(cat <<'EOF'
+docs(components): add live block + embed to DatePicker / RangePicker (en + ko)
+
+Each page now ships an inline `tsx live` block (rendered via the
+extended ReactLiveScope) and a <StackBlitzEmbed> pointing at the
+corresponding examples/* project. Korean pages mirror the structure.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+#### Task 14: TimePicker + DateTimePicker (en + ko)
+
+Same pattern. Live blocks use `TimePicker` and `DateTimePicker` respectively. Embed ids: `timepicker-12h` and `datetimepicker-timezone`.
+
+Commit: `docs(components): add live block + embed to TimePicker / DateTimePicker (en + ko)`.
+
+#### Task 15: MonthPicker + YearPicker + WeekPicker (en + ko)
+
+Same pattern. All three use `datepicker-basic` as the StackBlitz example since the existing 7 examples don't include picker-specific Month/Year/Week sandboxes (a future addition; for now `datepicker-basic` shows the consistent compositional API).
+
+Commit: `docs(components): add live block + embed to Month / Year / WeekPicker (en + ko)`.
+
+After Task 15, do a final cross-check:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test:run
+pnpm --filter docs-site build
+node scripts/check-stackblitz-urls.mjs
+```
+
+All exit 0. Open the PR:
+
+```bash
+git log --oneline main..HEAD
+```
+Expected: 15 commits.
+
+```bash
+gh pr create --base main --title "feat(track1): PR-B — sandbox infrastructure (ReactLiveScope + StackBlitzEmbed + 7 examples)" --body "$(cat <<'EOF'
+## Summary
+
+Third PR in Track 1. Gives every picker docs page a real interactive sandbox.
+
+- **Live blocks** — \`ReactLiveScope\` now exposes every \`@kalyx/react\` public export. Every \`.md\`/\`.mdx\` page can drop a \`\`\`tsx live\`\`\` block to render a real picker.
+- **StackBlitz embeds** — new \`<StackBlitzEmbed>\` component. Iframe + "Open in StackBlitz" link, lazy-loaded.
+- **7 example projects** — \`examples/datepicker-basic\`, \`-rhf\`, \`rangepicker-presets\`, \`timepicker-12h\`, \`datetimepicker-timezone\`, \`datepicker-tailwind\`, \`datepicker-shadcn\`. Each is a real Vite + React 19 + \`@kalyx/react\` project that typechecks at workspace root.
+- **Docs edits** — every picker docs page (7 en + 7 ko) gets a live block + an embed below the intro.
+- **CI helper** — \`scripts/check-stackblitz-urls.mjs\` validates all 7 embed URLs return HTTP 200.
+- **Stale removal** — \`examples/stackblitz-rc/\` is deleted (RC-era).
+
+Spec: \`docs/superpowers/specs/2026-06-11-track1-pr-b-sandbox-infrastructure-design.md\`
+Plan: \`docs/superpowers/plans/2026-06-11-track1-pr-b-sandbox-infrastructure.md\`
+
+## Test plan
+
+- [x] \`pnpm test:run\` — all suites pass with 3 new \`<StackBlitzEmbed>\` tests
+- [x] \`pnpm -r --filter "@kalyx-example/*" typecheck\` — all 7 examples pass tsc
+- [x] \`pnpm --filter docs-site build\` succeeds for en + ko
+- [x] \`node scripts/check-stackblitz-urls.mjs\` — 7× HTTP 200
+- [x] Dev render — every picker docs page shows the live block (renders a real picker) and the embed iframe (lazy-loaded)
+- [x] Click "Open in StackBlitz" on one embed — sandbox opens with the right example project
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes for the executor
+
+**If a `tsx live` block crashes the docs-site build:** the JSX inside the block must be valid TypeScript that compiles in isolation with the ReactLiveScope identifiers. No `import` statements inside the block (everything is in scope already).
+
+**If an `examples/*` package typecheck fails because it can't resolve `@kalyx/react`:** ensure `pnpm install` ran at the root after creating the example. The workspace dep `"@kalyx/react": "workspace:*"` is resolved by pnpm at install time.
+
+**If a Vite dep version is incompatible with the workspace's React 19:** pin to the same Vite/plugin-react majors as `apps/docs-site` uses (currently Vite 7, plugin-react 5).
+
+**If `<StackBlitzEmbed>` iframe shows a "Repository not found" page in dev:** the URL pattern requires `jiji-hoon96/kalyx` to be public. If the user forks under a different account, parameterise `REPO_PATH` via an env-driven Docusaurus customField; the parent spec defers that to a follow-up.
+
+**Korean docs edits:** keep code blocks English. Only translate prose headings (e.g., "Try it" → "직접 사용해보기"). JSX identifiers (`DatePicker.Calendar` etc.) are product names and stay English.
+
+**If `check-stackblitz-urls.mjs` returns 404 for a URL:** that example's directory doesn't exist on the default branch yet. The script is meant to run AFTER the PR's merge — for local pre-merge runs, the URLs will 404 until merge.

--- a/docs/superpowers/plans/2026-06-11-track1-pr-c-playground-enhancement.md
+++ b/docs/superpowers/plans/2026-06-11-track1-pr-c-playground-enhancement.md
@@ -1,0 +1,1425 @@
+# Track 1 PR-C — `/playground` Enhancement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single-DatePicker live block in `apps/docs-site/src/pages/playground.mdx` with a `<Playground>` component offering picker selector, classNames editor, locale + timezone toggles, and "Open in StackBlitz" button.
+
+**Architecture:** New `apps/docs-site/src/components/Playground/` directory with 6 sub-components held together by a single `PlaygroundState` object. `@stackblitz/sdk` ships as a docs-site dep, mocked at vitest level for tests. The MDX page keeps its frontmatter and intro; the entire interactive surface is a single `<Playground />` mount.
+
+**Tech Stack:** React 19, `@stackblitz/sdk`, `@kalyx/react`, existing vitest + jest-axe + shared `@docusaurus/*` stubs from PR-A2, MDX from Docusaurus.
+
+**Scope:** Nine commits, ~500 LoC across 9 new files + 1 edited (the MDX page).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-11-track1-pr-c-playground-enhancement-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/docs-site/src/components/Playground/index.tsx` — root composer + state
+- `apps/docs-site/src/components/Playground/PickerSelector.tsx`
+- `apps/docs-site/src/components/Playground/ClassNamesEditor.tsx`
+- `apps/docs-site/src/components/Playground/LocaleTimezoneToggles.tsx`
+- `apps/docs-site/src/components/Playground/PreviewPanel.tsx`
+- `apps/docs-site/src/components/Playground/OpenInStackBlitz.tsx`
+- `apps/docs-site/src/components/Playground/classNamesByPicker.ts`
+- `apps/docs-site/src/components/Playground/seedProject.ts`
+- `apps/docs-site/src/components/Playground/Playground.module.css`
+- `apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx`
+- `test/__mocks__/stackblitz-sdk.ts` — vitest no-op stub
+
+**Modify:**
+- `apps/docs-site/package.json` — add `@stackblitz/sdk` as a `dependencies` entry
+- `apps/docs-site/src/pages/playground.mdx` — body replaced with `<Playground />`
+- `vitest.config.ts` — add alias for `@stackblitz/sdk` → the new mock
+
+---
+
+## Task list
+
+### Task 1: Verify env + add `@stackblitz/sdk` + mock
+
+**Files:**
+- Modify: `apps/docs-site/package.json`
+- Create: `test/__mocks__/stackblitz-sdk.ts`
+- Modify: `vitest.config.ts`
+
+- [ ] **Step 1: Confirm baseline tests pass**
+
+Run:
+```bash
+pnpm test:run
+```
+Expected: ≥ 535 tests pass.
+
+- [ ] **Step 2: Add the dep**
+
+```bash
+pnpm --filter docs-site add @stackblitz/sdk
+```
+Expected: pnpm installs the latest `@stackblitz/sdk`. Check the resulting `apps/docs-site/package.json` for the new line under `dependencies`.
+
+- [ ] **Step 3: Write the vitest mock**
+
+Create `test/__mocks__/stackblitz-sdk.ts`:
+
+```ts
+/**
+ * Vitest stub for @stackblitz/sdk.
+ * Returns a no-op `openProject` so Playground tests can assert the call
+ * without actually opening a sandbox.
+ */
+const openProject = (
+  ..._args: unknown[]
+): void => {
+  // intentionally empty
+};
+
+const sdk = { openProject };
+
+export default sdk;
+export { openProject };
+```
+
+- [ ] **Step 4: Wire the alias**
+
+Edit `vitest.config.ts`. Find the existing `resolve.alias` block (already aliases `@docusaurus/Link` etc. from PR-A2). Add one more entry:
+
+```ts
+'@stackblitz/sdk': path.resolve(__dirname, 'test/__mocks__/stackblitz-sdk.ts'),
+```
+
+- [ ] **Step 5: Verify tests still pass**
+
+```bash
+pnpm test:run
+```
+Expected: same count as Step 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/docs-site/package.json pnpm-lock.yaml test/__mocks__/stackblitz-sdk.ts vitest.config.ts
+git commit -m "$(cat <<'EOF'
+chore(docs-site): add @stackblitz/sdk + vitest mock
+
+@stackblitz/sdk powers the "Open in StackBlitz" button in the new
+Playground component. Aliased to a no-op stub in tests so Playground
+smoke tests don't actually try to open sandboxes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Define `classNamesByPicker` map
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/classNamesByPicker.ts`
+
+- [ ] **Step 1: Inspect each picker's published classNames types**
+
+For each of the 7 pickers, identify which `classNames` props they expose. The spec calls out reading the `*ClassNames` exported types from `@kalyx/react`. In practice, the Calendar / Grid / List parts already document their classNames:
+
+Run:
+```bash
+grep -rn "ClassNames" packages/react/src/components/ | grep -E "export (type|interface)" | head -20
+```
+
+Note the published surface — keys vary per picker.
+
+- [ ] **Step 2: Write the data file**
+
+Create `apps/docs-site/src/components/Playground/classNamesByPicker.ts`:
+
+```ts
+/**
+ * Static map of classNames parts exposed by each kalyx picker. The
+ * Playground's ClassNamesEditor renders one text input per leaf entry.
+ * Shape matches the published `classNames` prop of each picker; if a
+ * picker's prop surface grows in a future @kalyx/react release, this
+ * file needs a corresponding update.
+ *
+ * Keep nesting shallow (max 2 levels) so the editor UI stays scannable.
+ */
+export type ClassNamesShape = {
+  [key: string]: string | { [key: string]: string };
+};
+
+export type PickerId =
+  | 'datepicker'
+  | 'rangepicker'
+  | 'timepicker'
+  | 'datetimepicker'
+  | 'monthpicker'
+  | 'yearpicker'
+  | 'weekpicker';
+
+export const CLASSNAMES_BY_PICKER: Record<PickerId, ClassNamesShape> = {
+  datepicker: {
+    input: '',
+    calendar: {
+      root: '',
+      header: '',
+      navButton: '',
+      title: '',
+      grid: '',
+      day: '',
+      daySelected: '',
+      dayToday: '',
+      dayDisabled: '',
+      dayOutsideMonth: '',
+    },
+  },
+  rangepicker: {
+    input: '',
+    calendar: {
+      root: '',
+      header: '',
+      grid: '',
+      day: '',
+      daySelected: '',
+      dayInRange: '',
+      dayToday: '',
+      dayDisabled: '',
+    },
+  },
+  timepicker: {
+    input: '',
+    hourList: { root: '', option: '', optionSelected: '' },
+    minuteList: { root: '', option: '', optionSelected: '' },
+    ampmToggle: { root: '', button: '', buttonActive: '' },
+  },
+  datetimepicker: {
+    input: '',
+    calendar: { root: '', day: '', daySelected: '', dayToday: '' },
+    hourList: { root: '', option: '', optionSelected: '' },
+    minuteList: { root: '', option: '', optionSelected: '' },
+  },
+  monthpicker: {
+    input: '',
+    grid: { root: '', month: '', monthSelected: '', monthDisabled: '' },
+  },
+  yearpicker: {
+    input: '',
+    grid: { root: '', year: '', yearSelected: '', yearDisabled: '' },
+  },
+  weekpicker: {
+    input: '',
+    calendar: {
+      root: '',
+      header: '',
+      day: '',
+      dayInWeek: '',
+      daySelectedWeek: '',
+    },
+  },
+};
+
+/** All known picker ids in display order. */
+export const PICKER_IDS: readonly PickerId[] = Object.keys(CLASSNAMES_BY_PICKER) as readonly PickerId[];
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs-site/src/components/Playground/classNamesByPicker.ts
+git commit -m "$(cat <<'EOF'
+feat(playground): scaffold classNamesByPicker map
+
+Static map of each picker's classNames prop surface. Drives the
+Playground's ClassNamesEditor (one text input per leaf entry).
+Nesting capped at depth 2 to keep the editor scannable.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: PickerSelector
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/PickerSelector.tsx`
+
+- [ ] **Step 1: Write the test first** (TDD; consolidated test file)
+
+Create `apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@docusaurus/Translate', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  translate: ({ message }: { message: string }) => message,
+}));
+
+import PickerSelector from '../PickerSelector';
+import { PICKER_IDS } from '../classNamesByPicker';
+
+describe('<PickerSelector>', () => {
+  it('renders an option for each picker id', () => {
+    render(<PickerSelector value="datepicker" onChange={() => {}} />);
+    const select = screen.getByRole('combobox', { name: /picker/i });
+    const options = select.querySelectorAll('option');
+    expect(options).toHaveLength(PICKER_IDS.length);
+  });
+
+  it('calls onChange with the selected picker id', () => {
+    const handle = vi.fn();
+    render(<PickerSelector value="datepicker" onChange={handle} />);
+    const select = screen.getByRole('combobox', { name: /picker/i });
+    fireEvent.change(select, { target: { value: 'timepicker' } });
+    expect(handle).toHaveBeenCalledWith('timepicker');
+  });
+
+  it('passes axe', async () => {
+    const { container } = render(<PickerSelector value="datepicker" onChange={() => {}} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -5
+```
+Expected: FAIL — `Cannot find module '../PickerSelector'`.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/docs-site/src/components/Playground/PickerSelector.tsx`:
+
+```tsx
+import { PICKER_IDS, type PickerId } from './classNamesByPicker';
+import styles from './Playground.module.css';
+
+export type PickerSelectorProps = {
+  value: PickerId;
+  onChange: (next: PickerId) => void;
+};
+
+export default function PickerSelector({ value, onChange }: PickerSelectorProps) {
+  return (
+    <label className={styles.control}>
+      <span className={styles.controlLabel}>Picker</span>
+      <select
+        className={styles.select}
+        value={value}
+        onChange={e => onChange(e.target.value as PickerId)}
+        aria-label="Picker">
+        {PICKER_IDS.map(id => (
+          <option key={id} value={id}>{prettify(id)}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function prettify(id: string): string {
+  // 'datepicker' -> 'DatePicker'; 'datetimepicker' -> 'DateTimePicker'
+  const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+  if (id === 'datetimepicker') return 'DateTimePicker';
+  if (id === 'monthpicker') return 'MonthPicker';
+  if (id === 'yearpicker') return 'YearPicker';
+  if (id === 'weekpicker') return 'WeekPicker';
+  if (id === 'rangepicker') return 'RangePicker';
+  if (id === 'timepicker') return 'TimePicker';
+  return cap(id);
+}
+```
+
+- [ ] **Step 4: Add a placeholder CSS module so styles import works**
+
+Create `apps/docs-site/src/components/Playground/Playground.module.css`:
+
+```css
+.control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.controlLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+/* the rest of this module is filled in across tasks 4–8 */
+```
+
+- [ ] **Step 5: Test passes**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -3
+```
+Expected: 3/3 PickerSelector tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/docs-site/src/components/Playground/PickerSelector.tsx \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(playground): add PickerSelector
+
+Native <select> over the 7 picker ids with a Picker label. Sole control
+the user has for swapping the rendered picker; everything else cascades
+from this value.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: ClassNamesEditor
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/ClassNamesEditor.tsx`
+
+- [ ] **Step 1: Append tests** to the existing `__tests__/Playground.test.tsx` (before the final `});`):
+
+```tsx
+import ClassNamesEditor from '../ClassNamesEditor';
+import { CLASSNAMES_BY_PICKER } from '../classNamesByPicker';
+
+describe('<ClassNamesEditor>', () => {
+  it('renders one input per leaf entry for the active picker', () => {
+    render(<ClassNamesEditor pickerId="datepicker" value={CLASSNAMES_BY_PICKER.datepicker} onChange={() => {}} />);
+    const inputs = screen.getAllByRole('textbox');
+    // datepicker has 1 (input) + 10 (calendar.*) = 11 leaf entries
+    expect(inputs.length).toBe(11);
+  });
+
+  it('calls onChange when a leaf input is edited', () => {
+    const handle = vi.fn();
+    render(<ClassNamesEditor pickerId="datepicker" value={CLASSNAMES_BY_PICKER.datepicker} onChange={handle} />);
+    const dayInput = screen.getByLabelText('calendar.day');
+    fireEvent.change(dayInput, { target: { value: 'bg-indigo-100' } });
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Verify the new ClassNamesEditor tests fail**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -5
+```
+Expected: 2 failures (`Cannot find module '../ClassNamesEditor'`), 3 still pass.
+
+- [ ] **Step 3: Implement**
+
+Create `apps/docs-site/src/components/Playground/ClassNamesEditor.tsx`:
+
+```tsx
+import type { ClassNamesShape, PickerId } from './classNamesByPicker';
+import styles from './Playground.module.css';
+
+export type ClassNamesEditorProps = {
+  pickerId: PickerId;
+  value: ClassNamesShape;
+  onChange: (next: ClassNamesShape) => void;
+};
+
+type LeafPath = readonly string[];
+
+function* walkLeaves(obj: ClassNamesShape, prefix: LeafPath = []): Generator<{ path: LeafPath; value: string }> {
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === 'string') {
+      yield { path: [...prefix, k], value: v };
+    } else {
+      yield* walkLeaves(v, [...prefix, k]);
+    }
+  }
+}
+
+function setAt(obj: ClassNamesShape, path: LeafPath, next: string): ClassNamesShape {
+  const [head, ...tail] = path;
+  if (tail.length === 0) {
+    return { ...obj, [head]: next };
+  }
+  const sub = obj[head];
+  if (typeof sub !== 'object') return obj;
+  return { ...obj, [head]: setAt(sub, tail, next) };
+}
+
+export default function ClassNamesEditor({ pickerId, value, onChange }: ClassNamesEditorProps) {
+  const leaves = Array.from(walkLeaves(value));
+  return (
+    <fieldset className={styles.classNamesEditor} aria-label={`classNames editor — ${pickerId}`}>
+      <legend className={styles.controlLabel}>classNames</legend>
+      {leaves.map(({ path, value: leafValue }) => {
+        const label = path.join('.');
+        return (
+          <label key={label} className={styles.leafRow}>
+            <span className={styles.leafKey}>{label}</span>
+            <input
+              type="text"
+              aria-label={label}
+              className={styles.leafInput}
+              value={leafValue}
+              onChange={e => onChange(setAt(value, path, e.target.value))}
+            />
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}
+```
+
+- [ ] **Step 4: Extend Playground.module.css**
+
+Append to `apps/docs-site/src/components/Playground/Playground.module.css`:
+
+```css
+.classNamesEditor {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.leafRow {
+  display: grid;
+  grid-template-columns: 9rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.leafKey {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-700);
+  word-break: break-all;
+}
+
+.leafInput {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 4px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+}
+```
+
+- [ ] **Step 5: Verify all 5 tests pass**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -3
+```
+Expected: 5/5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/docs-site/src/components/Playground/ClassNamesEditor.tsx \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(playground): add ClassNamesEditor
+
+Walks the nested ClassNamesShape and renders one text input per leaf
+entry, labelled with the dotted key path. Edits propagate up via a
+recursive setAt helper.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: LocaleTimezoneToggles
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/LocaleTimezoneToggles.tsx`
+
+- [ ] **Step 1: Append tests**
+
+In `__tests__/Playground.test.tsx`, before the final `});`, add:
+
+```tsx
+import LocaleTimezoneToggles from '../LocaleTimezoneToggles';
+
+describe('<LocaleTimezoneToggles>', () => {
+  it('renders 4 locale options and 4 timezone options', () => {
+    render(<LocaleTimezoneToggles locale="en-US" timezone="UTC" onLocaleChange={() => {}} onTimezoneChange={() => {}} />);
+    const localeSelect = screen.getByRole('combobox', { name: /locale/i });
+    const tzSelect = screen.getByRole('combobox', { name: /timezone/i });
+    expect(localeSelect.querySelectorAll('option')).toHaveLength(4);
+    expect(tzSelect.querySelectorAll('option')).toHaveLength(4);
+  });
+
+  it('reports locale change', () => {
+    const onLocale = vi.fn();
+    render(<LocaleTimezoneToggles locale="en-US" timezone="UTC" onLocaleChange={onLocale} onTimezoneChange={() => {}} />);
+    fireEvent.change(screen.getByRole('combobox', { name: /locale/i }), { target: { value: 'ko-KR' } });
+    expect(onLocale).toHaveBeenCalledWith('ko-KR');
+  });
+});
+```
+
+- [ ] **Step 2: Confirm 2 new failures**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Implement**
+
+Create `apps/docs-site/src/components/Playground/LocaleTimezoneToggles.tsx`:
+
+```tsx
+import styles from './Playground.module.css';
+
+export type Locale = 'en-US' | 'ko-KR' | 'ja-JP' | 'fr-FR';
+export type Timezone = 'UTC' | 'Asia/Seoul' | 'America/New_York' | 'Europe/London';
+
+const LOCALES: readonly { id: Locale; label: string }[] = [
+  { id: 'en-US', label: 'English (US)' },
+  { id: 'ko-KR', label: '한국어' },
+  { id: 'ja-JP', label: '日本語' },
+  { id: 'fr-FR', label: 'Français' },
+];
+
+const TIMEZONES: readonly Timezone[] = [
+  'UTC', 'Asia/Seoul', 'America/New_York', 'Europe/London',
+];
+
+export type LocaleTimezoneTogglesProps = {
+  locale: Locale;
+  timezone: Timezone;
+  onLocaleChange: (next: Locale) => void;
+  onTimezoneChange: (next: Timezone) => void;
+};
+
+export default function LocaleTimezoneToggles({
+  locale, timezone, onLocaleChange, onTimezoneChange,
+}: LocaleTimezoneTogglesProps) {
+  return (
+    <div className={styles.toggleRow}>
+      <label className={styles.control}>
+        <span className={styles.controlLabel}>Locale</span>
+        <select
+          className={styles.select}
+          value={locale}
+          onChange={e => onLocaleChange(e.target.value as Locale)}
+          aria-label="Locale">
+          {LOCALES.map(l => <option key={l.id} value={l.id}>{l.label}</option>)}
+        </select>
+      </label>
+      <label className={styles.control}>
+        <span className={styles.controlLabel}>Timezone</span>
+        <select
+          className={styles.select}
+          value={timezone}
+          onChange={e => onTimezoneChange(e.target.value as Timezone)}
+          aria-label="Timezone">
+          {TIMEZONES.map(tz => <option key={tz} value={tz}>{tz}</option>)}
+        </select>
+      </label>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Extend module CSS**
+
+Append:
+
+```css
+.toggleRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+```
+
+- [ ] **Step 5: Tests pass + commit**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -3
+git add apps/docs-site/src/components/Playground/LocaleTimezoneToggles.tsx \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(playground): add LocaleTimezoneToggles
+
+Two parallel <select>s for locale (4 options) and timezone (4 options).
+Independent onChange callbacks keep the parent state granular.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: PreviewPanel
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/PreviewPanel.tsx`
+
+- [ ] **Step 1: Append integration smoke tests**
+
+In `__tests__/Playground.test.tsx`:
+
+```tsx
+import PreviewPanel from '../PreviewPanel';
+
+describe('<PreviewPanel>', () => {
+  it('renders a DatePicker when pickerId="datepicker"', () => {
+    render(
+      <PreviewPanel
+        pickerId="datepicker"
+        classNames={CLASSNAMES_BY_PICKER.datepicker}
+        locale="en-US"
+        timezone="UTC"
+      />
+    );
+    // DatePicker.Input ends up as a button/combobox at the top of the tree
+    expect(screen.getByTestId('preview-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-panel').getAttribute('data-picker')).toBe('datepicker');
+  });
+
+  it('switches to TimePicker when pickerId="timepicker"', () => {
+    const { rerender } = render(
+      <PreviewPanel pickerId="datepicker" classNames={CLASSNAMES_BY_PICKER.datepicker} locale="en-US" timezone="UTC" />
+    );
+    rerender(
+      <PreviewPanel pickerId="timepicker" classNames={CLASSNAMES_BY_PICKER.timepicker} locale="en-US" timezone="UTC" />
+    );
+    expect(screen.getByTestId('preview-panel').getAttribute('data-picker')).toBe('timepicker');
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+Create `apps/docs-site/src/components/Playground/PreviewPanel.tsx`:
+
+```tsx
+import { useState } from 'react';
+import {
+  DatePicker, RangePicker, TimePicker, DateTimePicker,
+  MonthPicker, YearPicker, WeekPicker,
+} from '@kalyx/react';
+import type { ClassNamesShape, PickerId } from './classNamesByPicker';
+import type { Locale, Timezone } from './LocaleTimezoneToggles';
+import styles from './Playground.module.css';
+
+const FROZEN_DATE = '2026-06-15T00:00:00.000Z';
+const FROZEN_RANGE = { start: '2026-06-15T00:00:00.000Z', end: '2026-06-19T00:00:00.000Z' };
+const FROZEN_WEEK = { start: '2026-06-14T00:00:00.000Z', end: '2026-06-20T00:00:00.000Z' };
+const FROZEN_TIME = '2026-06-15T14:30:00.000Z';
+
+export type PreviewPanelProps = {
+  pickerId: PickerId;
+  classNames: ClassNamesShape;
+  locale: Locale;
+  timezone: Timezone;
+};
+
+export default function PreviewPanel({ pickerId, classNames, locale, timezone }: PreviewPanelProps) {
+  return (
+    <div
+      data-testid="preview-panel"
+      data-picker={pickerId}
+      className={styles.preview}>
+      {pickerId === 'datepicker' && <DatePickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+      {pickerId === 'rangepicker' && <RangePickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+      {pickerId === 'timepicker' && <TimePickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+      {pickerId === 'datetimepicker' && <DateTimePickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+      {pickerId === 'monthpicker' && <MonthPickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+      {pickerId === 'yearpicker' && <YearPickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+      {pickerId === 'weekpicker' && <WeekPickerPreview classNames={classNames} locale={locale} timezone={timezone} />}
+    </div>
+  );
+}
+
+type SubProps = { classNames: ClassNamesShape; locale: Locale; timezone: Timezone };
+
+function DatePickerPreview({ classNames, locale, timezone }: SubProps) {
+  const [iso, setIso] = useState<string | null>(FROZEN_DATE);
+  const cn = classNames as { input?: string; calendar?: Record<string, string> };
+  return (
+    <DatePicker value={iso} onChange={setIso} locale={locale} displayTimezone={timezone}>
+      <DatePicker.Input className={cn.input} placeholder="Pick a date" />
+      <DatePicker.Popover>
+        <DatePicker.Calendar classNames={cn.calendar} />
+      </DatePicker.Popover>
+    </DatePicker>
+  );
+}
+
+// Similar shape for the other 6 pickers; copy the DatePickerPreview pattern and
+// adjust the picker component + value type. For brevity each preview is short:
+
+function RangePickerPreview({ classNames, locale, timezone }: SubProps) {
+  const [v, setV] = useState(FROZEN_RANGE);
+  const cn = classNames as { input?: string; calendar?: Record<string, string> };
+  return (
+    <RangePicker value={v} onChange={setV} locale={locale} displayTimezone={timezone}>
+      <RangePicker.Input className={cn.input} part="start" />
+      <RangePicker.Input className={cn.input} part="end" />
+      <RangePicker.Popover>
+        <RangePicker.Calendar classNames={cn.calendar} />
+      </RangePicker.Popover>
+    </RangePicker>
+  );
+}
+
+function TimePickerPreview({ classNames, locale, timezone }: SubProps) {
+  const [v, setV] = useState<string | null>(FROZEN_TIME);
+  return (
+    <TimePicker value={v} onChange={setV} format="12h" locale={locale} displayTimezone={timezone}>
+      <TimePicker.Input />
+      <div style={{ display: 'flex', gap: 8 }}>
+        <TimePicker.HourList />
+        <TimePicker.MinuteList />
+        <TimePicker.AmPmToggle />
+      </div>
+    </TimePicker>
+  );
+}
+
+function DateTimePickerPreview({ classNames, locale, timezone }: SubProps) {
+  const [v, setV] = useState<string | null>(FROZEN_DATE);
+  return (
+    <DateTimePicker value={v} onChange={setV} locale={locale} displayTimezone={timezone}>
+      <DateTimePicker.Input />
+      <DateTimePicker.Popover>
+        <DateTimePicker.Calendar />
+        <DateTimePicker.HourList />
+        <DateTimePicker.MinuteList />
+      </DateTimePicker.Popover>
+    </DateTimePicker>
+  );
+}
+
+function MonthPickerPreview({ locale, timezone }: SubProps) {
+  const [v, setV] = useState<string | null>(FROZEN_DATE);
+  return (
+    <MonthPicker value={v} onChange={setV} locale={locale} displayTimezone={timezone}>
+      <MonthPicker.Input />
+      <MonthPicker.Popover>
+        <MonthPicker.Grid />
+      </MonthPicker.Popover>
+    </MonthPicker>
+  );
+}
+
+function YearPickerPreview({ locale, timezone }: SubProps) {
+  const [v, setV] = useState<string | null>(FROZEN_DATE);
+  return (
+    <YearPicker value={v} onChange={setV} locale={locale} displayTimezone={timezone}>
+      <YearPicker.Input />
+      <YearPicker.Popover>
+        <YearPicker.Grid />
+      </YearPicker.Popover>
+    </YearPicker>
+  );
+}
+
+function WeekPickerPreview({ locale, timezone }: SubProps) {
+  const [v, setV] = useState(FROZEN_WEEK);
+  return (
+    <WeekPicker value={v} onChange={setV} locale={locale} displayTimezone={timezone}>
+      <WeekPicker.Input part="start" />
+      <WeekPicker.Input part="end" />
+      <WeekPicker.Popover>
+        <WeekPicker.Calendar />
+      </WeekPicker.Popover>
+    </WeekPicker>
+  );
+}
+```
+
+- [ ] **Step 3: Extend module CSS**
+
+Append:
+
+```css
+.preview {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 1.5rem;
+  background: var(--ifm-background-color);
+  min-height: 320px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+```
+
+- [ ] **Step 4: Tests pass + commit**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -3
+git add apps/docs-site/src/components/Playground/PreviewPanel.tsx \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(playground): add PreviewPanel
+
+Dispatches to the right @kalyx/react picker based on pickerId, passing
+classNames/locale/timezone through. Each picker sub-preview is local
+state — switching pickerId hard-resets via React's key-on-conditional
+behaviour.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: OpenInStackBlitz + seedProject
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/OpenInStackBlitz.tsx`
+- Create: `apps/docs-site/src/components/Playground/seedProject.ts`
+
+- [ ] **Step 1: Append tests**
+
+In `__tests__/Playground.test.tsx`:
+
+```tsx
+import OpenInStackBlitz from '../OpenInStackBlitz';
+import sdk from '@stackblitz/sdk';
+
+describe('<OpenInStackBlitz>', () => {
+  it('renders a button that calls sdk.openProject when clicked', () => {
+    const openProject = vi.spyOn(sdk, 'openProject');
+    render(
+      <OpenInStackBlitz
+        pickerId="datepicker"
+        classNames={CLASSNAMES_BY_PICKER.datepicker}
+        locale="en-US"
+        timezone="UTC"
+      />
+    );
+    const btn = screen.getByRole('button', { name: /open in stackblitz/i });
+    fireEvent.click(btn);
+    expect(openProject).toHaveBeenCalledTimes(1);
+    const arg = openProject.mock.calls[0][0] as { title: string; files: Record<string, string> };
+    expect(arg.title).toContain('datepicker');
+    expect(arg.files['src/App.tsx']).toContain('<DatePicker');
+    openProject.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `seedProject.ts`**
+
+Create `apps/docs-site/src/components/Playground/seedProject.ts`:
+
+```ts
+import type { ClassNamesShape, PickerId } from './classNamesByPicker';
+import type { Locale, Timezone } from './LocaleTimezoneToggles';
+
+export type Seed = {
+  title: string;
+  files: Record<string, string>;
+  template: 'node';
+};
+
+const PACKAGE_JSON = `{
+  "name": "kalyx-playground",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": { "dev": "vite", "build": "vite build", "preview": "vite preview" },
+  "dependencies": {
+    "@kalyx/react": "latest",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^7.0.0"
+  }
+}`;
+
+const INDEX_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kalyx Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>`;
+
+const MAIN_TSX = `import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);`;
+
+const VITE_CONFIG = `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({ plugins: [react()] });`;
+
+const TSCONFIG = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}`;
+
+function renderAppCode(pickerId: PickerId, classNames: ClassNamesShape, locale: Locale, tz: Timezone): string {
+  // For brevity here, generate a uniform App.tsx that imports the right picker.
+  const cn = JSON.stringify(classNames, null, 2);
+  const importName = pickerName(pickerId);
+  return `import { useState } from 'react';
+import { ${importName} } from '@kalyx/react';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T00:00:00.000Z');
+  const classNames = ${cn};
+  return (
+    <div style={{ padding: 32, fontFamily: 'sans-serif' }}>
+      <h1>Kalyx — ${importName}</h1>
+      <p>Locale: ${locale} · Timezone: ${tz}</p>
+      <${importName} value={iso} onChange={setIso} locale="${locale}" displayTimezone="${tz}">
+        <${importName}.Input className={classNames.input} />
+        <${importName}.Popover>
+          <${importName}.Calendar classNames={classNames.calendar} />
+        </${importName}.Popover>
+      </${importName}>
+    </div>
+  );
+}`;
+}
+
+function pickerName(id: PickerId): string {
+  switch (id) {
+    case 'datetimepicker': return 'DateTimePicker';
+    case 'monthpicker':    return 'MonthPicker';
+    case 'yearpicker':     return 'YearPicker';
+    case 'weekpicker':     return 'WeekPicker';
+    case 'rangepicker':    return 'RangePicker';
+    case 'timepicker':     return 'TimePicker';
+    default:               return 'DatePicker';
+  }
+}
+
+export function buildSeed(
+  pickerId: PickerId,
+  classNames: ClassNamesShape,
+  locale: Locale,
+  timezone: Timezone,
+): Seed {
+  return {
+    title: `Kalyx Playground — ${pickerId}`,
+    template: 'node',
+    files: {
+      'package.json': PACKAGE_JSON,
+      'index.html': INDEX_HTML,
+      'src/main.tsx': MAIN_TSX,
+      'src/App.tsx': renderAppCode(pickerId, classNames, locale, timezone),
+      'vite.config.ts': VITE_CONFIG,
+      'tsconfig.json': TSCONFIG,
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Implement `OpenInStackBlitz.tsx`**
+
+Create `apps/docs-site/src/components/Playground/OpenInStackBlitz.tsx`:
+
+```tsx
+import sdk from '@stackblitz/sdk';
+import { buildSeed } from './seedProject';
+import type { ClassNamesShape, PickerId } from './classNamesByPicker';
+import type { Locale, Timezone } from './LocaleTimezoneToggles';
+import styles from './Playground.module.css';
+
+export type OpenInStackBlitzProps = {
+  pickerId: PickerId;
+  classNames: ClassNamesShape;
+  locale: Locale;
+  timezone: Timezone;
+};
+
+export default function OpenInStackBlitz({ pickerId, classNames, locale, timezone }: OpenInStackBlitzProps) {
+  const handleClick = () => {
+    const seed = buildSeed(pickerId, classNames, locale, timezone);
+    sdk.openProject(seed, { openFile: 'src/App.tsx' });
+  };
+  return (
+    <button
+      type="button"
+      className={styles.stackblitzButton}
+      onClick={handleClick}>
+      Open in StackBlitz ↗
+    </button>
+  );
+}
+```
+
+- [ ] **Step 4: Extend module CSS**
+
+Append:
+
+```css
+.stackblitzButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  border: 0;
+  border-radius: 8px;
+  background: var(--ifm-color-primary);
+  color: var(--ifm-color-primary-contrast-foreground);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.stackblitzButton:hover {
+  background: var(--ifm-color-primary-dark);
+}
+```
+
+- [ ] **Step 5: Tests pass + commit**
+
+```bash
+pnpm test:run apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx 2>&1 | tail -3
+git add apps/docs-site/src/components/Playground/OpenInStackBlitz.tsx \
+        apps/docs-site/src/components/Playground/seedProject.ts \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(playground): add OpenInStackBlitz + seedProject
+
+Button calls sdk.openProject with a seed built from the current
+Playground state. seedProject.ts owns the file map (package.json,
+index.html, src/main.tsx, src/App.tsx, vite.config.ts, tsconfig.json).
+The vitest stub for @stackblitz/sdk keeps tests hermetic.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Compose Playground root
+
+**Files:**
+- Create: `apps/docs-site/src/components/Playground/index.tsx`
+
+- [ ] **Step 1: Append the final axe + integration test**
+
+In `__tests__/Playground.test.tsx`:
+
+```tsx
+import Playground from '../index';
+
+describe('<Playground>', () => {
+  it('renders all four controls + preview + StackBlitz button', () => {
+    render(<Playground />);
+    expect(screen.getByRole('combobox', { name: /picker/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /locale/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /timezone/i })).toBeInTheDocument();
+    expect(screen.getByTestId('preview-panel')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open in stackblitz/i })).toBeInTheDocument();
+  });
+
+  it('changing picker selector swaps the preview', () => {
+    render(<Playground />);
+    const select = screen.getByRole('combobox', { name: /picker/i });
+    fireEvent.change(select, { target: { value: 'timepicker' } });
+    expect(screen.getByTestId('preview-panel').getAttribute('data-picker')).toBe('timepicker');
+  });
+
+  it('passes axe', async () => {
+    const { container } = render(<Playground />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Implement the composer**
+
+Create `apps/docs-site/src/components/Playground/index.tsx`:
+
+```tsx
+import { useState } from 'react';
+import PickerSelector from './PickerSelector';
+import ClassNamesEditor from './ClassNamesEditor';
+import LocaleTimezoneToggles from './LocaleTimezoneToggles';
+import PreviewPanel from './PreviewPanel';
+import OpenInStackBlitz from './OpenInStackBlitz';
+import { CLASSNAMES_BY_PICKER, type ClassNamesShape, type PickerId } from './classNamesByPicker';
+import type { Locale, Timezone } from './LocaleTimezoneToggles';
+import styles from './Playground.module.css';
+
+export default function Playground() {
+  const [pickerId, setPickerId] = useState<PickerId>('datepicker');
+  const [classNames, setClassNames] = useState<ClassNamesShape>(CLASSNAMES_BY_PICKER.datepicker);
+  const [locale, setLocale] = useState<Locale>('en-US');
+  const [timezone, setTimezone] = useState<Timezone>('UTC');
+
+  const handlePickerChange = (next: PickerId) => {
+    setPickerId(next);
+    setClassNames(CLASSNAMES_BY_PICKER[next]);
+  };
+
+  return (
+    <div className={styles.root}>
+      <aside className={styles.sidebar}>
+        <PickerSelector value={pickerId} onChange={handlePickerChange} />
+        <LocaleTimezoneToggles
+          locale={locale}
+          timezone={timezone}
+          onLocaleChange={setLocale}
+          onTimezoneChange={setTimezone}
+        />
+        <ClassNamesEditor
+          pickerId={pickerId}
+          value={classNames}
+          onChange={setClassNames}
+        />
+      </aside>
+      <main className={styles.main}>
+        <PreviewPanel
+          pickerId={pickerId}
+          classNames={classNames}
+          locale={locale}
+          timezone={timezone}
+        />
+        <div className={styles.footer}>
+          <OpenInStackBlitz
+            pickerId={pickerId}
+            classNames={classNames}
+            locale={locale}
+            timezone={timezone}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Finalise CSS**
+
+Append:
+
+```css
+.root {
+  display: grid;
+  grid-template-columns: 22rem 1fr;
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 996px) {
+  .root {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+- [ ] **Step 4: All tests pass + commit**
+
+```bash
+pnpm test:run
+git add apps/docs-site/src/components/Playground/index.tsx \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/Playground/__tests__/Playground.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(playground): compose Playground root
+
+State held at the root, fanned out to the 5 children. PickerId change
+also resets classNames to the new picker's defaults. Responsive sidebar
+collapses to a single column at the existing Docusaurus breakpoint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Replace `playground.mdx` body + final verify + PR
+
+**Files:**
+- Modify: `apps/docs-site/src/pages/playground.mdx`
+
+- [ ] **Step 1: Inspect current playground.mdx**
+
+```bash
+cat apps/docs-site/src/pages/playground.mdx
+```
+Identify the frontmatter, title, intro paragraph, and the existing `tsx live` block. Frontmatter + title + intro stay; the live block (and any sibling demo code) is removed.
+
+- [ ] **Step 2: Rewrite the body**
+
+Overwrite the file (preserving the frontmatter / title / intro at the top):
+
+```mdx
+---
+title: Playground
+description: Try every Kalyx picker live. Edit classNames, toggle locale and timezone, open in StackBlitz.
+---
+
+import Playground from '@site/src/components/Playground';
+
+# Playground
+
+Try every Kalyx picker live. Edit `classNames` to apply your own design tokens, toggle locale and timezone to see formatting change, and open the current state in StackBlitz with one click.
+
+<Playground />
+```
+
+- [ ] **Step 3: Verify dev render**
+
+```bash
+pnpm --filter docs-site start --port 3100 --no-open &
+SERVE_PID=$!
+sleep 6
+```
+Open `http://localhost:3100/playground` — exercise picker selector, classNames inputs, locale/tz, click "Open in StackBlitz" (which opens a real sandbox in a new tab). Stop:
+
+```bash
+kill $SERVE_PID
+```
+
+- [ ] **Step 4: Final verification matrix**
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test:run
+pnpm --filter docs-site build
+```
+All exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/docs-site/src/pages/playground.mdx
+git commit -m "$(cat <<'EOF'
+refactor(docs-site): replace playground.mdx body with <Playground />
+
+Frontmatter + title + 1-paragraph lead retained for Docusaurus TOC +
+SEO. Body becomes a single <Playground /> mount.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git log --oneline main..HEAD
+```
+Expected: 9 new commits (Tasks 1-9).
+
+```bash
+gh pr create --base main --title "feat(track1): PR-C — /playground enhancement (picker selector, classNames editor, StackBlitz)" --body "$(cat <<'EOF'
+## Summary
+
+Fourth PR in Track 1. Rewrites the playground page as a real interactive sandbox.
+
+- Picker selector — choose from all 7 kalyx pickers
+- classNames editor — text input per published part for the active picker
+- Locale + timezone toggles (4 each) drive the live preview's formatting
+- "Open in StackBlitz" button via \`@stackblitz/sdk\` — spawns a real sandbox seeded with the current playground state
+
+Spec: \`docs/superpowers/specs/2026-06-11-track1-pr-c-playground-enhancement-design.md\`
+Plan: \`docs/superpowers/plans/2026-06-11-track1-pr-c-playground-enhancement.md\`
+
+## Test plan
+
+- [x] \`pnpm test:run\` — all suites pass with 11+ new Playground tests
+- [x] \`pnpm typecheck\` / \`pnpm lint\` clean
+- [x] \`pnpm --filter docs-site build\` succeeds
+- [x] Dev render — every picker selector option swaps the preview, classNames edits apply live
+- [x] "Open in StackBlitz" opens a sandbox that renders the same picker with the same classNames
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes for the executor
+
+**If a picker's `classNames` prop type rejects the shape from `classNamesByPicker.ts`:** audit the `*ClassNames` type from `@kalyx/react`. Some keys (e.g., `Calendar` vs `calendar`) may differ in casing or be wrapped under a different parent. Update `classNamesByPicker.ts` to match — the source of truth is the published type.
+
+**If `@stackblitz/sdk` complains about TypeScript types:** the SDK exports default + named at the same time. `import sdk from '@stackblitz/sdk'` is the documented form; if your TS config rejects it, add `"esModuleInterop": true` in tsconfig (already true in docs-site's config). Otherwise use `import * as sdk from '@stackblitz/sdk'`.
+
+**If the dev render shows the picker overflowing the sidebar:** the Playground.module.css uses `grid-template-columns: 22rem 1fr;` — narrower sidebars push the preview wider. Adjust the rem value to taste.
+
+**If `pnpm install` flags a peer dep conflict on `@stackblitz/sdk`:** the SDK has minimal peer deps. If conflict persists, pin to the version range `^1`.

--- a/docs/superpowers/plans/2026-06-11-track1-pr-d-comparison-page.md
+++ b/docs/superpowers/plans/2026-06-11-track1-pr-d-comparison-page.md
@@ -1,0 +1,671 @@
+# Track 1 PR-D — `/docs/comparison` Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `/docs/comparison` (en + ko) with a feature matrix, inline-SVG bundle chart, and "When NOT to use Kalyx" section; wire it into the sidebar; swap `<WhyKalyx>`'s CTA to the new page.
+
+**Architecture:** New markdown pages in `apps/docs-site/docs/comparison.md` and `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md`. Sidebar entry in `apps/docs-site/sidebars.ts`. One-line href swap + one-line test update in the `<WhyKalyx>` component to close the PR-A2 follow-up.
+
+**Tech Stack:** Markdown / MDX, raw HTML SVG (no chart library), existing Docusaurus i18n pipeline, existing vitest + @testing-library/react test stack from PR-A2.
+
+**Scope:** Five commits, ~300 LoC, no new dependencies.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-11-track1-pr-d-comparison-page-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/docs-site/docs/comparison.md` — English comparison page
+- `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md` — Korean translation
+
+**Modify:**
+- `apps/docs-site/sidebars.ts` — add a `Comparison` doc entry
+- `apps/docs-site/src/components/WhyKalyx/index.tsx` — change CTA href from `/docs/intro#comparison` to `/docs/comparison`
+- `apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx` — update the expected href
+
+---
+
+## Task list
+
+### Task 1: Verify env + locate current sidebars / WhyKalyx state
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm we're on the latest main**
+
+Run:
+```bash
+git log -1 --format="%h %s"
+```
+Expected: HEAD points at PR-A2 merge (`7990348` or newer). If older, `git pull --ff-only` on the host worktree first.
+
+- [ ] **Step 2: Read the current sidebars structure**
+
+Run:
+```bash
+cat apps/docs-site/sidebars.ts
+```
+Identify which `category` the comparison page should slot into. The likely spot is a top-level "Reference" or "Concepts" category — match whatever pattern is already there. If no obvious fit exists, plan to add a new `category: 'Comparison'` (or fold it into the top-level docs list).
+
+Record the exact insertion point in your status.
+
+- [ ] **Step 3: Read WhyKalyx component + test**
+
+Run:
+```bash
+sed -n '30,55p' apps/docs-site/src/components/WhyKalyx/index.tsx
+sed -n '20,40p' apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx
+```
+Confirm the current href is exactly `/docs/intro#comparison` (it is, per PR-A2). Your edits will touch only this one string in each file.
+
+- [ ] **Step 4: Confirm baseline tests pass**
+
+Run:
+```bash
+pnpm test:run
+```
+Expected: 535+ tests pass. **Do not proceed if anything fails.**
+
+No commit. Verification only.
+
+---
+
+### Task 2: Write the English comparison page
+
+**Files:**
+- Create: `apps/docs-site/docs/comparison.md`
+
+- [ ] **Step 1: Write the page**
+
+Create `apps/docs-site/docs/comparison.md` with the following content:
+
+````markdown
+---
+title: How Kalyx compares
+description: How Kalyx stacks up against react-datepicker, react-day-picker, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates.
+slug: /comparison
+---
+
+# How Kalyx compares
+
+The 2026 React date-picker landscape has two extremes: integrated-but-heavy
+(react-datepicker, MUI) and headless-but-partial (react-day-picker, react-aria,
+ark-ui). Picking either side forces a real trade-off — bundle size vs assembly
+cost, CSS lock-in vs missing primitives. Kalyx is built to occupy the middle:
+seven complete primitives, one composition API, no required stylesheet,
+≤16 KB gzipped.
+
+## Feature matrix
+
+<div style={{overflowX: 'auto'}}>
+
+| Feature | react-datepicker | react-day-picker | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| RangePicker               | ✓ | partial[^1] | ✓ | partial[^1] | ✓ | ✓ | **✓** |
+| TimePicker                | partial[^2] | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
+| DateTimePicker            | partial[^2] | ✗ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
+| MonthPicker               | ✓ | ✗ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
+| YearPicker                | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | **✓** |
+| WeekPicker                | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Timezone-aware (IANA)     | partial[^4] | ✗ | ✓ | ✗ | ✓ | partial[^4] | **✓** |
+| Zero CSS (no required import) | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | **✓** |
+| SSR-safe (App Router)     | partial[^5] | ✓ | ✓ | ✓ | partial[^5] | ✓ | **✓** |
+| RSC-friendly              | ✗ | ✓ | partial[^6] | ✓ | ✗ | partial[^6] | **✓** |
+| a11y verified (axe + WAI-ARIA) | partial[^7] | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| ISO string API (UTC in/out) | ✗ | partial[^8] | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Adapter pattern (date-fns/dayjs/luxon) | ✗ | ✗ | partial[^9] | ✗ | ✓ | ✗ | **partial[^10]** |
+| Bundle gzip (KB)          | ~62 | ~22 | ~28 | ~20 | ~45 | ~30 | **~15** |
+| License                   | MIT | MIT | Apache-2.0 | MIT | MIT | MIT | **MIT** |
+
+</div>
+
+[^1]: Calendar grid is provided; range commit semantics must be wired by the consumer.
+[^2]: Time controls are bundled but require separate components and configuration props.
+[^3]: Available via underlying calendar primitives, not as a standalone exported component.
+[^4]: Timezone helpers exist but require manual offset bookkeeping for DST-correct displays.
+[^5]: Renders client-side, with hydration warnings if `window` is touched before mount.
+[^6]: Compatible inside RSC trees only when the component sits behind a `'use client'` boundary.
+[^7]: WAI-ARIA roles present; full axe pass varies by configuration.
+[^8]: Returns native `Date`; ISO conversion is the consumer's responsibility.
+[^9]: Pinned to `@internationalized/date`; date-fns / dayjs interop must round-trip via that type.
+[^10]: Default adapter is `@kalyx/adapter-date-fns`; alternate adapters (`-dayjs`, `-luxon`, `-temporal`) ship across v1.1+.
+
+> _Last measured 2026-06-11. Methodology: bundle sizes via bundlephobia + each
+> library's published `size-limit`; feature presence verified against each
+> library's v-latest docs at the time of writing._
+
+## Bundle size at a glance
+
+<svg role="img" aria-label="Bundle size comparison in KB gzip — Kalyx is the smallest at 15 KB" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" style={{width: '100%', maxWidth: 640, height: 'auto'}}>
+  <style>{`
+    .lbl { font: 13px var(--ifm-font-family-base, sans-serif); fill: var(--ifm-font-color-base, #1f1f1f); }
+    .val { font: 12px var(--ifm-font-family-monospace, monospace); fill: var(--ifm-color-emphasis-700, #555); }
+    .bar { fill: var(--ifm-color-emphasis-400, #b0b0b0); }
+    .barKalyx { fill: var(--ifm-color-primary, #6366f1); }
+    .axis { stroke: var(--ifm-color-emphasis-300, #d0d0d0); stroke-width: 1; }
+  `}</style>
+  {/* y axis labels (left side, 180px wide) — each row is 32px tall, starting y=18 */}
+  <text x="0" y="22" className="lbl">react-datepicker</text>
+  <text x="0" y="54" className="lbl">@mui/x-date-pickers</text>
+  <text x="0" y="86" className="lbl">@mantine/dates</text>
+  <text x="0" y="118" className="lbl">react-aria</text>
+  <text x="0" y="150" className="lbl">react-day-picker</text>
+  <text x="0" y="182" className="lbl">ark-ui</text>
+  <text x="0" y="214" className="lbl" style={{fontWeight: 700}}>Kalyx</text>
+
+  {/* bars: x starts at 180, scale = 6.5px per KB (62 KB → 403px, fits in 410px max) */}
+  <rect className="bar" x="180" y="10" width="403" height="16" rx="3" />
+  <rect className="bar" x="180" y="42" width="293" height="16" rx="3" />
+  <rect className="bar" x="180" y="74" width="195" height="16" rx="3" />
+  <rect className="bar" x="180" y="106" width="182" height="16" rx="3" />
+  <rect className="bar" x="180" y="138" width="143" height="16" rx="3" />
+  <rect className="bar" x="180" y="170" width="130" height="16" rx="3" />
+  <rect className="barKalyx" x="180" y="202" width="98" height="16" rx="3" />
+
+  {/* value labels on the right of each bar */}
+  <text x="590" y="22" className="val" textAnchor="end">62 KB</text>
+  <text x="480" y="54" className="val" textAnchor="end">45 KB</text>
+  <text x="382" y="86" className="val" textAnchor="end">30 KB</text>
+  <text x="369" y="118" className="val" textAnchor="end">28 KB</text>
+  <text x="330" y="150" className="val" textAnchor="end">22 KB</text>
+  <text x="317" y="182" className="val" textAnchor="end">20 KB</text>
+  <text x="285" y="214" className="val" textAnchor="end" style={{fontWeight: 700, fill: 'var(--ifm-color-primary, #6366f1)'}}>15 KB</text>
+
+  {/* baseline */}
+  <line className="axis" x1="180" y1="232" x2="600" y2="232" />
+  <text x="180" y="250" className="val">0</text>
+  <text x="600" y="250" className="val" textAnchor="end">64 KB</text>
+</svg>
+
+## When NOT to use Kalyx
+
+We try to be honest about where each competitor wins.
+
+**Use `react-datepicker`** if you need every edge case fixed and don't mind 4×
+the bundle. It's been shipping since 2015 — corner cases like Hijri calendars,
+Bengali numerals, and exotic date formats are battle-tested there in ways Kalyx
+will never catch up on for its v1 line.
+
+**Use `react-aria`** if you're building a design system from scratch and want
+Adobe's a11y team standing behind every primitive. React Aria's accessibility
+guarantees and platform-aware behavior (selection models, focus rings, screen
+reader hints) are deeper than what we ship. The trade is more code to assemble
+and a strict dependency on `@internationalized/date`.
+
+**Use `@mui/x-date-pickers`** if your app already uses MUI. The visual / theme
+integration with MUI's design tokens is automatic; bringing Kalyx into a
+MUI codebase means rewriting `classNames` to map to MUI's class API.
+
+In every other case — modern Next.js / Remix app, headless styling story, ISO
+strings as your storage primitive, single-digit-KB bundle target — Kalyx is
+designed to be the right pick.
+````
+
+- [ ] **Step 2: Verify the build picks it up**
+
+Run:
+```bash
+pnpm --filter docs-site build 2>&1 | tail -20
+```
+Expected: `[SUCCESS] Generated static files in "build"` for both en and ko (ko will still serve the English version as fallback at this point — Korean translation lands in Task 3). NO broken-anchor warnings; the WhyKalyx CTA still points at `/docs/intro#comparison` so that's the only remaining broken anchor (we fix it in Task 6).
+
+Open `apps/docs-site/build/comparison/index.html`:
+```bash
+ls apps/docs-site/build/comparison/
+```
+Expected: `index.html` exists.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs-site/docs/comparison.md
+git commit -m "$(cat <<'EOF'
+docs(comparison): add /docs/comparison page (en)
+
+Feature matrix across 7 competing libraries × 16 features, inline SVG
+horizontal bar chart for bundle size, "When NOT to use Kalyx" honesty
+section. Footer documents the 2026-06-11 measurement date and methodology.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Add Korean translation
+
+**Files:**
+- Create: `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md`
+
+- [ ] **Step 1: Create the Korean file**
+
+Create `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md` with the following content:
+
+````markdown
+---
+title: Kalyx 비교
+description: react-datepicker, react-day-picker, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates와 Kalyx를 비교합니다.
+slug: /comparison
+---
+
+# Kalyx 비교
+
+2026년 React 날짜 선택 라이브러리 생태계는 두 극단으로 나뉘어 있습니다. 통합되어
+있지만 무거운 쪽(react-datepicker, MUI)과 headless지만 일부 기능만 제공하는
+쪽(react-day-picker, react-aria, ark-ui). 어느 쪽을 택하든 번들 크기 vs 조립 비용,
+CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아들여야 합니다. Kalyx는 그
+중간을 차지하도록 설계됐습니다 — 7개의 완전한 프리미티브, 하나의 조합 API,
+강제 스타일시트 없음, 16 KB gzip 이하.
+
+## 기능 매트릭스
+
+<div style={{overflowX: 'auto'}}>
+
+| 기능 | react-datepicker | react-day-picker | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| RangePicker               | ✓ | 부분[^1] | ✓ | 부분[^1] | ✓ | ✓ | **✓** |
+| TimePicker                | 부분[^2] | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
+| DateTimePicker            | 부분[^2] | ✗ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
+| MonthPicker               | ✓ | ✗ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
+| YearPicker                | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | **✓** |
+| WeekPicker                | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Timezone (IANA)           | 부분[^4] | ✗ | ✓ | ✗ | ✓ | 부분[^4] | **✓** |
+| Zero CSS (강제 import 없음) | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | **✓** |
+| SSR 안전 (App Router)     | 부분[^5] | ✓ | ✓ | ✓ | 부분[^5] | ✓ | **✓** |
+| RSC 친화                  | ✗ | ✓ | 부분[^6] | ✓ | ✗ | 부분[^6] | **✓** |
+| 접근성 검증 (axe + WAI-ARIA) | 부분[^7] | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| ISO string API (UTC in/out) | ✗ | 부분[^8] | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Adapter 패턴 (date-fns/dayjs/luxon) | ✗ | ✗ | 부분[^9] | ✗ | ✓ | ✗ | **부분[^10]** |
+| 번들 gzip (KB)            | ~62 | ~22 | ~28 | ~20 | ~45 | ~30 | **~15** |
+| 라이선스                  | MIT | MIT | Apache-2.0 | MIT | MIT | MIT | **MIT** |
+
+</div>
+
+[^1]: 캘린더 그리드는 제공되지만 range commit 동작은 소비자가 직접 wiring해야 합니다.
+[^2]: 시간 컨트롤은 포함되지만 별도 컴포넌트와 설정 prop이 필요합니다.
+[^3]: 별도 export된 standalone 컴포넌트가 아니라 캘린더 프리미티브를 통해 가능합니다.
+[^4]: Timezone 헬퍼는 있지만 DST 정확한 표시를 위해 수동 오프셋 관리가 필요합니다.
+[^5]: 클라이언트 사이드에서만 렌더링되며 mount 전 `window` 접근 시 hydration warning이 발생합니다.
+[^6]: `'use client'` 경계 뒤에 있을 때만 RSC 트리 내에서 호환됩니다.
+[^7]: WAI-ARIA 역할은 존재하지만 axe 전수 통과는 설정에 따라 다릅니다.
+[^8]: native `Date`를 반환하며 ISO 변환은 소비자의 책임입니다.
+[^9]: `@internationalized/date`로 고정되어 date-fns / dayjs 상호운용은 해당 타입을 통해 round-trip 해야 합니다.
+[^10]: 기본 adapter는 `@kalyx/adapter-date-fns`이며 대체 adapter (`-dayjs`, `-luxon`, `-temporal`)는 v1.1+에서 출시됩니다.
+
+> _2026-06-11 기준 측정. 방법론: 번들 크기는 bundlephobia + 각 라이브러리의 공식
+> `size-limit`으로 측정, 기능 유무는 각 라이브러리의 v-latest 문서로 검증._
+
+## 한 눈에 보는 번들 크기
+
+<svg role="img" aria-label="번들 크기 비교 (KB gzip) — Kalyx가 15 KB로 가장 작음" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" style={{width: '100%', maxWidth: 640, height: 'auto'}}>
+  <style>{`
+    .lbl { font: 13px var(--ifm-font-family-base, sans-serif); fill: var(--ifm-font-color-base, #1f1f1f); }
+    .val { font: 12px var(--ifm-font-family-monospace, monospace); fill: var(--ifm-color-emphasis-700, #555); }
+    .bar { fill: var(--ifm-color-emphasis-400, #b0b0b0); }
+    .barKalyx { fill: var(--ifm-color-primary, #6366f1); }
+    .axis { stroke: var(--ifm-color-emphasis-300, #d0d0d0); stroke-width: 1; }
+  `}</style>
+  <text x="0" y="22" className="lbl">react-datepicker</text>
+  <text x="0" y="54" className="lbl">@mui/x-date-pickers</text>
+  <text x="0" y="86" className="lbl">@mantine/dates</text>
+  <text x="0" y="118" className="lbl">react-aria</text>
+  <text x="0" y="150" className="lbl">react-day-picker</text>
+  <text x="0" y="182" className="lbl">ark-ui</text>
+  <text x="0" y="214" className="lbl" style={{fontWeight: 700}}>Kalyx</text>
+
+  <rect className="bar" x="180" y="10" width="403" height="16" rx="3" />
+  <rect className="bar" x="180" y="42" width="293" height="16" rx="3" />
+  <rect className="bar" x="180" y="74" width="195" height="16" rx="3" />
+  <rect className="bar" x="180" y="106" width="182" height="16" rx="3" />
+  <rect className="bar" x="180" y="138" width="143" height="16" rx="3" />
+  <rect className="bar" x="180" y="170" width="130" height="16" rx="3" />
+  <rect className="barKalyx" x="180" y="202" width="98" height="16" rx="3" />
+
+  <text x="590" y="22" className="val" textAnchor="end">62 KB</text>
+  <text x="480" y="54" className="val" textAnchor="end">45 KB</text>
+  <text x="382" y="86" className="val" textAnchor="end">30 KB</text>
+  <text x="369" y="118" className="val" textAnchor="end">28 KB</text>
+  <text x="330" y="150" className="val" textAnchor="end">22 KB</text>
+  <text x="317" y="182" className="val" textAnchor="end">20 KB</text>
+  <text x="285" y="214" className="val" textAnchor="end" style={{fontWeight: 700, fill: 'var(--ifm-color-primary, #6366f1)'}}>15 KB</text>
+
+  <line className="axis" x1="180" y1="232" x2="600" y2="232" />
+  <text x="180" y="250" className="val">0</text>
+  <text x="600" y="250" className="val" textAnchor="end">64 KB</text>
+</svg>
+
+## Kalyx를 쓰지 않아야 할 때
+
+각 경쟁 라이브러리가 어디서 더 나은지 솔직하게 정리합니다.
+
+**`react-datepicker`를 쓰세요** — 모든 엣지 케이스가 다 잡혀있어야 하고 번들이
+4배 무거운 게 괜찮다면. 2015년부터 출하된 라이브러리라 히지리력, 벵골 숫자,
+특이한 날짜 포맷 같은 코너 케이스는 거기서 검증된 깊이로 Kalyx v1이 따라잡지
+않을 영역입니다.
+
+**`react-aria`를 쓰세요** — 디자인 시스템을 처음부터 만들고 모든 프리미티브에
+Adobe의 접근성 팀이 보증해주길 원한다면. React Aria의 접근성 보장과 플랫폼
+인식 동작(선택 모델, focus ring, screen reader hint)은 우리가 제공하는 것보다
+깊습니다. 트레이드오프는 더 많은 조립 코드와 `@internationalized/date`에 대한
+엄격한 의존성입니다.
+
+**`@mui/x-date-pickers`를 쓰세요** — 앱이 이미 MUI를 사용한다면. MUI 디자인
+토큰과의 시각/테마 통합이 자동입니다. MUI 코드베이스에 Kalyx를 도입하려면
+`classNames`를 MUI의 클래스 API로 매핑하는 재작성이 필요합니다.
+
+그 외 모든 경우 — 모던 Next.js / Remix 앱, headless 스타일링 스토리, 저장
+프리미티브로 ISO string, 한 자릿수 KB 번들 목표 — Kalyx가 올바른 선택이
+되도록 설계됐습니다.
+````
+
+- [ ] **Step 2: Verify ko build picks it up**
+
+Run:
+```bash
+pnpm --filter docs-site build 2>&1 | grep -E "\[en\]|\[ko\]|comparison|SUCCESS|broken" | head -10
+```
+Expected: `[SUCCESS]` for both locales. The Korean page should generate at `build/ko/comparison/index.html`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md
+git commit -m "$(cat <<'EOF'
+docs(comparison): add Korean translation of comparison page
+
+Verbatim structural mirror of /docs/comparison with Korean prose +
+Korean SVG aria-label. Footnotes preserved (same anchor names).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add sidebar entry
+
+**Files:**
+- Modify: `apps/docs-site/sidebars.ts`
+
+- [ ] **Step 1: Open the sidebars file**
+
+Run:
+```bash
+cat apps/docs-site/sidebars.ts
+```
+The file exports a `SidebarsConfig` object. Each top-level category is `{ type: 'category', label, items: [...] }`.
+
+- [ ] **Step 2: Add the comparison entry**
+
+The right home for the comparison page depends on the existing categories — pick the option below that matches what you saw in Task 1 Step 2:
+
+**Option A** — if there's a "Concepts" / "Reference" / "Why" category, add `'comparison'` as the last item of that array.
+
+**Option B** — if no obvious category fits, add a new top-level entry between the existing "Getting started" and "Components" categories:
+
+```ts
+{
+  type: 'category',
+  label: 'Why Kalyx',
+  collapsed: false,
+  items: ['comparison'],
+},
+```
+
+Edit `sidebars.ts` accordingly. The doc id `'comparison'` matches the markdown filename (Docusaurus resolves it automatically because the slug `/comparison` is at root).
+
+- [ ] **Step 3: Verify sidebar renders**
+
+Run:
+```bash
+pnpm --filter docs-site build 2>&1 | tail -3
+```
+Expected: build succeeds with no warnings about a missing sidebar reference.
+
+Visit `pnpm --filter docs-site serve --port 3100` and open `http://localhost:3100/docs/intro`. The sidebar should now show the new entry. Stop the dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/docs-site/sidebars.ts
+git commit -m "$(cat <<'EOF'
+docs(comparison): add sidebar entry for comparison page
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Swap WhyKalyx CTA href
+
+**Files:**
+- Modify: `apps/docs-site/src/components/WhyKalyx/index.tsx`
+
+- [ ] **Step 1: Open the file**
+
+Run:
+```bash
+grep -n "/docs/intro#comparison" apps/docs-site/src/components/WhyKalyx/index.tsx
+```
+Expected: one match in the `<Link to=...>` and one match in the surrounding comment block (the comment was added in PR-A2 as a swap-target marker).
+
+- [ ] **Step 2: Replace the href + update the comment**
+
+Edit `apps/docs-site/src/components/WhyKalyx/index.tsx`. Find:
+
+```tsx
+          {/*
+            PR-D will ship /docs/comparison; until then point at the
+            existing anchor on /docs/intro. PR-D's plan must swap this
+            href to '/docs/comparison'.
+          */}
+          <Link className={styles.cta} to="/docs/intro#comparison">
+```
+
+Replace with:
+
+```tsx
+          <Link className={styles.cta} to="/docs/comparison">
+```
+
+(Both the comment block and the href change in one edit. The comment was a PR-A2-era TODO; with PR-D shipping, it's no longer relevant.)
+
+- [ ] **Step 3: Test still fails** (TDD-style sanity check)
+
+Run:
+```bash
+pnpm test:run apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx 2>&1 | tail -5
+```
+Expected: 1 failing test (the one that asserts `'/docs/intro#comparison'`). Other 2 tests pass. This proves the href edit landed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/docs-site/src/components/WhyKalyx/index.tsx
+git commit -m "$(cat <<'EOF'
+feat(docs-site): swap WhyKalyx CTA target to /docs/comparison
+
+Closes the PR-A2 follow-up obligation: now that /docs/comparison
+exists, point the CTA there directly instead of at the
+/docs/intro#comparison anchor that never existed.
+
+The expected-href test in WhyKalyx.test.tsx fails after this commit
+and is fixed in the next commit (so the test history makes the swap
+explicit).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Update WhyKalyx test
+
+**Files:**
+- Modify: `apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx`
+
+- [ ] **Step 1: Update the expected href**
+
+Edit `apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx`. Find:
+
+```tsx
+  it('CTA points at the comparison anchor (stub until PR-D ships /docs/comparison)', () => {
+    render(<WhyKalyx />);
+    const link = screen.getByRole('link');
+    // PR-D swap-target: '/docs/comparison'. Until then we point at the
+    // anchor that already exists on /docs/intro.
+    expect(link.getAttribute('href')).toBe('/docs/intro#comparison');
+  });
+```
+
+Replace with:
+
+```tsx
+  it('CTA points at /docs/comparison', () => {
+    render(<WhyKalyx />);
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('/docs/comparison');
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+```bash
+pnpm test:run apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx 2>&1 | tail -3
+```
+Expected: 3/3 pass.
+
+- [ ] **Step 3: Sanity-run the whole suite**
+
+Run:
+```bash
+pnpm test:run
+```
+Expected: all tests pass, ≥ 535.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/docs-site/src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx
+git commit -m "$(cat <<'EOF'
+test(docs-site): update WhyKalyx expected href to /docs/comparison
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Final verification + PR
+
+- [ ] **Step 1: Full verification matrix**
+
+Run each in order:
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test:run
+pnpm --filter docs-site build
+```
+Expected: all four exit 0.
+
+- [ ] **Step 2: Confirm no broken anchors**
+
+Inspect the docs-site build output for broken-anchor warnings:
+```bash
+pnpm --filter docs-site build 2>&1 | grep -iE "broken|anchor" | head -10
+```
+Expected: no output. (PR-A2's stub broken anchor is now resolved because we changed WhyKalyx's href.)
+
+- [ ] **Step 3: Visual review**
+
+Run:
+```bash
+pnpm --filter docs-site serve --port 3100 --no-open &
+SERVE_PID=$!
+sleep 5
+```
+Open in a browser:
+- `http://localhost:3100/docs/comparison` — verify matrix renders, SVG bar chart visible, "When NOT to use Kalyx" section present
+- `http://localhost:3100/ko/docs/comparison` — verify Korean translation, same structure
+- `http://localhost:3100/` — verify WhyKalyx CTA points to `/docs/comparison` (hover, click — should navigate to the new page)
+
+Kill the server:
+```bash
+kill $SERVE_PID
+```
+
+- [ ] **Step 4: Open the PR**
+
+Run:
+```bash
+git log --oneline main..HEAD
+```
+Expected: 5 new commits (Tasks 2-6; Task 1 + Task 7 are verification-only).
+
+```bash
+gh pr create --base main --title "feat(track1): PR-D — /docs/comparison page + WhyKalyx CTA swap" --body "$(cat <<'EOF'
+## Summary
+
+Fifth and final PR in Track 1. Ships the comparison page that PR-A2 stubbed against.
+
+- New \`/docs/comparison\` page (en) — 7-library × 16-feature matrix, inline SVG bundle bar chart, honest "When NOT to use Kalyx" section
+- New \`/ko/docs/comparison\` — verbatim structural mirror with Korean prose
+- Sidebar entry under the existing category for navigation
+- Swap \`<WhyKalyx>\` CTA from \`/docs/intro#comparison\` (PR-A2 stub) → \`/docs/comparison\` (closes the PR-A2 follow-up obligation)
+- WhyKalyx test updated to assert the new href
+
+Spec: \`docs/superpowers/specs/2026-06-11-track1-pr-d-comparison-page-design.md\`
+Plan: \`docs/superpowers/plans/2026-06-11-track1-pr-d-comparison-page.md\`
+
+### Bundle figures
+
+Sources for the 7-library bar chart, as of 2026-06-11:
+- react-datepicker: 62 KB (bundlephobia)
+- @mui/x-date-pickers: 45 KB
+- @mantine/dates: 30 KB
+- react-aria: 28 KB
+- react-day-picker: 22 KB
+- ark-ui (DatePicker): 20 KB
+- Kalyx: 15 KB (live \`bundle-size\` CI value)
+
+### Resolved warnings
+
+The broken-anchor warning for \`/docs/intro#comparison\` that PR-A2 shipped is now resolved — the WhyKalyx CTA points at a real page.
+
+## Test plan
+
+- [x] \`pnpm test:run\` — all suites pass; WhyKalyx href test updated
+- [x] \`pnpm typecheck\` and \`pnpm lint\` clean
+- [x] \`pnpm --filter docs-site build\` succeeds for en + ko with no broken-anchor warnings
+- [x] Visual review of \`/docs/comparison\` and \`/ko/docs/comparison\` in dev — matrix + chart + "When NOT to use Kalyx" all render
+- [x] Click WhyKalyx CTA — navigates to \`/docs/comparison\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+Expected: PR URL printed.
+
+---
+
+## Notes for the executor
+
+**If a step fails:** do not skip ahead. Fix in place, re-run the verification, then re-commit (amend if no commits since, otherwise a new commit).
+
+**If the SVG looks broken in the build:** Docusaurus's MDX pipeline can be strict about JSX-in-markdown. The inline `<style>{`...`}</style>` blocks use template literals — if MDX complains, fall back to inline `style={{...}}` attributes on each `<text>` / `<rect>` instead of the CSS classes.
+
+**If the build emits a warning about a missing slug for `comparison`:** confirm the markdown frontmatter has `slug: /comparison`. The sidebar uses the doc id `'comparison'` which is the filename minus `.md`, NOT the slug — these can differ.
+
+**If `pnpm test:run` reports a different baseline than 535:** the project may have moved on. Verify nothing else is broken; the absolute number isn't the criterion — "no regressions vs the pre-Task-1 baseline" is.

--- a/docs/superpowers/specs/2026-06-11-track1-pr-b-sandbox-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-06-11-track1-pr-b-sandbox-infrastructure-design.md
@@ -1,0 +1,300 @@
+# Track 1 PR-B — Per-Picker Sandbox Infrastructure
+
+**Date:** 2026-06-11
+**Status:** Approved (parent spec) — subset spec for implementation
+**Track:** 1 (Visuals · Interactivity · Comparison) — PR #3 of 5
+**Parent spec:** [`2026-06-09-track1-visuals-interactive-comparison-design.md`](./2026-06-09-track1-visuals-interactive-comparison-design.md) § B
+
+## Context
+
+Track 1 ships visual/interactive/comparison improvements to the docs site. PR-B is the biggest of the five (~1200 LoC across many files): it gives every picker docs page a real interactive sandbox via two parallel mechanisms — inline `live` code blocks (already-enabled Docusaurus theme, just needs scope extension) and full StackBlitz iframe embeds backed by 7 new `examples/` projects.
+
+No code dependency on PR-C or PR-D. Independently shippable.
+
+## Scope
+
+**In:**
+
+- **B.1** — Extend `apps/docs-site/src/theme/ReactLiveScope/index.tsx` to expose every public `@kalyx/react` export. After this, any `.md`/`.mdx` page can use ```` ```tsx live ```` blocks rendering real pickers.
+- **B.2** — New component `apps/docs-site/src/components/StackBlitzEmbed.tsx`. Iframe + "Open in StackBlitz" link, props per parent spec § B.2.
+- **B.2** — 7 new example projects under `examples/`:
+  - `examples/datepicker-basic/`
+  - `examples/datepicker-rhf/`
+  - `examples/rangepicker-presets/`
+  - `examples/timepicker-12h/`
+  - `examples/datetimepicker-timezone/`
+  - `examples/datepicker-tailwind/`
+  - `examples/datepicker-shadcn/`
+- Remove `examples/stackblitz-rc/` (stale RC-era artifact).
+- Add an inline `tsx live` block to each of the 7 picker docs pages (`apps/docs-site/docs/components/<picker>.md`), placed below the intro and above the existing API table.
+- Add a `<StackBlitzEmbed>` to each picker docs page referencing the corresponding example project (use `datepicker-basic` for DatePicker, etc.).
+- Korean docs (`i18n/ko/docusaurus-plugin-content-docs/current/components/<picker>.md`) get the same `live` blocks and `<StackBlitzEmbed>` — example projects are language-agnostic, embed URLs are identical.
+- New CI helper `scripts/check-stackblitz-urls.mjs` that returns HTTP status for each of the 7 embed URLs. Manual-run + can be wired into the existing E2E workflow as a follow-up (not in this PR).
+- Workspace + pnpm config updates so the 7 `examples/*` packages are recognized as workspace packages and pass `pnpm typecheck` at the root.
+
+**Out:**
+
+- `<StackBlitzEmbed>` is a thin iframe + link wrapper. It does NOT use `@stackblitz/sdk` (that dep is owned by PR-C's `OpenInStackBlitz` button). Keeps PR-B and PR-C dep ownership clean.
+- The `scripts/check-stackblitz-urls.mjs` cron wiring (nightly issue creation) is out of scope; the parent spec lists it as a separate follow-up.
+- "Recipes" deep-dives on each picker page (deferred — current recipe content stays, only the live block + embed are added at the top of each page).
+- Re-styling of existing docs pages.
+- A `<LiveBlock>` wrapper component on top of Docusaurus's built-in — the built-in already works once the scope is extended.
+
+## Architecture
+
+### File tree
+
+```
+apps/docs-site/
+├── src/
+│   ├── theme/
+│   │   └── ReactLiveScope/
+│   │       └── index.tsx                      ← edit: expose @kalyx/react
+│   └── components/
+│       └── StackBlitzEmbed/
+│           ├── index.tsx                      ← iframe + link
+│           ├── StackBlitzEmbed.module.css
+│           └── __tests__/StackBlitzEmbed.test.tsx
+├── docs/components/
+│   ├── datepicker.md                          ← edit: add live + embed
+│   ├── rangepicker.md                         ← edit
+│   ├── timepicker.md                          ← edit
+│   ├── datetimepicker.md                      ← edit
+│   ├── monthpicker.md                         ← edit
+│   ├── yearpicker.md                          ← edit
+│   └── weekpicker.md                          ← edit
+└── i18n/ko/docusaurus-plugin-content-docs/current/components/
+    └── (same 7 files)                         ← edit: mirror live + embed
+
+examples/
+├── datepicker-basic/
+│   ├── package.json
+│   ├── index.html
+│   ├── tsconfig.json
+│   ├── vite.config.ts
+│   └── src/
+│       ├── App.tsx
+│       └── main.tsx
+├── datepicker-rhf/                             ← + react-hook-form dep
+├── rangepicker-presets/
+├── timepicker-12h/
+├── datetimepicker-timezone/
+├── datepicker-tailwind/                        ← + tailwindcss dep
+├── datepicker-shadcn/                          ← + cn util + cva pattern
+└── stackblitz-rc/                              ← DELETED
+
+scripts/
+└── check-stackblitz-urls.mjs                  ← new: HTTP HEAD against each embed URL
+
+pnpm-workspace.yaml                             ← add 'examples/*' if not already
+```
+
+### `<StackBlitzEmbed>` API
+
+```tsx
+type Props = {
+  id: string;                       // examples/<id>
+  file?: string;                    // default 'src/App.tsx'
+  height?: number;                  // default 600
+  theme?: 'dark' | 'light';         // default 'dark'
+};
+```
+
+Renders:
+
+```tsx
+<div className={styles.wrapper}>
+  <iframe
+    src={`https://stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/${id}?embed=1&file=${file ?? 'src/App.tsx'}&hideExplorer=1&theme=${theme ?? 'dark'}`}
+    title={`Kalyx example: ${id}`}
+    loading="lazy"
+    height={height ?? 600}
+    style={{ width: '100%', border: 0 }}
+  />
+  <a
+    className={styles.openLink}
+    href={`https://stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/${id}`}
+    target="_blank"
+    rel="noopener noreferrer">
+    Open in StackBlitz ↗
+  </a>
+</div>
+```
+
+`title` is required for iframe a11y. `loading="lazy"` keeps iframes from competing with first paint when multiple embeds appear on one docs page (rare, but possible).
+
+### ReactLiveScope extension
+
+```tsx
+// apps/docs-site/src/theme/ReactLiveScope/index.tsx
+import * as React from 'react';
+import {
+  DatePicker, RangePicker, TimePicker, DateTimePicker,
+  MonthPicker, YearPicker, WeekPicker,
+  useDatePicker, useRangePicker, useTimePicker,
+  DateFnsAdapter,
+} from '@kalyx/react';
+
+export default {
+  React,
+  ...React,
+  DatePicker, RangePicker, TimePicker, DateTimePicker,
+  MonthPicker, YearPicker, WeekPicker,
+  useDatePicker, useRangePicker, useTimePicker,
+  DateFnsAdapter,
+};
+```
+
+If `ReactLiveScope/index.tsx` already exists (it does — Docusaurus theme-live-codeblock is wired in), this is a content swap, not a new file.
+
+### Example project shape
+
+Each `examples/<id>/` is a real pnpm workspace package. Minimal template:
+
+```json
+// package.json
+{
+  "name": "@kalyx-example/datepicker-basic",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": { "dev": "vite", "build": "vite build", "typecheck": "tsc -b --noEmit" },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@kalyx/react": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^7.0.0"
+  }
+}
+```
+
+```tsx
+// src/App.tsx
+import { useState } from 'react';
+import { DatePicker } from '@kalyx/react';
+
+export default function App() {
+  const [iso, setIso] = useState<string | null>('2026-06-15T00:00:00.000Z');
+  return (
+    <div style={{ padding: 32 }}>
+      <h1>Kalyx — DatePicker basic</h1>
+      <DatePicker value={iso} onChange={setIso}>
+        <DatePicker.Input placeholder="Pick a date" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>
+      <pre style={{ marginTop: 16 }}>{JSON.stringify({ iso }, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+Specialised examples (`-rhf`, `-tailwind`, `-shadcn`) add the relevant peer deps and demonstrate the integration pattern. Each example's `App.tsx` is < 80 LoC — focused, copy-paste-ready snippets.
+
+### CI helper script
+
+`scripts/check-stackblitz-urls.mjs`:
+
+```js
+#!/usr/bin/env node
+import { request } from 'undici';
+
+const EXAMPLES = [
+  'datepicker-basic', 'datepicker-rhf', 'rangepicker-presets',
+  'timepicker-12h', 'datetimepicker-timezone',
+  'datepicker-tailwind', 'datepicker-shadcn',
+];
+
+let fail = 0;
+for (const id of EXAMPLES) {
+  const url = `https://stackblitz.com/github/jiji-hoon96/kalyx/tree/main/examples/${id}`;
+  const res = await request(url, { method: 'HEAD' });
+  if (res.statusCode >= 400) {
+    console.error(`✗ ${id}: HTTP ${res.statusCode}`);
+    fail++;
+  } else {
+    console.log(`✓ ${id}: HTTP ${res.statusCode}`);
+  }
+}
+process.exit(fail > 0 ? 1 : 0);
+```
+
+Manual-run. Not wired into PR-check yet — parent spec earmarks that for a nightly job.
+
+## Testing strategy
+
+### Component tests
+
+- `<StackBlitzEmbed>` smoke: renders iframe with correct URL, "Open in StackBlitz" link present, axe pass (3 tests).
+- ReactLiveScope: no direct test; verified indirectly by the docs-site build succeeding with new ```` ```tsx live ```` blocks.
+
+### Example project verification
+
+- `pnpm -r --filter "@kalyx-example/*" typecheck` — all 7 examples must pass `tsc -b`. This catches API drift if `@kalyx/react` exports change.
+- Each example project must build via `pnpm --filter "@kalyx-example/<id>" build`. Sampled, not exhaustive in CI (manual or local).
+
+### Docs build
+
+- `pnpm --filter docs-site build` must succeed for en + ko after every picker page's edits — confirms the `tsx live` syntax passes Docusaurus's MDX transform and the embeds are valid markup.
+
+### Manual
+
+- Click through each picker docs page in dev, exercise the live block, click "Open in StackBlitz" to confirm the URL loads a real sandbox.
+- Run `node scripts/check-stackblitz-urls.mjs` — expect 7× HTTP 200 (StackBlitz returns 200 even for repo paths it hasn't snapshotted, so this is a weak signal but better than nothing).
+
+## Success criteria
+
+- [ ] `ReactLiveScope` exposes all 7 pickers + 3 hooks + `DateFnsAdapter`
+- [ ] At least one inline ```` ```tsx live ```` block on each of the 7 picker docs pages, both en and ko (14 pages)
+- [ ] At least one `<StackBlitzEmbed>` on each of the 7 picker docs pages, both en and ko
+- [ ] All 7 example projects under `examples/` pass `pnpm typecheck`
+- [ ] All 7 StackBlitz URLs return HTTP 200 via `scripts/check-stackblitz-urls.mjs`
+- [ ] `examples/stackblitz-rc/` removed
+- [ ] Vitest baseline + 3 new `<StackBlitzEmbed>` tests pass
+- [ ] `pnpm --filter docs-site build` succeeds for en + ko
+- [ ] No regression in `@kalyx/react` bundle (no source touched)
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| StackBlitz embed URL changes / repo path moves | The URL convention is documented in `<StackBlitzEmbed>`'s JSDoc. The `check-stackblitz-urls.mjs` script catches URL rot. |
+| One bad `live` block breaks the docs-site build | Each picker page edited in a separate commit. CI build runs per commit; bad blocks isolated. |
+| `examples/*` packages bloat `pnpm install` time at root | Each example pulls only React + `@kalyx/react`. The 7 examples together add ~80 MB to `node_modules` (mostly shared). Acceptable. |
+| `@vitejs/plugin-react@^5` / `vite@^7` are bleeding-edge in some examples | Use the same versions the workspace already uses; do not introduce new majors. |
+| The Tailwind / shadcn examples need their own configs that drift from the recipes docs | Each example folder gets a `README.md` (one paragraph) summarising the integration. Lightweight; not in the success criteria above. |
+| The 7 examples each get their own `index.html` + `main.tsx` with the same boilerplate — DRY violation | Acceptable — copy-paste examples ARE the point. A shared template would defeat the purpose of "open in StackBlitz, see exact code". |
+
+## PR breakdown
+
+Single PR. Commit shape (~15 commits):
+
+1. `chore(workspace): include examples/* and remove stackblitz-rc`
+2. `feat(docs-site): expose @kalyx/react in ReactLiveScope`
+3. `feat(docs-site): add StackBlitzEmbed component + tests`
+4. `feat(examples): add datepicker-basic`
+5. `feat(examples): add datepicker-rhf`
+6. `feat(examples): add rangepicker-presets`
+7. `feat(examples): add timepicker-12h`
+8. `feat(examples): add datetimepicker-timezone`
+9. `feat(examples): add datepicker-tailwind`
+10. `feat(examples): add datepicker-shadcn`
+11. `feat(scripts): add check-stackblitz-urls.mjs`
+12. `docs(components): add live block + embed to DatePicker (en + ko)`
+13. `docs(components): add live block + embed to RangePicker (en + ko)`
+14. `docs(components): add live block + embed to TimePicker / DateTimePicker (en + ko)`
+15. `docs(components): add live block + embed to Month / Year / WeekPicker (en + ko)`
+
+The 7 example-project commits are the largest individual diffs (~150 LoC each); the docs commits are small (~30 LoC per picker page).
+
+## References
+
+- Parent spec § B — `docs/superpowers/specs/2026-06-09-track1-visuals-interactive-comparison-design.md`
+- Docusaurus theme-live-codeblock — https://docusaurus.io/docs/markdown-features/code-blocks#interactive-code-editor
+- StackBlitz GitHub embeds — https://developer.stackblitz.com/platform/embed-a-github-project
+- Existing `ReactLiveScope` — `apps/docs-site/src/theme/ReactLiveScope/index.tsx`
+- Existing examples directory — `examples/`

--- a/docs/superpowers/specs/2026-06-11-track1-pr-c-playground-enhancement-design.md
+++ b/docs/superpowers/specs/2026-06-11-track1-pr-c-playground-enhancement-design.md
@@ -1,0 +1,193 @@
+# Track 1 PR-C — `/playground` Enhancement
+
+**Date:** 2026-06-11
+**Status:** Approved (parent spec) — subset spec for implementation
+**Track:** 1 (Visuals · Interactivity · Comparison) — PR #4 of 5
+**Parent spec:** [`2026-06-09-track1-visuals-interactive-comparison-design.md`](./2026-06-09-track1-visuals-interactive-comparison-design.md) § C
+
+## Context
+
+`apps/docs-site/src/pages/playground.mdx` currently renders one editable DatePicker as a Docusaurus live block. The page is one of the top conversion surfaces — a visitor playing with the live picker is most of the way to installing.
+
+This PR replaces the single-picker MDX page with a richer `<Playground>` component: picker selector, classNames editor, locale + timezone toggles, and an "Open in StackBlitz" button.
+
+No code dependency on PR-B or PR-D. Independently shippable.
+
+## Scope
+
+**In:**
+
+- New component `apps/docs-site/src/components/Playground/index.tsx` (default-exported) with the three controls + live render + StackBlitz button.
+- Replace `apps/docs-site/src/pages/playground.mdx` body with a single `<Playground />` mount (keep the existing MDX frontmatter / heading / lead paragraph above the component).
+- Add `@stackblitz/sdk` as a dependency of `apps/docs-site` (used only in the playground page — no impact on landing or other routes).
+- Per-component classNames editor that covers the published `classNames` prop surface for each picker (see § Architecture).
+- Locale options: `en-US`, `ko-KR`, `ja-JP`, `fr-FR`. Timezone options: `UTC`, `Asia/Seoul`, `America/New_York`, `Europe/London`.
+- Tests: render-smoke + axe for `<Playground>`; smoke that switching the picker selector swaps the rendered picker; smoke that the StackBlitz button is reachable by keyboard.
+
+**Out:**
+
+- Save/restore playground state to URL (deferred — adds query-string parsing complexity)
+- Sharing the StackBlitz link as a paste-friendly URL (the SDK's `openProject` opens a fresh sandbox each click; long-link sharing is a follow-up)
+- Custom theme variants beyond the existing CSS variables
+- Live preview of generated TS interfaces / props
+- Mobile-first redesign — the playground is desktop-primary on purpose
+
+## Architecture
+
+### File layout
+
+```
+apps/docs-site/
+├── src/
+│   ├── components/
+│   │   └── Playground/
+│   │       ├── index.tsx                     ← composer + state
+│   │       ├── PickerSelector.tsx            ← <select> for 7 pickers
+│   │       ├── ClassNamesEditor.tsx          ← per-part class inputs
+│   │       ├── LocaleTimezoneToggles.tsx     ← two <select>s
+│   │       ├── PreviewPanel.tsx              ← live picker render
+│   │       ├── OpenInStackBlitz.tsx          ← button + SDK call
+│   │       ├── classNamesByPicker.ts         ← static map of parts per picker
+│   │       ├── seedProject.ts                ← StackBlitz project seed builder
+│   │       ├── Playground.module.css
+│   │       └── __tests__/Playground.test.tsx
+│   └── pages/playground.mdx                   ← rewrite body to <Playground />
+```
+
+### State model
+
+A single `PlaygroundState` object passed top-down:
+
+```ts
+type PlaygroundState = {
+  pickerId: 'datepicker' | 'rangepicker' | 'timepicker' | 'datetimepicker' | 'monthpicker' | 'yearpicker' | 'weekpicker';
+  classNames: Record<string, string>; // keys depend on pickerId
+  locale: 'en-US' | 'ko-KR' | 'ja-JP' | 'fr-FR';
+  timezone: 'UTC' | 'Asia/Seoul' | 'America/New_York' | 'Europe/London';
+};
+```
+
+Held in `useState` at `<Playground>` root. Three controls call setters; `<PreviewPanel>` reads the whole state and dispatches to the right `@kalyx/react` component.
+
+When `pickerId` changes, the new picker's default classNames map seeds in; the user's previous custom class strings for the old picker are discarded (simpler than persistence and matches user expectation of "I switched pickers, start fresh").
+
+### `classNamesByPicker.ts`
+
+Static map listing the published `classNames` prop surface for each picker. Source-of-truth: read each picker's `*ClassNames` exported type from `@kalyx/react`. Example:
+
+```ts
+export const CLASSNAMES_BY_PICKER = {
+  datepicker: {
+    input: '',
+    calendar: { root: '', header: '', grid: '', day: '', daySelected: '', dayToday: '', dayDisabled: '', dayOutsideMonth: '' },
+  },
+  rangepicker: { /* ... */ },
+  // ... 5 more
+} as const;
+```
+
+UI flattens this into a `key.path` ↔ string-input list (`calendar.day`, `calendar.daySelected`, etc.) for editing.
+
+### StackBlitz seed
+
+`seedProject.ts` builds a project descriptor:
+
+```ts
+import sdk from '@stackblitz/sdk';
+
+sdk.openProject({
+  title: `Kalyx Playground — ${state.pickerId}`,
+  template: 'create-react-app-typescript', // or 'node' with Vite — see § Risks
+  files: {
+    'src/App.tsx': renderAppCode(state),
+    'src/index.tsx': INDEX_STUB,
+    'package.json': renderPackageJson(state),
+  },
+}, { openFile: 'src/App.tsx' });
+```
+
+The state hash goes into the title only (StackBlitz's project name suffix). No project URL persistence.
+
+### MDX integration
+
+```mdx
+---
+title: Playground
+description: Try every Kalyx picker live. Edit classNames, toggle locale and timezone, open in StackBlitz.
+---
+
+import Playground from '@site/src/components/Playground';
+
+# Playground
+
+Try every Kalyx picker live. Edit classNames, toggle locale and timezone, open in StackBlitz with one click.
+
+<Playground />
+```
+
+The page-level frontmatter / title / lead paragraph stays in MDX so Docusaurus's TOC and SEO meta still work. The actual interactive surface is one React mount.
+
+## Testing strategy
+
+### Per-component smoke tests
+
+- `<PickerSelector>` — renders 7 options, fires onChange when changed (1 test)
+- `<ClassNamesEditor>` — renders one input per part for the active pickerId, fires onChange (1 test)
+- `<LocaleTimezoneToggles>` — renders 4 locale + 4 timezone options each (1 test)
+- `<OpenInStackBlitz>` — renders button, clickable, `sdk.openProject` called with correct file map on click (1 test, `sdk` mocked)
+- `<Playground>` (integration smoke) — renders all four controls, switching pickerId changes the rendered preview (2 tests)
+- Axe pass on `<Playground>` (1 test)
+
+Target: **7 new tests**, all under `Playground/__tests__/`.
+
+### Mocks
+
+- `@stackblitz/sdk` mocked at vitest config level (alias to `test/__mocks__/stackblitz-sdk.ts` returning a no-op `openProject`)
+- `@docusaurus/*` already aliased from PR-A2
+
+### Manual review
+
+- `pnpm --filter docs-site start`, navigate to `/playground`, exercise every control on every picker.
+- Click "Open in StackBlitz" — sandbox must open in a new tab with the right picker and classNames applied.
+
+## Success criteria
+
+- [ ] `<Playground>` renders without runtime errors on initial mount
+- [ ] Picker selector switches between all 7 pickers without crashing
+- [ ] classNames edits apply live to the rendered picker
+- [ ] Locale + timezone toggles take effect (verify date display formats change)
+- [ ] "Open in StackBlitz" spawns a working sandbox that renders the same picker config
+- [ ] Existing `<DatePicker live>` block in `playground.mdx` is replaced — no orphan
+- [ ] All 7 new tests pass + axe
+- [ ] `pnpm --filter docs-site build` succeeds for en + ko
+- [ ] Bundle size for landing chunk unchanged (`<Playground>` is on its own route, lazy by Docusaurus's per-page splitting)
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `@stackblitz/sdk` doesn't have a Vite-friendly template, only Webpack 4-era CRA | Use `template: 'node'` + a minimal Vite `vite.config.ts` in the seeded files. Vite templates work cleanly with React 19 + `@kalyx/react`. Verify in the implementation plan. |
+| `@stackblitz/sdk` pulls in a heavy chunk on the playground page | The dep ships its own iframe-API client (~10 KB gzip). Acceptable on a non-landing route. Lazy-import it inside `OpenInStackBlitz.tsx` if it bloats further. |
+| classNames-editor UI feels cluttered with 8-10 part inputs visible | Group inputs by section header (Calendar / Input / Popover). Collapsible groups deferred — out of scope. |
+| Switching pickerId mid-edit loses the user's class strings | Acknowledged trade-off (per § Architecture). A confirmation dialog is feature creep. |
+| `@kalyx/react` typings for `*ClassNames` don't expose every part | Audit during implementation. If any part is private, document the gap and skip that input. |
+
+## PR breakdown
+
+Single PR. Commit shape (~9 commits):
+
+1. `chore(docs-site): add @stackblitz/sdk dependency + mock`
+2. `feat(playground): scaffold classNamesByPicker map`
+3. `feat(playground): add PickerSelector`
+4. `feat(playground): add ClassNamesEditor`
+5. `feat(playground): add LocaleTimezoneToggles`
+6. `feat(playground): add PreviewPanel`
+7. `feat(playground): add OpenInStackBlitz + seedProject`
+8. `feat(playground): compose Playground root`
+9. `refactor(docs-site): replace playground.mdx body with <Playground />`
+
+## References
+
+- Parent spec § C — `docs/superpowers/specs/2026-06-09-track1-visuals-interactive-comparison-design.md`
+- StackBlitz SDK docs — https://developer.stackblitz.com/platform/api/javascript-sdk
+- Each picker's `*ClassNames` export — `packages/react/src/components/<picker>/`

--- a/docs/superpowers/specs/2026-06-11-track1-pr-d-comparison-page-design.md
+++ b/docs/superpowers/specs/2026-06-11-track1-pr-d-comparison-page-design.md
@@ -1,0 +1,142 @@
+# Track 1 PR-D — `/docs/comparison` Page
+
+**Date:** 2026-06-11
+**Status:** Approved (parent spec) — subset spec for implementation
+**Track:** 1 (Visuals · Interactivity · Comparison) — PR #5 of 5
+**Parent spec:** [`2026-06-09-track1-visuals-interactive-comparison-design.md`](./2026-06-09-track1-visuals-interactive-comparison-design.md) § D
+
+## Context
+
+Track 1 has already shipped PR-A1 (hero recorder + WebPs) and PR-A2 (landing redesign). PR-A2 stubbed the `<WhyKalyx>` CTA to `/docs/intro#comparison` because the comparison page didn't exist yet — that's the follow-up obligation this PR closes.
+
+PR-D is small (~300 LoC, mostly markdown) and has no code dependencies on PR-B or PR-C. It can ship in any order relative to those.
+
+## Scope
+
+**In:**
+
+- New file `apps/docs-site/docs/comparison.md` (English)
+- New file `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md` (Korean translation)
+- Sidebar entry in `apps/docs-site/sidebars.ts` so the page appears in the docs nav
+- Inline SVG bundle-size bar chart (hand-coded, no chart library)
+- Static feature matrix with 7 libraries × ~16 features
+- "When NOT to use Kalyx" honesty paragraph
+- Swap `<WhyKalyx>` CTA from `/docs/intro#comparison` → `/docs/comparison` (closes the PR-A2 follow-up)
+- Update the WhyKalyx smoke test's expected href
+
+**Out:**
+
+- Live re-measurement of competitor bundle sizes (illustrative values per parent spec § D; explicit "Last measured" note)
+- Methodology automation (CI script that diffs bundle sizes weekly) — deferred
+- Interactive sort/filter on the matrix — static is fine
+- Per-library deep-dive subsections — keep page concise
+
+## Architecture
+
+### File layout
+
+```
+apps/docs-site/
+├── docs/comparison.md                                              ← English
+├── i18n/ko/docusaurus-plugin-content-docs/current/comparison.md    ← Korean
+├── src/components/WhyKalyx/index.tsx                                ← edit: swap href
+└── src/components/WhyKalyx/__tests__/WhyKalyx.test.tsx              ← edit: update expected href
+sidebars.ts                                                          ← add entry
+```
+
+### Comparison page structure (markdown)
+
+```markdown
+---
+title: How Kalyx compares
+description: How Kalyx stacks up against react-datepicker, react-day-picker, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates.
+slug: /comparison
+---
+
+# How Kalyx compares
+
+3-sentence intro (problem statement).
+
+## Feature matrix
+
+| Feature | react-datepicker | react-day-picker | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | Kalyx |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| DatePicker | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ... 15 more rows ... |
+
+> Last measured 2026-06-11. Methodology: bundle sizes via bundlephobia + size-limit; feature presence verified against each library's v-latest docs at the time of writing.
+
+## Bundle size at a glance
+
+[Inline SVG horizontal bar chart, Kalyx bar highlighted]
+
+## When NOT to use Kalyx
+
+3-paragraph honesty section.
+```
+
+### Inline SVG bar chart
+
+Hand-coded SVG inside the markdown (Docusaurus allows raw HTML/SVG via MDX). Each `<rect>` width scaled by `kb / max_kb * total_pixel_width`. Kalyx bar gets a distinct fill matching `var(--ifm-color-primary)` so it visually pops.
+
+Approximate sizes used (per parent spec § D — illustrative until re-measured):
+
+| Library | KB gzip |
+|---|---|
+| react-datepicker | 62 |
+| @mui/x-date-pickers | 45 |
+| @mantine/dates | 30 |
+| react-aria | 28 |
+| react-day-picker | 22 |
+| ark-ui (DatePicker) | 20 |
+| **Kalyx** | **15** (live `bundle-size` CI value) |
+
+The SVG is one block of inline markup at the bottom of section 2. Dimensions: ~640 px × ~280 px, no scripting, accessible via `role="img"` + `aria-label="Bundle size comparison (gzip, KB)"`.
+
+### Korean translation
+
+Verbatim structure mirroring the English file. Korean text written by hand from the English source. Same SVG (kept English library names — they're product names — but legend / `<title>` translated).
+
+## Testing strategy
+
+- WhyKalyx component test: expected href updated from `/docs/intro#comparison` → `/docs/comparison`. Existing 3 tests stay; no new tests added.
+- Docs-site build: `pnpm --filter docs-site build` must pass for both locales, no broken anchor warnings (since the target page now exists).
+- No new vitest unit tests for the markdown page itself (it's content, not logic).
+- Manual visual review on `pnpm --filter docs-site start` of `/docs/comparison` and `/ko/docs/comparison`.
+
+## Success criteria
+
+- [ ] `/docs/comparison` and `/ko/docs/comparison` both exist and render
+- [ ] Feature matrix shows all 7 libraries × ≥ 15 features
+- [ ] Inline SVG bar chart renders with all 7 bars + accessible label
+- [ ] "When NOT to use Kalyx" section present
+- [ ] "Last measured 2026-06-11" footer present
+- [ ] Sidebar shows a `Comparison` entry under the appropriate category
+- [ ] `WhyKalyx` CTA navigates to `/docs/comparison` (no longer to `#comparison` anchor)
+- [ ] `pnpm --filter docs-site build` produces no broken-anchor warnings on either locale
+- [ ] All existing tests still pass (no smoke tests broken by the WhyKalyx href change — only its expectation is bumped)
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Library data points get stale | "Last measured YYYY-MM-DD" footer + 90-day staleness check is a follow-up. PR-D ships a fresh snapshot. |
+| Markdown table renders wide on mobile and overflows | Wrap matrix in a `<div style="overflow-x:auto">` so it scrolls horizontally on narrow viewports. |
+| Korean page diverges from English over time | Out of scope here; parent spec lists `scripts/check-comparison-parity.mjs` as a future tool. |
+| WhyKalyx href swap breaks the existing test | One-line test update. Smoke-test pass required before merge. |
+
+## PR breakdown
+
+Single PR. Commit shape (~5 commits):
+
+1. `docs(comparison): add /docs/comparison page (en)`
+2. `docs(comparison): add Korean translation`
+3. `docs(comparison): add sidebar entry`
+4. `feat(docs-site): swap WhyKalyx CTA target to /docs/comparison`
+5. `test(docs-site): update WhyKalyx expected href`
+
+## References
+
+- Parent spec § D — `docs/superpowers/specs/2026-06-09-track1-visuals-interactive-comparison-design.md`
+- PR-A2 follow-up obligation — see PR #102 description
+- Bundle figures sourced from bundlephobia + each library's own `size-limit`/published gzip stats, as of 2026-06-11


### PR DESCRIPTION
## Summary

Subset specs **and** implementation plans for the remaining 3 Track 1 PRs, bundled into a single docs PR so they review together.

### Specs (3)
- `docs/superpowers/specs/2026-06-11-track1-pr-b-sandbox-infrastructure-design.md` — ReactLiveScope extension + `<StackBlitzEmbed>` + 7 `examples/*` projects + picker docs embeds
- `docs/superpowers/specs/2026-06-11-track1-pr-c-playground-enhancement-design.md` — picker selector + classNames editor + locale/tz toggles + StackBlitz button via `@stackblitz/sdk`
- `docs/superpowers/specs/2026-06-11-track1-pr-d-comparison-page-design.md` — `/docs/comparison` (en+ko) + inline SVG bundle chart + WhyKalyx CTA swap (closes the PR-A2 follow-up)

### Plans (3)
- `docs/superpowers/plans/2026-06-11-track1-pr-d-comparison-page.md` (~7 tasks, smallest)
- `docs/superpowers/plans/2026-06-11-track1-pr-c-playground-enhancement.md` (~9 tasks)
- `docs/superpowers/plans/2026-06-11-track1-pr-b-sandbox-infrastructure.md` (~15 tasks, largest)

Each plan ships in TDD shape (failing test → impl → pass → commit) and references its matching spec.

### Order of execution after this merges
PR-D → PR-C → PR-B (small → large, PR-D unblocks the PR-A2 WhyKalyx follow-up). All three are independent — no code dependencies between them, so they can land in any order.

## Test plan

- [ ] Skim each subset spec for scope / placeholders / missing interfaces
- [ ] Skim each plan for concrete code blocks (no TBDs) and consistent file paths
- [ ] Confirm: each plan can be executed independently of the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * Track 1 PR-B/C/D에 대한 구현 계획 및 설계 문서 6개 추가
  * 피커 문서의 인터랙티브 샌드박스 구축 계획 및 설계 스펙 추가
  * 플레이그라운드 기능 강화 계획 및 설계 스펙 추가
  * 제품 비교 페이지 구현 계획 및 설계 스펙 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->