### PR TITLE
docs(comparison): react-calendar, react-native-calendars + popularity table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ scheduled_tasks.lock
 .tmp-*/
 
 # scripts/verify-entry-split.mjs output
-.tmp/
+.tmp/.superpowers/

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-15.01KB-brightgreen)](https://kalyx-docs-site.vercel.app/ko/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.63KB-brightgreen)](https://kalyx-docs-site.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -43,11 +43,13 @@ import { DatePicker } from '@kalyx/react';
 
 `onChange`는 항상 `ISODateString | null` — UTC 안전, `Date` 객체 없음.
 
-## 왜 Kalyx인가
+## Kalyx를 쓰는 이유
 
-2026년 React 생태계는 양극단입니다 — **react-day-picker**는 캘린더 그리드만, **react-datepicker**는 통합됐지만 40–60 KB · CSS 결합, **Ark UI**는 TimePicker를 제거, **React Aria**는 `@internationalized/date` 강제. Kalyx는 그 사이를 채웁니다 — Headless + 통합 + date-fns 호환 + SSR 안전.
+2026년 React 데이트 피커 시장은 둘 중 하나를 강요한다: 통합됐지만 무거운 것(react-datepicker ~62 KB, MUI ~45 KB), 또는 가볍지만 부분적인 것(react-day-picker · react-aria · ark-ui — calendar grid만). react-calendar는 단일 날짜·범위는 다루지만 time·RSC·timezone 저장이 빠지고, react-native-calendars는 모바일 우선이다.
 
-상세 비교표 → [docs-site](https://kalyx-docs-site.vercel.app/ko/docs/intro#%EB%B9%84%EA%B5%90).
+Kalyx는 **7개 프리미티브** — 단일 날짜, 범위, 시간, 날짜+시간, 월, 연, 주 — 를 하나의 composition API로 묶는다. Headless, ~15 KB gzip, SSR 안전, ISO 문자열 입출력, date-fns/dayjs/luxon용 adapter 패턴.
+
+[전체 비교 표 →](https://kalyx-docs-site.vercel.app/ko/docs/comparison)
 
 ## 특징
 
@@ -90,7 +92,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` v1.0.0-rc.8 → **15.01 KB** gzip (ESM) / **15.16 KB** (CJS). CI 한계 ≤ 16 KB.
+`@kalyx/react` v1.0.0 → **15.63 KB** gzip (ESM) / **15.76 KB** (CJS). CI 한계 ≤ 16 KB.
 
 ## 지원 환경
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
 [![RC](https://img.shields.io/npm/v/@kalyx/react/rc?color=f59e0b&label=RC)](https://www.npmjs.com/package/@kalyx/react?activeTab=versions)
-[![Bundle](https://img.shields.io/badge/gzip-15.01KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.63KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -45,9 +45,11 @@ import { DatePicker } from '@kalyx/react';
 
 ## Why Kalyx
 
-The 2026 React date-picker landscape forces a tradeoff: **react-day-picker** ships only a calendar grid; **react-datepicker** is integrated but 40–60 KB and CSS-coupled; **Ark UI** dropped TimePicker; **React Aria** locks you into `@internationalized/date`. Kalyx fills the gap — headless + integrated + date-fns compatible + SSR-safe.
+In 2026, the React date-picker landscape forces a trade-off: integrated-but-heavy (react-datepicker ~62 KB, MUI ~45 KB) or headless-but-partial (react-day-picker, react-aria, ark-ui — calendar grid only). react-calendar covers single dates and ranges but stops short of time, RSC, and timezone-aware storage. react-native-calendars is mobile-first.
 
-Detailed comparison table → [docs-site](https://kalyx-docs-site.vercel.app/docs/intro#comparison).
+Kalyx ships **seven primitives** — single date, range, time, date+time, month, year, week — under one composition API. Headless, ~15 KB gzip, SSR-safe, ISO strings in / ISO strings out, adapter pattern for date-fns / dayjs / luxon.
+
+[See the full comparison →](https://kalyx-docs-site.vercel.app/docs/comparison)
 
 ## Features
 
@@ -90,7 +92,7 @@ API reference, recipes (Tailwind / shadcn / React Hook Form), and migration guid
 
 ## Bundle
 
-`@kalyx/react` v1.0.0-rc.8 → **15.01 KB** gzip (ESM) / **15.16 KB** (CJS). CI gate: ≤ 16 KB.
+`@kalyx/react` v1.0.0 → **15.63 KB** gzip (ESM) / **15.76 KB** (CJS). CI gate: ≤ 16 KB.
 
 ## Browser support
 

--- a/apps/docs-site/docs/comparison.md
+++ b/apps/docs-site/docs/comparison.md
@@ -1,6 +1,6 @@
 ---
 title: How Kalyx compares
-description: How Kalyx stacks up against react-datepicker, react-day-picker, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates.
+description: How Kalyx stacks up against react-datepicker, react-day-picker, react-calendar, react-native-calendars, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates.
 slug: /comparison
 ---
 
@@ -13,28 +13,44 @@ cost, CSS lock-in vs missing primitives. Kalyx is built to occupy the middle:
 seven complete primitives, one composition API, no required stylesheet,
 ≤16 KB gzipped.
 
+## Popularity at a glance
+
+Stars and weekly downloads move quickly — treat these as a snapshot, not a leaderboard.
+
+| Library | GitHub stars | npm weekly downloads |
+| --- | :---: | :---: |
+| react-datepicker | 8.4k | 4,600,048 |
+| react-day-picker | 6.8k | 39,161,992 |
+| react-calendar | 3.8k | 1,132,734 |
+| react-native-calendars | 10.3k | 541,161 |
+| react-aria | 15.5k | 5,934,915 |
+| ark-ui | 5.2k | 815,578 |
+| @mui/x-date-pickers | 5.7k | 4,779,445 |
+| @mantine/dates | 31.2k | 955,080 |
+| **Kalyx** | 4 | 618 |
+
 ## Feature matrix
 
 <div style={{overflowX: 'auto'}}>
 
-| Feature | react-datepicker | react-day-picker | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
-| RangePicker               | ✓ | partial[^1] | ✓ | partial[^1] | ✓ | ✓ | **✓** |
-| TimePicker                | partial[^2] | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
-| DateTimePicker            | partial[^2] | ✗ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
-| MonthPicker               | ✓ | ✗ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
-| YearPicker                | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | **✓** |
-| WeekPicker                | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | **✓** |
-| Timezone-aware (IANA)     | partial[^4] | ✗ | ✓ | ✗ | ✓ | partial[^4] | **✓** |
-| Zero CSS (no required import) | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | **✓** |
-| SSR-safe (App Router)     | partial[^5] | ✓ | ✓ | ✓ | partial[^5] | ✓ | **✓** |
-| RSC-friendly              | ✗ | ✓ | partial[^6] | ✓ | ✗ | partial[^6] | **✓** |
-| a11y verified (axe + WAI-ARIA) | partial[^7] | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
-| ISO string API (UTC in/out) | ✗ | partial[^8] | ✗ | ✗ | ✗ | ✗ | **✓** |
-| Adapter pattern (date-fns/dayjs/luxon) | ✗ | ✗ | partial[^9] | ✗ | ✓ | ✗ | **partial[^10]** |
-| Bundle gzip (KB)          | ~62 | ~22 | ~28 | ~20 | ~45 | ~30 | **~15** |
-| License                   | MIT | MIT | Apache-2.0 | MIT | MIT | MIT | **MIT** |
+| Feature | react-datepicker | react-day-picker | react-calendar | react-native-calendars | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| RangePicker               | ✓ | partial[^1] | ✓ | ✓ | ✓ | partial[^1] | ✓ | ✓ | **✓** |
+| TimePicker                | partial[^2] | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
+| DateTimePicker            | partial[^2] | ✗ | ✗ | ✗ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
+| MonthPicker               | ✓ | ✗ | partial[^11] | ✓ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
+| YearPicker                | ✓ | ✗ | partial[^11] | partial[^11] | ✗ | ✗ | ✓ | ✓ | **✓** |
+| WeekPicker                | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Timezone-aware (IANA)     | partial[^4] | ✗ | ✗ | partial[^4] | ✓ | ✗ | ✓ | partial[^4] | **✓** |
+| Zero CSS (no required import) | ✗ | ✓ | ✗ | partial[^12] | ✓ | ✓ | ✗ | ✗ | **✓** |
+| SSR-safe (App Router)     | partial[^5] | ✓ | ✓ | partial[^13] | ✓ | ✓ | partial[^5] | ✓ | **✓** |
+| RSC-friendly              | ✗ | ✓ | partial[^6] | ✗ | partial[^6] | ✓ | ✗ | partial[^6] | **✓** |
+| a11y verified (axe + WAI-ARIA) | partial[^7] | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| ISO string API (UTC in/out) | ✗ | partial[^8] | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Adapter pattern (date-fns/dayjs/luxon) | ✗ | ✗ | ✗ | ✗ | partial[^9] | ✗ | ✓ | ✗ | **partial[^10]** |
+| Bundle gzip (KB)          | ~62 | ~22 | ~17 | ~85 (RN) | ~28 | ~20 | ~45 | ~30 | **~15** |
+| License                   | MIT | MIT | MIT | MIT | Apache-2.0 | MIT | MIT | MIT | **MIT** |
 
 </div>
 
@@ -48,6 +64,9 @@ seven complete primitives, one composition API, no required stylesheet,
 [^8]: Returns native `Date`; ISO conversion is the consumer's responsibility.
 [^9]: Pinned to `@internationalized/date`; date-fns / dayjs interop must round-trip via that type.
 [^10]: Default adapter is `@kalyx/adapter-date-fns`; alternate adapters (`-dayjs`, `-luxon`, `-temporal`) ship across v1.1+.
+[^11]: Surfaces a `view` or `defaultView` prop for month/year drill-down; not exported as a dedicated standalone component.
+[^12]: Inline styles by default; theme can be customized but there is no CSS-free escape hatch comparable to Kalyx.
+[^13]: React Native first; the web shim runs in browsers but the package isn't designed for Next.js App Router server boundaries.
 
 > _Last measured 2026-06-11. Methodology: bundle sizes via bundlephobia + each
 > library's published `size-limit`; feature presence verified against each
@@ -55,7 +74,7 @@ seven complete primitives, one composition API, no required stylesheet,
 
 ## Bundle size at a glance
 
-<svg role="img" aria-label="Bundle size comparison in KB gzip — Kalyx is the smallest at 15 KB" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" style={{width: '100%', maxWidth: 640, height: 'auto'}}>
+<svg role="img" aria-label="Bundle size comparison in KB gzip — Kalyx is among the smallest, alongside react-calendar and ark-ui" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" style={{width: '100%', maxWidth: 640, height: 'auto'}}>
   <style>{`
     .lbl { font: 13px var(--ifm-font-family-base, sans-serif); fill: var(--ifm-font-color-base, #1f1f1f); }
     .val { font: 12px var(--ifm-font-family-monospace, monospace); fill: var(--ifm-color-emphasis-700, #555); }
@@ -63,37 +82,43 @@ seven complete primitives, one composition API, no required stylesheet,
     .barKalyx { fill: var(--ifm-color-primary, #6366f1); }
     .axis { stroke: var(--ifm-color-emphasis-300, #d0d0d0); stroke-width: 1; }
   `}</style>
-  {/* y axis labels (left side, 180px wide) — each row is 32px tall, starting y=18 */}
-  <text x="0" y="22" className="lbl">react-datepicker</text>
-  <text x="0" y="54" className="lbl">@mui/x-date-pickers</text>
-  <text x="0" y="86" className="lbl">@mantine/dates</text>
-  <text x="0" y="118" className="lbl">react-aria</text>
-  <text x="0" y="150" className="lbl">react-day-picker</text>
-  <text x="0" y="182" className="lbl">ark-ui</text>
-  <text x="0" y="214" className="lbl" style={{fontWeight: 700}}>Kalyx</text>
+  {/* y axis labels (left side, 180px wide) — each row is 32px tall, starting y=22 */}
+  <text x="0" y="22" className="lbl">react-native-calendars</text>
+  <text x="0" y="54" className="lbl">react-datepicker</text>
+  <text x="0" y="86" className="lbl">@mui/x-date-pickers</text>
+  <text x="0" y="118" className="lbl">@mantine/dates</text>
+  <text x="0" y="150" className="lbl">react-aria</text>
+  <text x="0" y="182" className="lbl">react-day-picker</text>
+  <text x="0" y="214" className="lbl">ark-ui</text>
+  <text x="0" y="246" className="lbl">react-calendar</text>
+  <text x="0" y="278" className="lbl" style={{fontWeight: 700}}>Kalyx</text>
 
-  {/* bars: x starts at 180, scale = 6.5px per KB (62 KB → 403px, fits in 410px max) */}
-  <rect className="bar" x="180" y="10" width="403" height="16" rx="3" />
-  <rect className="bar" x="180" y="42" width="293" height="16" rx="3" />
-  <rect className="bar" x="180" y="74" width="195" height="16" rx="3" />
-  <rect className="bar" x="180" y="106" width="182" height="16" rx="3" />
-  <rect className="bar" x="180" y="138" width="143" height="16" rx="3" />
-  <rect className="bar" x="180" y="170" width="130" height="16" rx="3" />
-  <rect className="barKalyx" x="180" y="202" width="98" height="16" rx="3" />
+  {/* bars: x starts at 180, scale = (kb/90)*410 px per KB (85 KB → 387px, fits in 410px max) */}
+  <rect className="bar" x="180" y="10" width="387" height="16" rx="3" />
+  <rect className="bar" x="180" y="42" width="282" height="16" rx="3" />
+  <rect className="bar" x="180" y="74" width="205" height="16" rx="3" />
+  <rect className="bar" x="180" y="106" width="137" height="16" rx="3" />
+  <rect className="bar" x="180" y="138" width="128" height="16" rx="3" />
+  <rect className="bar" x="180" y="170" width="100" height="16" rx="3" />
+  <rect className="bar" x="180" y="202" width="91" height="16" rx="3" />
+  <rect className="bar" x="180" y="234" width="77" height="16" rx="3" />
+  <rect className="barKalyx" x="180" y="266" width="68" height="16" rx="3" />
 
   {/* value labels on the right of each bar */}
-  <text x="590" y="22" className="val" textAnchor="end">62 KB</text>
-  <text x="480" y="54" className="val" textAnchor="end">45 KB</text>
-  <text x="382" y="86" className="val" textAnchor="end">30 KB</text>
-  <text x="369" y="118" className="val" textAnchor="end">28 KB</text>
-  <text x="330" y="150" className="val" textAnchor="end">22 KB</text>
-  <text x="317" y="182" className="val" textAnchor="end">20 KB</text>
-  <text x="285" y="214" className="val" textAnchor="end" style={{fontWeight: 700, fill: 'var(--ifm-color-primary, #6366f1)'}}>15 KB</text>
+  <text x="574" y="22" className="val" textAnchor="end">~85 KB (RN)</text>
+  <text x="469" y="54" className="val" textAnchor="end">62 KB</text>
+  <text x="392" y="86" className="val" textAnchor="end">45 KB</text>
+  <text x="324" y="118" className="val" textAnchor="end">30 KB</text>
+  <text x="315" y="150" className="val" textAnchor="end">28 KB</text>
+  <text x="287" y="182" className="val" textAnchor="end">22 KB</text>
+  <text x="278" y="214" className="val" textAnchor="end">20 KB</text>
+  <text x="264" y="246" className="val" textAnchor="end">~17 KB</text>
+  <text x="255" y="278" className="val" textAnchor="end" style={{fontWeight: 700, fill: 'var(--ifm-color-primary, #6366f1)'}}>15 KB</text>
 
   {/* baseline */}
-  <line className="axis" x1="180" y1="232" x2="600" y2="232" />
-  <text x="180" y="250" className="val">0</text>
-  <text x="600" y="250" className="val" textAnchor="end">64 KB</text>
+  <line className="axis" x1="180" y1="312" x2="600" y2="312" />
+  <text x="180" y="330" className="val">0</text>
+  <text x="600" y="330" className="val" textAnchor="end">~90 KB</text>
 </svg>
 
 ## When NOT to use Kalyx

--- a/apps/docs-site/docs/comparison.md
+++ b/apps/docs-site/docs/comparison.md
@@ -16,11 +16,12 @@ seven complete primitives, one composition API, no required stylesheet,
 ## Popularity at a glance
 
 Stars and weekly downloads move quickly — treat these as a snapshot, not a leaderboard.
+For libraries that live in a monorepo (react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates), star counts reflect the parent repo, not the sub-package.
 
 | Library | GitHub stars | npm weekly downloads |
 | --- | :---: | :---: |
 | react-datepicker | 8.4k | 4,600,048 |
-| react-day-picker | 6.8k | 39,161,992 |
+| react-day-picker | 6.8k | 39,161,992[^14] |
 | react-calendar | 3.8k | 1,132,734 |
 | react-native-calendars | 10.3k | 541,161 |
 | react-aria | 15.5k | 5,934,915 |
@@ -67,6 +68,7 @@ Stars and weekly downloads move quickly — treat these as a snapshot, not a lea
 [^11]: Surfaces a `view` or `defaultView` prop for month/year drill-down; not exported as a dedicated standalone component.
 [^12]: Inline styles by default; theme can be customized but there is no CSS-free escape hatch comparable to Kalyx.
 [^13]: React Native first; the web shim runs in browsers but the package isn't designed for Next.js App Router server boundaries.
+[^14]: shadcn/ui's `Calendar` component depends on react-day-picker; the count includes downstream adoption via shadcn rather than direct use only.
 
 > _Last measured 2026-06-11. Methodology: bundle sizes via bundlephobia + each
 > library's published `size-limit`; feature presence verified against each

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md
@@ -1,6 +1,6 @@
 ---
 title: Kalyx 비교
-description: react-datepicker, react-day-picker, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates와 Kalyx를 비교합니다.
+description: react-datepicker, react-day-picker, react-calendar, react-native-calendars, react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates와 Kalyx를 비교합니다.
 slug: /comparison
 ---
 
@@ -13,28 +13,45 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
 중간을 차지하도록 설계됐습니다 — 7개의 완전한 프리미티브, 하나의 조합 API,
 강제 스타일시트 없음, 16 KB gzip 이하.
 
+## 인기도 한눈에
+
+별 수와 주간 다운로드는 빠르게 움직인다 — 리더보드가 아니라 스냅샷으로 받아들이면 된다.
+모노레포에서 호스팅되는 라이브러리(react-aria, ark-ui, @mui/x-date-pickers, @mantine/dates)는 부모 저장소의 스타 수다 — 서브 패키지 단위가 아니다.
+
+| 라이브러리 | GitHub 스타 | npm 주간 다운로드 |
+| --- | :---: | :---: |
+| react-datepicker | 8.4k | 4,600,048 |
+| react-day-picker | 6.8k | 39,161,992[^14] |
+| react-calendar | 3.8k | 1,132,734 |
+| react-native-calendars | 10.3k | 541,161 |
+| react-aria | 15.5k | 5,934,915 |
+| ark-ui | 5.2k | 815,578 |
+| @mui/x-date-pickers | 5.7k | 4,779,445 |
+| @mantine/dates | 31.2k | 955,080 |
+| **Kalyx** | 4 | 618 |
+
 ## 기능 매트릭스
 
 <div style={{overflowX: 'auto'}}>
 
-| 기능 | react-datepicker | react-day-picker | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
-| RangePicker               | ✓ | 부분[^1] | ✓ | 부분[^1] | ✓ | ✓ | **✓** |
-| TimePicker                | 부분[^2] | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
-| DateTimePicker            | 부분[^2] | ✗ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
-| MonthPicker               | ✓ | ✗ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
-| YearPicker                | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | **✓** |
-| WeekPicker                | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | **✓** |
-| Timezone (IANA)           | 부분[^4] | ✗ | ✓ | ✗ | ✓ | 부분[^4] | **✓** |
-| Zero CSS (강제 import 없음) | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | **✓** |
-| SSR 안전 (App Router)     | 부분[^5] | ✓ | ✓ | ✓ | 부분[^5] | ✓ | **✓** |
-| RSC 친화                  | ✗ | ✓ | 부분[^6] | ✓ | ✗ | 부분[^6] | **✓** |
-| 접근성 검증 (axe + WAI-ARIA) | 부분[^7] | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
-| ISO string API (UTC in/out) | ✗ | 부분[^8] | ✗ | ✗ | ✗ | ✗ | **✓** |
-| Adapter 패턴 (date-fns/dayjs/luxon) | ✗ | ✗ | 부분[^9] | ✗ | ✓ | ✗ | **부분[^10]** |
-| 번들 gzip (KB)            | ~62 | ~22 | ~28 | ~20 | ~45 | ~30 | **~15** |
-| 라이선스                  | MIT | MIT | Apache-2.0 | MIT | MIT | MIT | **MIT** |
+| 기능 | react-datepicker | react-day-picker | react-calendar | react-native-calendars | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| RangePicker               | ✓ | 부분[^1] | ✓ | ✓ | ✓ | 부분[^1] | ✓ | ✓ | **✓** |
+| TimePicker                | 부분[^2] | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
+| DateTimePicker            | 부분[^2] | ✗ | ✗ | ✗ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
+| MonthPicker               | ✓ | ✗ | 부분[^11] | ✓ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
+| YearPicker                | ✓ | ✗ | 부분[^11] | 부분[^11] | ✗ | ✗ | ✓ | ✓ | **✓** |
+| WeekPicker                | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Timezone (IANA)           | 부분[^4] | ✗ | ✗ | 부분[^4] | ✓ | ✗ | ✓ | 부분[^4] | **✓** |
+| Zero CSS (강제 import 없음) | ✗ | ✓ | ✗ | 부분[^12] | ✓ | ✓ | ✗ | ✗ | **✓** |
+| SSR 안전 (App Router)     | 부분[^5] | ✓ | ✓ | 부분[^13] | ✓ | ✓ | 부분[^5] | ✓ | **✓** |
+| RSC 친화                  | ✗ | ✓ | 부분[^6] | ✗ | 부분[^6] | ✓ | ✗ | 부분[^6] | **✓** |
+| 접근성 검증 (axe + WAI-ARIA) | 부분[^7] | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
+| ISO string API (UTC in/out) | ✗ | 부분[^8] | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | **✓** |
+| Adapter 패턴 (date-fns/dayjs/luxon) | ✗ | ✗ | ✗ | ✗ | 부분[^9] | ✗ | ✓ | ✗ | **부분[^10]** |
+| 번들 gzip (KB)            | ~62 | ~22 | ~17 | ~85 (RN) | ~28 | ~20 | ~45 | ~30 | **~15** |
+| 라이선스                  | MIT | MIT | MIT | MIT | Apache-2.0 | MIT | MIT | MIT | **MIT** |
 
 </div>
 
@@ -48,13 +65,17 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
 [^8]: native `Date`를 반환하며 ISO 변환은 소비자의 책임입니다.
 [^9]: `@internationalized/date`로 고정되어 date-fns / dayjs 상호운용은 해당 타입을 통해 round-trip 해야 합니다.
 [^10]: 기본 adapter는 `@kalyx/adapter-date-fns`이며 대체 adapter (`-dayjs`, `-luxon`, `-temporal`)는 v1.1+에서 출시됩니다.
+[^11]: 월/연 드릴다운용 `view` 또는 `defaultView` prop은 제공하지만, 독립 컴포넌트로 export되지 않는다.
+[^12]: 기본은 인라인 스타일이고, 테마 커스터마이징은 가능하지만 Kalyx 수준의 CSS-free 옵트아웃은 없다.
+[^13]: React Native 우선. 웹 shim으로 브라우저에서 동작하긴 하지만 Next.js App Router의 server boundary용으로 설계되지 않았다.
+[^14]: shadcn/ui의 `Calendar` 컴포넌트가 react-day-picker를 dependency로 쓴다 — 직접 사용자보다 다운스트림 채택분이 큰 비중.
 
 > _2026-06-11 기준 측정. 방법론: 번들 크기는 bundlephobia + 각 라이브러리의 공식
 > `size-limit`으로 측정, 기능 유무는 각 라이브러리의 v-latest 문서로 검증._
 
 ## 한 눈에 보는 번들 크기
 
-<svg role="img" aria-label="번들 크기 비교 (KB gzip) — Kalyx가 15 KB로 가장 작음" viewBox="0 0 640 280" xmlns="http://www.w3.org/2000/svg" style={{width: '100%', maxWidth: 640, height: 'auto'}}>
+<svg role="img" aria-label="번들 크기 비교 (KB gzip) — Kalyx는 react-calendar, ark-ui와 함께 가장 작은 축이다" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg" style={{width: '100%', maxWidth: 640, height: 'auto'}}>
   <style>{`
     .lbl { font: 13px var(--ifm-font-family-base, sans-serif); fill: var(--ifm-font-color-base, #1f1f1f); }
     .val { font: 12px var(--ifm-font-family-monospace, monospace); fill: var(--ifm-color-emphasis-700, #555); }
@@ -62,33 +83,43 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
     .barKalyx { fill: var(--ifm-color-primary, #6366f1); }
     .axis { stroke: var(--ifm-color-emphasis-300, #d0d0d0); stroke-width: 1; }
   `}</style>
-  <text x="0" y="22" className="lbl">react-datepicker</text>
-  <text x="0" y="54" className="lbl">@mui/x-date-pickers</text>
-  <text x="0" y="86" className="lbl">@mantine/dates</text>
-  <text x="0" y="118" className="lbl">react-aria</text>
-  <text x="0" y="150" className="lbl">react-day-picker</text>
-  <text x="0" y="182" className="lbl">ark-ui</text>
-  <text x="0" y="214" className="lbl" style={{fontWeight: 700}}>Kalyx</text>
+  {/* y axis labels (left side, 180px wide) — each row is 32px tall, starting y=22 */}
+  <text x="0" y="22" className="lbl">react-native-calendars</text>
+  <text x="0" y="54" className="lbl">react-datepicker</text>
+  <text x="0" y="86" className="lbl">@mui/x-date-pickers</text>
+  <text x="0" y="118" className="lbl">@mantine/dates</text>
+  <text x="0" y="150" className="lbl">react-aria</text>
+  <text x="0" y="182" className="lbl">react-day-picker</text>
+  <text x="0" y="214" className="lbl">ark-ui</text>
+  <text x="0" y="246" className="lbl">react-calendar</text>
+  <text x="0" y="278" className="lbl" style={{fontWeight: 700}}>Kalyx</text>
 
-  <rect className="bar" x="180" y="10" width="403" height="16" rx="3" />
-  <rect className="bar" x="180" y="42" width="293" height="16" rx="3" />
-  <rect className="bar" x="180" y="74" width="195" height="16" rx="3" />
-  <rect className="bar" x="180" y="106" width="182" height="16" rx="3" />
-  <rect className="bar" x="180" y="138" width="143" height="16" rx="3" />
-  <rect className="bar" x="180" y="170" width="130" height="16" rx="3" />
-  <rect className="barKalyx" x="180" y="202" width="98" height="16" rx="3" />
+  {/* bars: x starts at 180, scale = (kb/90)*410 px per KB (85 KB → 387px, fits in 410px max) */}
+  <rect className="bar" x="180" y="10" width="387" height="16" rx="3" />
+  <rect className="bar" x="180" y="42" width="282" height="16" rx="3" />
+  <rect className="bar" x="180" y="74" width="205" height="16" rx="3" />
+  <rect className="bar" x="180" y="106" width="137" height="16" rx="3" />
+  <rect className="bar" x="180" y="138" width="128" height="16" rx="3" />
+  <rect className="bar" x="180" y="170" width="100" height="16" rx="3" />
+  <rect className="bar" x="180" y="202" width="91" height="16" rx="3" />
+  <rect className="bar" x="180" y="234" width="77" height="16" rx="3" />
+  <rect className="barKalyx" x="180" y="266" width="68" height="16" rx="3" />
 
-  <text x="590" y="22" className="val" textAnchor="end">62 KB</text>
-  <text x="480" y="54" className="val" textAnchor="end">45 KB</text>
-  <text x="382" y="86" className="val" textAnchor="end">30 KB</text>
-  <text x="369" y="118" className="val" textAnchor="end">28 KB</text>
-  <text x="330" y="150" className="val" textAnchor="end">22 KB</text>
-  <text x="317" y="182" className="val" textAnchor="end">20 KB</text>
-  <text x="285" y="214" className="val" textAnchor="end" style={{fontWeight: 700, fill: 'var(--ifm-color-primary, #6366f1)'}}>15 KB</text>
+  {/* value labels on the right of each bar */}
+  <text x="574" y="22" className="val" textAnchor="end">~85 KB (RN)</text>
+  <text x="469" y="54" className="val" textAnchor="end">62 KB</text>
+  <text x="392" y="86" className="val" textAnchor="end">45 KB</text>
+  <text x="324" y="118" className="val" textAnchor="end">30 KB</text>
+  <text x="315" y="150" className="val" textAnchor="end">28 KB</text>
+  <text x="287" y="182" className="val" textAnchor="end">22 KB</text>
+  <text x="278" y="214" className="val" textAnchor="end">20 KB</text>
+  <text x="264" y="246" className="val" textAnchor="end">~17 KB</text>
+  <text x="255" y="278" className="val" textAnchor="end" style={{fontWeight: 700, fill: 'var(--ifm-color-primary, #6366f1)'}}>15 KB</text>
 
-  <line className="axis" x1="180" y1="232" x2="600" y2="232" />
-  <text x="180" y="250" className="val">0</text>
-  <text x="600" y="250" className="val" textAnchor="end">64 KB</text>
+  {/* baseline */}
+  <line className="axis" x1="180" y1="312" x2="600" y2="312" />
+  <text x="180" y="330" className="val">0</text>
+  <text x="600" y="330" className="val" textAnchor="end">~90 KB</text>
 </svg>
 
 ## Kalyx를 쓰지 않아야 할 때

--- a/docs/superpowers/plans/2026-06-11-aurora-visual-overhaul.md
+++ b/docs/superpowers/plans/2026-06-11-aurora-visual-overhaul.md
@@ -1,0 +1,1793 @@
+# Aurora Visual Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify every docs-site surface that renders a Kalyx picker around the Aurora visual system (v7 from brainstorming), regenerate hero images, refresh competitive comparison.
+
+**Architecture:** Single-source `.kx-live-*` token system in `custom.css` drives every surface (HeroDemo, Playground, PickerGrid, every live doc example). HeroDemo's bespoke `:global([role='grid'])` block is deleted and replaced with the same classNames every other example uses. Library code in `packages/core` and `packages/react` is not touched — the zero-CSS public API is preserved.
+
+**Tech Stack:** Docusaurus 3, React 19, CSS modules + global custom.css, Playwright (e2e + recorder), pnpm workspaces.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-aurora-visual-overhaul-design.md` — read sections 4 (token values) and 5 (component mapping) before starting.
+
+**Branching strategy:** PR-1 is the foundation; PR-2 and PR-3 depend on PR-1's tokens; PR-4 is content-only and independent. Recommended worktree layout (per the project's parallel-PR convention):
+
+```
+feat/aurora-tokens         ← PR-1 (must land first)
+  └ feat/aurora-hero       ← PR-2 (after PR-1)
+  └ feat/aurora-playground ← PR-3 (after PR-1, parallel with PR-2)
+docs/aurora-comparison      ← PR-4 (independent, parallel from start)
+```
+
+---
+
+## File Structure
+
+### PR-1 — Aurora tokens & live-example styles
+- **Modify:** `apps/docs-site/src/css/custom.css` — token block (lines 219–237), all `.kx-live-*` classes (lines 239–656), add global Infima `[role='grid']` reset.
+
+### PR-2 — HeroDemo refactor + hero images
+- **Modify:** `apps/docs-site/src/components/HeroDemo/HeroDemo.module.css` — delete `:global([role='grid'])` block, add a single `.timeRow` class.
+- **Modify:** `apps/docs-site/src/components/HeroDemo/index.tsx` — pass `classNames` to every picker sub-component; remove inline `style` objects.
+- **Modify:** `apps/docs-site/src/components/HeroDemo/__tests__/HeroDemo.test.tsx` — update any structural assertions if needed.
+- **Regenerate:** `img/hero-light.webp`, `img/hero-dark.webp` via existing `scripts/record-hero.mjs` (Playwright).
+
+### PR-3 — Playground + PickerGrid polish
+- **Modify:** `apps/docs-site/src/components/Playground/PreviewPanel.tsx` — remove inline `style={{ display: 'flex', gap: 8 }}` from TimePicker and DateTimePicker previews; replace with `.kx-live-row` class.
+- **Modify:** `apps/docs-site/src/components/Playground/Playground.module.css` — `.preview` border + background to Aurora tokens.
+- **Modify:** `apps/docs-site/src/components/PickerGrid/PickerGrid.module.css` — `.card` border, background, hover to Aurora tokens.
+
+### PR-4 — Comparison & README
+- **Modify:** `apps/docs-site/docs/comparison.md` — add `react-calendar`, `react-native-calendars` rows; add GitHub stars + npm weekly columns; update SVG bar chart; refresh measurement date.
+- **Modify:** `README.md`, `README.ko.md`, `packages/react/README.md`, `packages/core/README.md` — "Why Kalyx" section tightened, comparison link confirmed.
+
+---
+
+## PR-1 — Aurora tokens + .kx-live-* polish
+
+### Task 1: Replace token block in custom.css
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` (token block around lines 219–237)
+
+- [ ] **Step 1.1: Locate the existing `--kx-ex-*` token block**
+
+Open `apps/docs-site/src/css/custom.css`. Find the comment `/* Live example theme ... */` followed by `:root { --kx-ex-bg: ...; }`. This block also has a `[data-theme='dark'] { --kx-ex-primary-weak: ...; }` override.
+
+- [ ] **Step 1.2: Replace the token block with Aurora tokens**
+
+Use Edit to replace the entire `:root { --kx-ex-* }` + `[data-theme='dark'] { --kx-ex-* }` block with:
+
+```css
+:root {
+  /* Aurora — light */
+  --kx-bg:            #ffffff;
+  --kx-bg-quiet:      #fafafa;
+  --kx-fg:            #18181b;
+  --kx-fg-muted:      #71717a;
+  --kx-fg-subtle:     #a1a1aa;
+  --kx-border:        rgba(91, 79, 225, 0.10);
+  --kx-primary:       #5b4fe1;
+  --kx-primary-fg:    #ffffff;
+  --kx-primary-weak:  rgba(91, 79, 225, 0.12);
+  --kx-primary-hover: rgba(91, 79, 225, 0.06);
+  --kx-glow:          0 3px 12px rgba(91, 79, 225, 0.32);
+  --kx-shadow-card:   0 8px 24px rgba(91, 79, 225, 0.06), 0 1px 2px rgba(0,0,0,0.04);
+  --kx-radius-cell:   8px;
+  --kx-radius-card:   14px;
+  --kx-radius-input:  8px;
+  --kx-cell:          32px;
+
+  /* Back-compat aliases — keep until any third-party docs page referencing
+   * the old names is updated. Safe to delete in a follow-up PR. */
+  --kx-ex-bg:            var(--kx-bg);
+  --kx-ex-border:        var(--kx-border);
+  --kx-ex-muted:         var(--kx-fg-muted);
+  --kx-ex-primary:       var(--kx-primary);
+  --kx-ex-primary-weak:  var(--kx-primary-weak);
+  --kx-ex-primary-hover: var(--kx-primary-hover);
+  --kx-ex-ring:          rgba(91, 79, 225, 0.22);
+  --kx-ex-shadow:        var(--kx-shadow-card);
+  --kx-ex-cell:          var(--kx-cell);
+}
+
+[data-theme='dark'] {
+  --kx-bg:            #111117;
+  --kx-bg-quiet:      #0a0a0f;
+  --kx-fg:            #f4f4f5;
+  --kx-fg-muted:      #a1a1aa;
+  --kx-fg-subtle:     #71717a;
+  --kx-border:        rgba(255, 255, 255, 0.08);
+  --kx-primary:       #8b80ff;
+  --kx-primary-fg:    #0a0a0f;
+  --kx-primary-weak:  rgba(139, 128, 255, 0.18);
+  --kx-primary-hover: rgba(139, 128, 255, 0.12);
+  --kx-glow:          0 3px 12px rgba(139, 128, 255, 0.32);
+  --kx-shadow-card:   0 12px 30px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.02);
+
+  --kx-ex-primary-weak:  var(--kx-primary-weak);
+  --kx-ex-primary-hover: var(--kx-primary-hover);
+  --kx-ex-ring:          rgba(139, 128, 255, 0.28);
+  --kx-ex-shadow:        var(--kx-shadow-card);
+}
+```
+
+- [ ] **Step 1.3: Verify the file parses**
+
+Run: `pnpm --filter docs-site build`
+Expected: build succeeds (no CSS parse errors). Visual changes will be incomplete at this point — that's expected, more classes update in next tasks.
+
+---
+
+### Task 2: Update calendar grid classes
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` — `.kx-live-popover`, `.kx-live-header`, `.kx-live-title`, `.kx-live-nav`, `.kx-live-grid`, `.kx-live-weekday`, `.kx-live-cell`, `.kx-live-day`, `.kx-live-day-selected`, `.kx-live-day-today`, `.kx-live-outside`, `.kx-live-disabled`
+
+- [ ] **Step 2.1: Update `.kx-live-popover` width**
+
+Find the current `.kx-live-popover` block (contains the `width: 280px` comment about issue #35). Replace with:
+
+```css
+.kx-live-popover {
+  padding: 14px;
+  border: 1px solid var(--kx-border);
+  border-radius: var(--kx-radius-card);
+  background: var(--kx-bg);
+  box-shadow: var(--kx-shadow-card);
+  margin-top: 6px;
+  z-index: 50;
+  /* width: fit-content — hug the 7×var(--kx-cell) calendar grid. Replaces
+   * the hardcoded 280px from issue #35 now that header and grid are the
+   * same width. See spec 2026-06-11 §4.2. */
+  width: fit-content;
+}
+
+.kx-live-popover--split {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+  width: fit-content;
+}
+```
+
+- [ ] **Step 2.2: Update `.kx-live-header` + nav + title**
+
+Replace the existing `.kx-live-header`, `.kx-live-title`, `.kx-live-nav` blocks with:
+
+```css
+.kx-live-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+  gap: 4px;
+}
+
+.kx-live-title {
+  font-weight: 600;
+  font-size: 13.5px;
+  flex: 1;
+  text-align: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 120ms, color 120ms;
+}
+
+.kx-live-title:hover {
+  background: var(--kx-primary-hover);
+  color: var(--kx-primary);
+}
+
+span.kx-live-title,
+.kx-live-title[aria-live]:not(button) {
+  cursor: default;
+}
+
+.kx-live-nav {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--kx-fg-muted);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 120ms, color 120ms;
+}
+
+.kx-live-nav:hover {
+  background: var(--kx-primary-hover);
+  color: var(--kx-primary);
+}
+```
+
+- [ ] **Step 2.3: Update grid + weekday + cell**
+
+Replace `.kx-live-grid`, `.kx-live-weekday`, `.kx-live-cell`, `.kx-live-outside`, `.kx-live-disabled` with:
+
+```css
+.kx-live-grid {
+  display: grid;
+  grid-template-columns: repeat(7, var(--kx-cell));
+  gap: 0;
+  font-size: 13px;
+}
+
+.kx-live-weekday {
+  width: var(--kx-cell);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--kx-fg-subtle);
+  text-align: center;
+  padding: 6px 0 8px;
+  letter-spacing: 0.04em;
+}
+
+.kx-live-cell {
+  padding: 0;
+  text-align: center;
+  vertical-align: middle;
+  height: var(--kx-cell);
+}
+
+.kx-live-outside {
+  color: var(--kx-fg-subtle);
+  opacity: 0.5;
+}
+
+.kx-live-disabled {
+  opacity: 0.3;
+  pointer-events: none;
+  text-decoration: line-through;
+}
+```
+
+- [ ] **Step 2.4: Update `.kx-live-day` + selected + today**
+
+Replace single-date day classes with:
+
+```css
+.kx-live-day {
+  width: var(--kx-cell);
+  height: var(--kx-cell);
+  padding: 0;
+  border: 0;
+  border-radius: var(--kx-radius-cell);
+  background: transparent;
+  color: inherit;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: background 120ms;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.kx-live-day:hover:not(:disabled):not(.kx-live-day-selected) {
+  background: var(--kx-primary-hover);
+}
+
+.kx-live-day-selected {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  font-weight: 600;
+  box-shadow: var(--kx-glow);
+}
+
+.kx-live-day-today {
+  box-shadow: inset 0 0 0 1.5px var(--kx-primary);
+  color: var(--kx-primary);
+  font-weight: 600;
+}
+
+.kx-live-day-today.kx-live-day-selected {
+  /* selected wins; glow replaces the ring */
+  box-shadow: var(--kx-glow);
+  color: var(--kx-primary-fg);
+}
+```
+
+- [ ] **Step 2.5: Verify the file still parses**
+
+Run: `pnpm --filter docs-site build`
+Expected: build succeeds. Calendar in component docs (e.g., `/docs/components/datepicker`) should now show clean 32×32 cells with no grid hairlines.
+
+---
+
+### Task 3: Update range visualization
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` — `.kx-live-day-range`, `.kx-live-inrange`, `.kx-live-range-start`, `.kx-live-range-end`
+
+- [ ] **Step 3.1: Replace range classes**
+
+Find the existing range block (starts with comment "Range visual"). Replace with:
+
+```css
+.kx-live-day-range {
+  width: var(--kx-cell);
+  height: var(--kx-cell);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: background 120ms;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--kx-radius-cell);
+}
+
+.kx-live-day-range:hover:not(:disabled):not(.kx-live-range-start):not(.kx-live-range-end):not(.kx-live-inrange) {
+  background: var(--kx-primary-hover);
+}
+
+/* In-range middle cells — fully rounded with primary-weak background.
+ * Reads as a row of soft pills inside the band, per v7 spec. */
+.kx-live-inrange {
+  background: var(--kx-primary-weak) !important;
+  border-radius: var(--kx-radius-cell) !important;
+}
+
+/* Start cell — left side rounded, right side flat (anchors to band). */
+.kx-live-range-start {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  font-weight: 600;
+  box-shadow: var(--kx-glow);
+  border-top-left-radius: var(--kx-radius-cell) !important;
+  border-bottom-left-radius: var(--kx-radius-cell) !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+/* End cell — right side rounded, left flat. */
+.kx-live-range-end {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  font-weight: 600;
+  box-shadow: var(--kx-glow);
+  border-top-right-radius: var(--kx-radius-cell) !important;
+  border-bottom-right-radius: var(--kx-radius-cell) !important;
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+/* Single-day range — start === end → full radius. */
+.kx-live-range-start.kx-live-range-end {
+  border-radius: var(--kx-radius-cell) !important;
+}
+```
+
+- [ ] **Step 3.2: Visual check — RangePicker doc**
+
+Run: `pnpm --filter docs-site start` (dev mode)
+Open: `http://localhost:3000/docs/components/rangepicker`
+Expected: Range visualization shows: left cell with left-only radius + glow, middle cells each as small rounded pills with primary-weak bg, right cell with right-only radius + glow. No vertical hairline gaps between in-range cells.
+
+---
+
+### Task 4: Update TimePicker option classes
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` — `.kx-live-list`, `.kx-live-option`, `.kx-live-ampm`, `.kx-live-ampm-btn`
+
+- [ ] **Step 4.1: Replace listbox + option blocks**
+
+```css
+.kx-live-list {
+  max-height: 176px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  border: 1px solid var(--kx-border);
+  border-radius: 10px;
+  background: var(--kx-bg);
+  min-width: 56px;
+  scrollbar-width: thin;
+  display: inline-block;
+  vertical-align: top;
+}
+
+.kx-live-option {
+  padding: 6px 12px;
+  margin-block: 1px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: center;
+  list-style: none;
+  color: inherit;
+  font-variant-numeric: tabular-nums;
+}
+
+.kx-live-option:hover {
+  background: var(--kx-primary-hover);
+}
+
+.kx-live-option-selected {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  font-weight: 600;
+  box-shadow: var(--kx-glow);
+}
+
+.kx-live-ampm {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.kx-live-ampm-btn {
+  padding: 5px 12px;
+  border: 1px solid var(--kx-border);
+  background: var(--kx-bg);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  color: inherit;
+  min-width: 46px;
+  font-weight: 500;
+}
+
+.kx-live-ampm-btn:hover:not(.kx-live-ampm-selected) {
+  background: var(--kx-primary-hover);
+}
+
+.kx-live-ampm-selected {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  border-color: var(--kx-primary) !important;
+  box-shadow: var(--kx-glow);
+}
+```
+
+- [ ] **Step 4.2: Visual check — TimePicker doc**
+
+Open: `http://localhost:3000/docs/components/timepicker`
+Expected: Hour/minute lists have ~30px option rows with 1px breathing between rows. Selected option has glow.
+
+---
+
+### Task 5: Update MonthGrid / YearGrid
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` — `.kx-live-month-grid`, `.kx-live-year-grid`, `.kx-live-my-cell`, `.kx-live-my-selected`, `.kx-live-my-current`
+
+- [ ] **Step 5.1: Replace grid + cell blocks**
+
+```css
+.kx-live-month-grid,
+.kx-live-year-grid {
+  display: grid;
+  /* 7 × var(--kx-cell) - 2 × 6px gap, then /3 — matches calendar grid width
+   * so MonthPicker and DatePicker line up to the pixel. */
+  grid-template-columns: repeat(3, calc((7 * var(--kx-cell) - 2 * 6px) / 3));
+  gap: 6px;
+  padding: 4px 0;
+}
+
+/* ARIA row wrappers must not become grid items — they'd collapse 3 cells
+ * into one each. `display: contents` lets the cells participate in the
+ * outer grid directly while keeping the a11y tree intact. */
+.kx-live-month-grid > [role='row'],
+.kx-live-year-grid > [role='row'] {
+  display: contents !important;
+}
+
+.kx-live-my-cell {
+  padding: 10px 8px;
+  border: 0;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: inherit;
+  font-weight: 500;
+  transition: background 120ms;
+}
+
+.kx-live-my-cell:hover:not(.kx-live-my-selected) {
+  background: var(--kx-primary-hover);
+}
+
+.kx-live-my-selected {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  font-weight: 600;
+  box-shadow: var(--kx-glow);
+}
+
+.kx-live-my-current {
+  box-shadow: inset 0 0 0 1.5px var(--kx-primary);
+  color: var(--kx-primary);
+}
+```
+
+- [ ] **Step 5.2: Visual check — MonthPicker / YearPicker**
+
+Open: `http://localhost:3000/docs/components/monthpicker` and `/docs/components/yearpicker`
+Expected: 3×4 grid (months) and 3×4 grid (years) with the same total width as the date calendar above. No horizontal-row layout. Selected month/year has glow.
+
+---
+
+### Task 6: Add global Infima `[role='grid']` reset
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` — add a new top-level rule
+
+- [ ] **Step 6.1: Locate the existing local fix**
+
+Find the block of comments starting `/* Docusaurus's Infima theme also injects styles into table th, table td ...` followed by `.kx-live-grid th, .kx-live-grid td, .kx-tw-grid th, .kx-tw-grid td { border: 0; }`.
+
+- [ ] **Step 6.2: Replace local fix with a global `[role='grid']` reset**
+
+Replace the entire block (the comments + the `.kx-live-grid th, td` + `.kx-tw-grid th, td` rules) with:
+
+```css
+/* Global reset for any <table role="grid"> rendered by a Kalyx picker.
+ *
+ * Docusaurus's Infima injects `table th, table td { border: 1px solid;
+ * padding: var(--ifm-table-cell-padding) }` directly (no `.markdown` prefix),
+ * which leaks into every Kalyx calendar that renders as a <table>. This rule
+ * scopes the reset to ARIA grids so prose tables in Markdown stay untouched.
+ *
+ * Replaces the per-surface guards (`.kx-live-grid th, td`, `.kx-tw-grid th,
+ * td`) that lived here before. See spec 2026-06-11 §4.7 and issue #35. */
+[data-theme] [role='grid'] th,
+[data-theme] [role='grid'] td {
+  border: 0;
+  padding: 0;
+}
+
+[data-theme] [role='grid'] {
+  border-collapse: collapse;
+}
+```
+
+- [ ] **Step 6.3: Verify in-doc tables still render correctly**
+
+Open: `http://localhost:3000/docs/comparison` (has a `<table>` for the feature matrix)
+Expected: comparison table renders with Infima's normal borders + padding (no regression). Markdown tables on intro/migration pages also unaffected.
+
+Open: `http://localhost:3000/` (landing — HeroDemo renders `<table role="grid">`)
+Expected: even though HeroDemo is not yet refactored, the calendar table no longer shows hairlines between cells. (This is the first visible win of the global reset.)
+
+---
+
+### Task 7: Tailwind recipe regression check
+
+**Files:**
+- Modify: `apps/docs-site/src/css/custom.css` — `.tw-enable table th, td` rules
+
+- [ ] **Step 7.1: Verify the Tailwind recipe still resets cells**
+
+The Tailwind recipe pages use `.tw-enable` wrapper and don't carry `.kx-live-*` classes. After the global `[role='grid']` reset in Task 6, the `.tw-enable table th, td { border: 0 !important; padding: 0 !important }` block becomes mostly redundant, but `!important` ensures it still wins if Infima specificity changes.
+
+Open: `http://localhost:3000/docs/recipes/tailwind`
+Expected: Tailwind recipe live example renders correctly. No regression.
+
+- [ ] **Step 7.2: Leave the `.tw-enable` block intact**
+
+Do NOT delete the existing `.tw-enable table th, td` rules. They protect against Infima specificity drift across Docusaurus versions. Move on.
+
+---
+
+### Task 8: Run full PR-1 validation
+
+**Files:** none
+
+- [ ] **Step 8.1: Type check**
+
+Run: `pnpm typecheck`
+Expected: PASS. (No TypeScript changes in PR-1, so this is a sanity check.)
+
+- [ ] **Step 8.2: Library unit tests**
+
+Run: `pnpm test:run`
+Expected: 462+ tests pass. Library code is untouched — failures would indicate accidental edits.
+
+- [ ] **Step 8.3: docs-site build**
+
+Run: `pnpm --filter docs-site build`
+Expected: build succeeds, no CSS warnings about unknown selectors.
+
+- [ ] **Step 8.4: Manual visual walkthrough**
+
+Start dev server: `pnpm --filter docs-site start`
+
+Open each URL in both `?theme=light` and `?theme=dark` (toggle from navbar):
+- `/` — landing (HeroDemo still uses its own CSS; the cells should look cleaner thanks to the global reset, but selection styling is from `HeroDemo.module.css` until PR-2)
+- `/docs/components/datepicker` — DatePicker live example
+- `/docs/components/rangepicker` — RangePicker (range visual)
+- `/docs/components/timepicker` — TimePicker (option lists)
+- `/docs/components/monthpicker` — MonthPicker grid
+- `/docs/components/yearpicker` — YearPicker grid
+- `/docs/components/weekpicker` — WeekPicker (week-mark highlights)
+- `/docs/components/datetimepicker` — DateTimePicker
+- `/docs/recipes/tailwind` — Tailwind recipe
+- `/docs/recipes/shadcn` — shadcn recipe
+- `/docs/recipes/react-hook-form` — RHF recipe
+- `/playground` — interactive picker selector
+
+Expected: every live example reflects Aurora tokens. No grid hairlines. No layout breakage in the recipe pages (they use their own classNames, but they reference `--kx-*` variables for the surface).
+
+- [ ] **Step 8.5: axe accessibility check**
+
+In dev mode, install the axe DevTools browser extension and run on `/docs/components/datepicker` and `/docs/components/rangepicker` in both themes.
+Expected: 0 violations (matches the pre-existing baseline).
+
+Verify the dark mode contrast: `--kx-primary` (#8b80ff) on `--kx-bg` (#111117) should be ≥ 4.5:1. Use a contrast checker if needed.
+
+- [ ] **Step 8.6: Commit PR-1**
+
+```bash
+git checkout -b feat/aurora-tokens
+git add apps/docs-site/src/css/custom.css
+git commit -m "$(cat <<'EOF'
+feat(docs-site): Aurora tokens + .kx-live-* polish
+
+Replaces the divergent --kx-ex-* token block with a unified Aurora
+system (see docs/superpowers/specs/2026-06-11-aurora-visual-overhaul-
+design.md §4). Brings every live example surface under one set of
+variables: brand violet (#5b4fe1 light / #8b80ff dark), 32px cell,
+8px radius, soft 0 3px 12px /32 glow on selection.
+
+Behavioral changes visible across every live doc example:
+- Picker card hugs the calendar grid (fit-content width), no more
+  arrow overhang.
+- Range visualization: middle cells get full 8px radius (primary-weak
+  bg), start/end cells get one-side-only radius (anchor to band).
+- TimePicker options keep their height but breathe 1px between rows.
+- MonthGrid / YearGrid widths now match the calendar width to the pixel.
+- Global [role='grid'] reset replaces the per-surface guards from
+  issue #35 — fixes Infima table-border leak everywhere, including
+  HeroDemo (which still uses its own CSS until PR-2).
+
+Library code (@kalyx/core, @kalyx/react) is untouched. Bundle size
+unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/aurora-tokens
+gh pr create --title "feat(docs-site): Aurora tokens + .kx-live-* polish" --body "$(cat <<'EOF'
+## Summary
+- Unified Aurora token system replacing --kx-ex-* (spec §4).
+- All .kx-live-* classes upgraded: 32px cell, fit-content popover, range middle cells fully rounded, range start/end one-side rounded, TimePicker option breathing.
+- MonthGrid / YearGrid widths match calendar grid.
+- Global [role='grid'] reset closes the Infima table-border leak.
+
+## Test plan
+- [ ] pnpm typecheck
+- [ ] pnpm test:run (462+ green)
+- [ ] pnpm --filter docs-site build
+- [ ] Manual walk through every /docs/components/* page in light + dark
+- [ ] Manual walk through every /docs/recipes/* page
+- [ ] axe DevTools on DatePicker + RangePicker pages (light + dark)
+- [ ] Lighthouse check on Vercel real (per feedback_lighthouse_localhost_vs_vercel)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## PR-2 — HeroDemo refactor + hero image regen
+
+**Branch off `feat/aurora-tokens` (or main once PR-1 lands).**
+
+### Task 9: Replace HeroDemo CSS module
+
+**Files:**
+- Modify: `apps/docs-site/src/components/HeroDemo/HeroDemo.module.css`
+
+- [ ] **Step 9.1: Locate the `:global([role='grid'])` block**
+
+Open `HeroDemo.module.css`. Lines ~49–119 contain the `:global([role='grid'])`, `:global([role='gridcell'] button)`, `:global([role='listbox'])`, and `:global(thead th)` blocks.
+
+- [ ] **Step 9.2: Replace the entire bespoke styling block**
+
+Delete lines ~49–119 (everything from `/* Minimal styling for the headless kalyx pickers …` through the closing brace of the last `:global(thead th)` rule). Keep `.root`, `.frame`, `.frameActive`, `.label`, `.cycleHint` blocks intact (lines 1–47).
+
+Add at the end of the file:
+
+```css
+/* Composite layout helpers — HeroDemo passes structural classNames into
+ * each picker so the body uses the same Aurora .kx-live-* tokens as the
+ * rest of the site. No selection styling lives here; it all comes from
+ * apps/docs-site/src/css/custom.css. */
+.timeRow {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.dateTimeRow {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+```
+
+- [ ] **Step 9.3: Verify build still works**
+
+Run: `pnpm --filter docs-site build`
+Expected: build succeeds. HeroDemo on `/` may now render unstyled (no classNames piped through yet) — that's the next task.
+
+---
+
+### Task 10: Pipe Aurora classNames through HeroDemo frames
+
+**Files:**
+- Modify: `apps/docs-site/src/components/HeroDemo/index.tsx`
+
+- [ ] **Step 10.1: Update imports**
+
+In `apps/docs-site/src/components/HeroDemo/index.tsx`, the existing import line is:
+
+```tsx
+import styles from './HeroDemo.module.css';
+```
+
+Keep it. We'll reference `styles.timeRow` and `styles.dateTimeRow` from Task 9.
+
+- [ ] **Step 10.2: Replace the `useFrames()` body**
+
+Find the `useFrames()` function (around line 110). Replace its `useMemo` body with:
+
+```tsx
+function useFrames(): HeroFrame[] {
+  return useMemo(
+    () => [
+      {
+        id: 'datepicker',
+        label: 'DatePicker',
+        render: () => (
+          <DatePicker value={FROZEN_DATE} onChange={() => {}}>
+            <DatePicker.Calendar
+              classNames={{
+                root: 'kx-live-calendar',
+                header: 'kx-live-header',
+                title: 'kx-live-title',
+                navButton: 'kx-live-nav',
+                grid: 'kx-live-grid',
+                weekday: 'kx-live-weekday',
+                gridCell: 'kx-live-cell',
+                day: 'kx-live-day',
+                daySelected: 'kx-live-day-selected',
+                dayToday: 'kx-live-day-today',
+                dayOutsideMonth: 'kx-live-outside',
+                dayDisabled: 'kx-live-disabled',
+              }}
+            />
+          </DatePicker>
+        ),
+      },
+      {
+        id: 'rangepicker',
+        label: 'RangePicker',
+        render: () => (
+          <RangePicker value={FROZEN_RANGE} onChange={() => {}}>
+            <RangePicker.Calendar
+              classNames={{
+                root: 'kx-live-calendar',
+                header: 'kx-live-header',
+                title: 'kx-live-title',
+                navButton: 'kx-live-nav',
+                grid: 'kx-live-grid',
+                weekday: 'kx-live-weekday',
+                gridCell: 'kx-live-cell',
+                day: 'kx-live-day-range',
+                dayInRange: 'kx-live-inrange',
+                dayRangeStart: 'kx-live-range-start',
+                dayRangeEnd: 'kx-live-range-end',
+                dayToday: 'kx-live-day-today',
+                dayOutsideMonth: 'kx-live-outside',
+                dayDisabled: 'kx-live-disabled',
+              }}
+            />
+          </RangePicker>
+        ),
+      },
+      {
+        id: 'timepicker',
+        label: 'TimePicker',
+        render: () => (
+          <TimePicker value={FROZEN_TIME} onChange={() => {}} format="12h">
+            <div className={styles.timeRow}>
+              <TimePicker.HourList
+                classNames={{
+                  root: 'kx-live-list',
+                  option: 'kx-live-option',
+                  optionSelected: 'kx-live-option-selected',
+                }}
+              />
+              <TimePicker.MinuteList
+                classNames={{
+                  root: 'kx-live-list',
+                  option: 'kx-live-option',
+                  optionSelected: 'kx-live-option-selected',
+                }}
+              />
+              <TimePicker.AmPmToggle
+                classNames={{
+                  root: 'kx-live-ampm',
+                  option: 'kx-live-ampm-btn',
+                  optionSelected: 'kx-live-ampm-selected',
+                }}
+              />
+            </div>
+          </TimePicker>
+        ),
+      },
+      {
+        id: 'datetimepicker',
+        label: 'DateTimePicker',
+        render: () => (
+          <DateTimePicker value={FROZEN_DATE} onChange={() => {}} format="24h">
+            <div className={styles.dateTimeRow}>
+              <DateTimePicker.Calendar
+                classNames={{
+                  root: 'kx-live-calendar',
+                  header: 'kx-live-header',
+                  title: 'kx-live-title',
+                  navButton: 'kx-live-nav',
+                  grid: 'kx-live-grid',
+                  weekday: 'kx-live-weekday',
+                  gridCell: 'kx-live-cell',
+                  day: 'kx-live-day',
+                  daySelected: 'kx-live-day-selected',
+                  dayToday: 'kx-live-day-today',
+                  dayOutsideMonth: 'kx-live-outside',
+                  dayDisabled: 'kx-live-disabled',
+                }}
+              />
+              <div className={styles.timeRow}>
+                <DateTimePicker.HourList
+                  classNames={{
+                    root: 'kx-live-list',
+                    option: 'kx-live-option',
+                    optionSelected: 'kx-live-option-selected',
+                  }}
+                />
+                <DateTimePicker.MinuteList
+                  classNames={{
+                    root: 'kx-live-list',
+                    option: 'kx-live-option',
+                    optionSelected: 'kx-live-option-selected',
+                  }}
+                />
+              </div>
+            </div>
+          </DateTimePicker>
+        ),
+      },
+      {
+        id: 'monthpicker',
+        label: 'MonthPicker',
+        render: () => (
+          <MonthPicker value={FROZEN_DATE} onChange={() => {}}>
+            <MonthPicker.Grid
+              classNames={{
+                root: 'kx-live-month-grid',
+                header: 'kx-live-header',
+                title: 'kx-live-title',
+                navButton: 'kx-live-nav',
+                month: 'kx-live-my-cell',
+                monthSelected: 'kx-live-my-selected',
+                monthCurrent: 'kx-live-my-current',
+              }}
+            />
+          </MonthPicker>
+        ),
+      },
+      {
+        id: 'yearpicker',
+        label: 'YearPicker',
+        render: () => (
+          <YearPicker value={FROZEN_DATE} onChange={() => {}}>
+            <YearPicker.Grid
+              classNames={{
+                root: 'kx-live-year-grid',
+                header: 'kx-live-header',
+                title: 'kx-live-title',
+                navButton: 'kx-live-nav',
+                year: 'kx-live-my-cell',
+                yearSelected: 'kx-live-my-selected',
+                yearCurrent: 'kx-live-my-current',
+              }}
+            />
+          </YearPicker>
+        ),
+      },
+      {
+        id: 'weekpicker',
+        label: 'WeekPicker',
+        render: () => (
+          <WeekPicker value={FROZEN_WEEK} onChange={() => {}}>
+            <WeekPicker.Calendar
+              classNames={{
+                root: 'kx-live-calendar',
+                header: 'kx-live-header',
+                title: 'kx-live-title',
+                navButton: 'kx-live-nav',
+                grid: 'kx-live-grid',
+                weekday: 'kx-live-weekday',
+                gridCell: 'kx-live-cell',
+                day: 'kx-live-day-range',
+                dayInWeek: 'kx-live-inrange',
+                dayWeekStart: 'kx-live-range-start',
+                dayWeekEnd: 'kx-live-range-end',
+                dayToday: 'kx-live-day-today',
+                dayOutsideMonth: 'kx-live-outside',
+              }}
+            />
+          </WeekPicker>
+        ),
+      },
+    ],
+    []
+  );
+}
+```
+
+- [ ] **Step 10.3: Verify each classNames key matches the picker's API**
+
+Before running, sanity-check each `classNames={{...}}` shape against the picker's TypeScript type. Open the picker's source (e.g., `packages/react/src/components/DatePicker/Calendar.tsx`) and confirm every key (`root`, `header`, `title`, `navButton`, `grid`, `weekday`, `gridCell`, `day`, `daySelected`, `dayToday`, `dayOutsideMonth`, `dayDisabled`) is listed in its `ClassNames` type.
+
+If any key is missing from the type, either:
+- (a) the key isn't supported — drop it from the classNames object, OR
+- (b) it's named differently — adjust the key
+
+For RangePicker.Calendar: confirm `dayInRange`, `dayRangeStart`, `dayRangeEnd` exist. For WeekPicker.Calendar: confirm `dayInWeek`, `dayWeekStart`, `dayWeekEnd`.
+
+If a class name change is needed, also update the corresponding CSS class in `custom.css` to match — keep the names symmetric.
+
+- [ ] **Step 10.4: Verify build**
+
+Run: `pnpm typecheck`
+Expected: PASS. TypeScript catches any unknown classNames keys.
+
+Run: `pnpm --filter docs-site build`
+Expected: PASS.
+
+---
+
+### Task 11: Update HeroDemo snapshot tests
+
+**Files:**
+- Modify: `apps/docs-site/src/components/HeroDemo/__tests__/HeroDemo.test.tsx` (only if it snapshots structure)
+
+- [ ] **Step 11.1: Read the existing test file**
+
+Open `HeroDemo.test.tsx`. Identify any assertions that depend on:
+- Inline `style={{ display: 'flex', gap: 8 }}` strings (removed in Task 10)
+- Specific selector chains like `[role='grid'] > div > [role='gridcell']` (still present but now styled by global rules)
+
+- [ ] **Step 11.2: Update assertions**
+
+If a test asserts inline style presence, change it to assert the new `className` (e.g., `expect(container.querySelector(`.${styles.timeRow}`)).toBeInTheDocument()`).
+
+If tests snapshot HTML output, update the snapshot:
+```bash
+pnpm --filter docs-site test -u
+```
+
+- [ ] **Step 11.3: Run tests**
+
+Run: `pnpm --filter docs-site test`
+Expected: PASS.
+
+---
+
+### Task 12: Regenerate hero images
+
+**Files:**
+- Modify: `img/hero-light.webp`, `img/hero-dark.webp`
+
+- [ ] **Step 12.1: Verify the recorder script exists**
+
+Run: `ls scripts/record-hero.mjs`
+Expected: file exists. (If not, check `apps/docs-site/scripts/` — the project may have moved the path.) This script uses Playwright to capture HeroDemo at the deterministic `?frame=N` query, light + dark.
+
+- [ ] **Step 12.2: Start docs-site dev**
+
+Run: `pnpm --filter docs-site start`
+Wait for "compiled successfully" — recorder script needs a live server.
+
+- [ ] **Step 12.3: Run the recorder**
+
+In a separate terminal:
+```bash
+node scripts/record-hero.mjs
+```
+
+Expected output: 14 frames captured (7 frames × 2 themes), composed into `hero-light.webp` and `hero-dark.webp`. Check the output directory the script writes to (likely `img/` at repo root or `apps/docs-site/static/img/`).
+
+- [ ] **Step 12.4: Move the images to the canonical location**
+
+The README references `./img/hero-light.webp` from the repo root. Confirm the files landed there (or move them):
+```bash
+ls -lh img/hero-light.webp img/hero-dark.webp
+```
+Expected: both files exist and are ≤ 200 KB each (webp is small).
+
+- [ ] **Step 12.5: Spot-check the images**
+
+Open both webp files in a viewer (Finder Quick Look on macOS works). Verify:
+- All 7 frames look like the v7 mockup
+- Light hero has white surface with violet selection
+- Dark hero has #111117 surface with #8b80ff selection
+- No grid hairlines anywhere
+- MonthPicker frame shows a 3×4 grid (not a horizontal row)
+
+If anything looks off, investigate before committing — the regenerated image is what every README reader sees.
+
+---
+
+### Task 13: Commit PR-2
+
+- [ ] **Step 13.1: Stage files**
+
+```bash
+git checkout -b feat/aurora-hero
+git add apps/docs-site/src/components/HeroDemo/HeroDemo.module.css \
+        apps/docs-site/src/components/HeroDemo/index.tsx \
+        apps/docs-site/src/components/HeroDemo/__tests__/HeroDemo.test.tsx \
+        img/hero-light.webp \
+        img/hero-dark.webp
+```
+
+- [ ] **Step 13.2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(docs-site): HeroDemo uses Aurora classNames + regen hero images
+
+Closes the styling-system divergence between HeroDemo and the rest of
+the live examples. HeroDemo.module.css no longer ships its own
+:global([role='grid']) selectors — every frame now passes classNames
+into the picker so the Aurora .kx-live-* tokens drive the look.
+
+Side effects:
+- Hero MonthPicker frame is now a proper 3-column grid (was a single
+  horizontal row falling through to <table>).
+- DateTimePicker frame's inline style={{ display:'flex', gap:8 }} on
+  the time columns is replaced by a CSS-module class.
+- hero-light.webp and hero-dark.webp regenerated via scripts/record-
+  hero.mjs from the new system — README first impression matches the
+  live docs.
+
+Depends on PR feat/aurora-tokens (Aurora token definitions).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/aurora-hero
+gh pr create --title "feat(docs-site): HeroDemo Aurora classNames + hero image regen" --body "$(cat <<'EOF'
+## Summary
+- HeroDemo no longer carries bespoke calendar CSS; it now consumes Aurora .kx-live-* via classNames.
+- Hero images regenerated to reflect the v7 system (spec §5.5).
+- Closes the gap that left MonthPicker rendering as a single horizontal row in the landing demo.
+
+## Test plan
+- [ ] pnpm typecheck
+- [ ] pnpm --filter docs-site test
+- [ ] pnpm --filter docs-site build
+- [ ] Manual: open / in light + dark, watch all 7 frames cycle correctly
+- [ ] Verify regenerated img/hero-light.webp + hero-dark.webp render on GitHub README
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## PR-3 — Playground + PickerGrid polish
+
+**Branch off `feat/aurora-tokens` (or main once PR-1 lands). Independent of PR-2.**
+
+### Task 14: Strip PreviewPanel inline styles
+
+**Files:**
+- Modify: `apps/docs-site/src/components/Playground/PreviewPanel.tsx`
+
+- [ ] **Step 14.1: Locate inline styles**
+
+Open `PreviewPanel.tsx`. Two places use inline style objects:
+- `TimePickerPreview` — `<div style={{ display: 'flex', gap: 8 }}>` wraps HourList/MinuteList/AmPmToggle (line ~77)
+- `DateTimePickerPreview` — no explicit time row wrapper, but layout may need one
+
+- [ ] **Step 14.2: Add CSS module classes**
+
+Open `apps/docs-site/src/components/Playground/Playground.module.css`. After the existing `.preview` rule, add:
+
+```css
+.timeRow {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.dateTimeRow {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+```
+
+- [ ] **Step 14.3: Update PreviewPanel**
+
+In `PreviewPanel.tsx`:
+
+Update the `TimePickerPreview` function:
+
+```tsx
+function TimePickerPreview({ timezone }: SubProps) {
+  const [v, setV] = useState<string | null>(FROZEN_TIME);
+  return (
+    <TimePicker value={v} onChange={setV} format="12h" displayTimezone={timezone}>
+      <TimePicker.Input className="kx-live-input" />
+      <div className={styles.timeRow}>
+        <TimePicker.HourList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+        <TimePicker.MinuteList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+        <TimePicker.AmPmToggle classNames={{ root: 'kx-live-ampm', option: 'kx-live-ampm-btn', optionSelected: 'kx-live-ampm-selected' }} />
+      </div>
+    </TimePicker>
+  );
+}
+```
+
+Update the `DateTimePickerPreview` to use a similar pattern:
+
+```tsx
+function DateTimePickerPreview({ classNames, locale, timezone }: SubProps) {
+  const [v, setV] = useState<string | null>(FROZEN_DATE);
+  const cn = classNames as { input?: string; calendar?: Record<string, string> };
+  return (
+    <DateTimePicker value={v} onChange={setV} locale={locale} displayTimezone={timezone}>
+      <DateTimePicker.Input className={cn.input} />
+      <DateTimePicker.Popover>
+        <div className={styles.dateTimeRow}>
+          <DateTimePicker.Calendar classNames={cn.calendar} />
+          <div className={styles.timeRow}>
+            <DateTimePicker.HourList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+            <DateTimePicker.MinuteList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+          </div>
+        </div>
+      </DateTimePicker.Popover>
+    </DateTimePicker>
+  );
+}
+```
+
+- [ ] **Step 14.4: Verify import**
+
+At the top of `PreviewPanel.tsx`, confirm `import styles from './Playground.module.css';` exists. Add if missing.
+
+- [ ] **Step 14.5: Type check + manual test**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+Run: `pnpm --filter docs-site start`
+Open: `http://localhost:3000/playground` → switch to TimePicker, DateTimePicker
+Expected: both render with proper layout (no jammed columns) in light + dark.
+
+---
+
+### Task 15: Refresh Playground card surface
+
+**Files:**
+- Modify: `apps/docs-site/src/components/Playground/Playground.module.css`
+
+- [ ] **Step 15.1: Replace the `.preview` rule**
+
+Find:
+```css
+.preview {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 1.5rem;
+  background: var(--ifm-background-color);
+  min-height: 320px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+```
+
+Replace with:
+```css
+.preview {
+  border: 1px solid var(--kx-border);
+  border-radius: var(--kx-radius-card);
+  padding: 1.5rem;
+  background: var(--kx-bg);
+  box-shadow: var(--kx-shadow-card);
+  min-height: 320px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+```
+
+- [ ] **Step 15.2: Update the `.classNamesEditor` and `.leafInput` surfaces**
+
+In the same file, find `.classNamesEditor` and `.leafInput`. Replace `var(--ifm-color-emphasis-*)` references with `var(--kx-border)` / `var(--kx-bg)` to stay consistent with the Aurora palette:
+
+```css
+.classNamesEditor {
+  border: 1px solid var(--kx-border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0;
+  background: var(--kx-bg-quiet);
+}
+
+.leafInput {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--kx-border);
+  border-radius: 4px;
+  background: var(--kx-bg);
+  color: var(--kx-fg);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+}
+```
+
+- [ ] **Step 15.3: Visual check**
+
+`http://localhost:3000/playground`
+Expected: the preview panel and classNames editor pick up the Aurora surface (subtle violet-tinted border, Aurora shadow).
+
+---
+
+### Task 16: Refresh PickerGrid cards
+
+**Files:**
+- Modify: `apps/docs-site/src/components/PickerGrid/PickerGrid.module.css`
+
+- [ ] **Step 16.1: Update the `.card` rule**
+
+Find:
+```css
+.card {
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.card:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+  text-decoration: none;
+  color: inherit;
+}
+```
+
+Replace with:
+```css
+.card {
+  background: var(--kx-bg);
+  border: 1px solid var(--kx-border);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+}
+
+.card:hover {
+  border-color: var(--kx-primary);
+  transform: translateY(-2px);
+  box-shadow: var(--kx-shadow-card);
+  text-decoration: none;
+  color: inherit;
+}
+```
+
+- [ ] **Step 16.2: Update `.section` background to use `--kx-bg-quiet`**
+
+Find:
+```css
+.section {
+  padding: 5rem 0;
+  background: var(--ifm-color-emphasis-100);
+}
+```
+
+Replace with:
+```css
+.section {
+  padding: 5rem 0;
+  background: var(--kx-bg-quiet);
+}
+```
+
+- [ ] **Step 16.3: Visual check**
+
+Open: `http://localhost:3000/` and scroll to the PickerGrid section (7 cards).
+Expected: cards have Aurora-tinted hover state with subtle shadow lift.
+
+---
+
+### Task 17: Run PR-3 validation + commit
+
+- [ ] **Step 17.1: Tests + build**
+
+Run: `pnpm typecheck && pnpm --filter docs-site test && pnpm --filter docs-site build`
+Expected: all PASS.
+
+- [ ] **Step 17.2: Manual visual walk**
+
+Open `/playground` and `/` (PickerGrid section) in light + dark.
+
+- [ ] **Step 17.3: Commit + PR**
+
+```bash
+git checkout -b feat/aurora-playground
+git add apps/docs-site/src/components/Playground/PreviewPanel.tsx \
+        apps/docs-site/src/components/Playground/Playground.module.css \
+        apps/docs-site/src/components/PickerGrid/PickerGrid.module.css
+git commit -m "$(cat <<'EOF'
+feat(docs-site): Playground + PickerGrid Aurora polish
+
+- PreviewPanel: drop inline style={{ display:'flex', gap:8 }} for
+  TimePicker and DateTimePicker layouts; use module-scoped .timeRow /
+  .dateTimeRow classes instead.
+- Playground.module.css: .preview, .classNamesEditor, .leafInput surfaces
+  use Aurora tokens (border, bg, shadow) instead of Infima emphasis.
+- PickerGrid.module.css: .card and .section pick up Aurora palette;
+  hover lifts with the soft Aurora shadow.
+
+Depends on PR feat/aurora-tokens.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin feat/aurora-playground
+gh pr create --title "feat(docs-site): Playground + PickerGrid Aurora polish" --body "$(cat <<'EOF'
+## Summary
+- Playground PreviewPanel: removed inline styles, added module classes.
+- Playground + PickerGrid surfaces use Aurora tokens.
+
+## Test plan
+- [ ] pnpm typecheck
+- [ ] pnpm --filter docs-site test
+- [ ] pnpm --filter docs-site build
+- [ ] Manual: /playground all 7 picker types in light + dark
+- [ ] Manual: / scroll to PickerGrid cards, verify hover lift
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## PR-4 — Comparison & README
+
+**Branch off main. Independent of PR-1/2/3 — content only.**
+
+### Task 18: Fetch competitor stats from live sources
+
+**Files:** none (research)
+
+- [ ] **Step 18.1: Fetch react-calendar stats**
+
+Open in browser:
+- GitHub: `https://github.com/wojtekmaj/react-calendar` — read the star count from the header.
+- npm: `https://www.npmjs.com/package/react-calendar` — read "Weekly Downloads" from the sidebar.
+- bundlephobia: `https://bundlephobia.com/package/react-calendar` — read gzip size.
+
+Record values in a scratch note:
+```
+react-calendar (wojtekmaj/react-calendar)
+- GitHub stars: ___
+- npm weekly downloads: ___
+- gzip size: ___ KB
+- License: MIT
+- Last update measured: 2026-MM-DD
+```
+
+- [ ] **Step 18.2: Fetch react-native-calendars stats**
+
+Same drill:
+- GitHub: `https://github.com/wix/react-native-calendars`
+- npm: `https://www.npmjs.com/package/react-native-calendars`
+- bundlephobia: probably not meaningful for React Native — note the package is RN-focused with a partial web shim.
+
+```
+react-native-calendars (wix/react-native-calendars)
+- GitHub stars: ___
+- npm weekly downloads: ___
+- Note: React Native first, web shim via react-native-web
+- License: MIT
+```
+
+- [ ] **Step 18.3: Refresh existing competitor stats**
+
+While at it, refresh the existing 6 competitors' numbers since the spec stamp ("Last measured 2026-06-11") is over 6 months old by the time this lands:
+- react-datepicker
+- react-day-picker
+- react-aria
+- ark-ui
+- @mui/x-date-pickers
+- @mantine/dates
+
+Record GitHub stars + npm weekly for each.
+
+---
+
+### Task 19: Update comparison.md feature matrix
+
+**Files:**
+- Modify: `apps/docs-site/docs/comparison.md`
+
+- [ ] **Step 19.1: Add the two new library columns**
+
+Open `apps/docs-site/docs/comparison.md`. Find the feature matrix table (starts around line 20). The current header is:
+
+```
+| Feature | react-datepicker | react-day-picker | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
+```
+
+Replace with:
+
+```
+| Feature | react-datepicker | react-day-picker | react-calendar | react-native-calendars | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+```
+
+Then add the new columns to every row. For react-calendar (read-only calendar grid, no time/range/RSC):
+
+| Feature | react-calendar |
+|---|---|
+| DatePicker | ✓ |
+| RangePicker | ✓ |
+| TimePicker | ✗ |
+| DateTimePicker | ✗ |
+| MonthPicker | partial[^11] |
+| YearPicker | partial[^11] |
+| WeekPicker | ✗ |
+| Timezone-aware (IANA) | ✗ |
+| Zero CSS (no required import) | ✗ |
+| SSR-safe (App Router) | ✓ |
+| RSC-friendly | partial[^6] |
+| a11y verified | ✓ |
+| ISO string API | ✗ |
+| Adapter pattern | ✗ |
+| Bundle gzip (KB) | ~17 |
+| License | MIT |
+
+For react-native-calendars (RN-first with web shim):
+
+| Feature | react-native-calendars |
+|---|---|
+| DatePicker | ✓ |
+| RangePicker | ✓ |
+| TimePicker | ✗ |
+| DateTimePicker | ✗ |
+| MonthPicker | ✓ |
+| YearPicker | partial[^11] |
+| WeekPicker | ✓ |
+| Timezone-aware (IANA) | partial[^4] |
+| Zero CSS (no required import) | partial[^12] |
+| SSR-safe (App Router) | partial[^13] |
+| RSC-friendly | ✗ |
+| a11y verified | ✓ |
+| ISO string API | ✗ |
+| Adapter pattern | ✗ |
+| Bundle gzip (KB) | ~85 (RN) |
+| License | MIT |
+
+Add new footnotes at the end of the footnote block:
+
+```
+[^11]: Surfaces a `view` or `defaultView` prop for month/year drilldown; not exported as a dedicated standalone component.
+[^12]: Inline styles by default; theme can be customized but there is no CSS-free escape hatch comparable to Kalyx.
+[^13]: React Native first; the web shim runs in browsers but the package isn't designed for Next.js App Router server boundaries.
+```
+
+- [ ] **Step 19.2: Add a "Popularity" subsection above the feature matrix**
+
+Insert a new H2 section right before `## Feature matrix`:
+
+```markdown
+## Popularity at a glance
+
+Numbers measured at the time of writing — see footer for date.
+
+| Library | GitHub stars | npm weekly downloads |
+| --- | :---: | :---: |
+| react-datepicker | _value from 18.3_ | _value_ |
+| react-day-picker | _value_ | _value_ |
+| react-calendar | _value_ | _value_ |
+| react-native-calendars | _value_ | _value_ |
+| react-aria | _value_ | _value_ |
+| ark-ui | _value_ | _value_ |
+| @mui/x-date-pickers | _value_ | _value_ |
+| @mantine/dates | _value_ | _value_ |
+| **Kalyx** | _check our own_ | _check npm_ |
+
+> _Last measured YYYY-MM-DD._ Stars and download counts move quickly; treat these as a snapshot, not a leaderboard.
+
+```
+
+Replace each `_value_` with the actual number fetched in Task 18.
+
+- [ ] **Step 19.3: Update the date stamp**
+
+Find the existing line at the end of the feature matrix section:
+```
+> _Last measured 2026-06-11. Methodology: bundle sizes via bundlephobia + each
+> library's published `size-limit`; feature presence verified against each
+> library's v-latest docs at the time of writing._
+```
+
+Update the date to the actual PR date.
+
+---
+
+### Task 20: Update the comparison.md SVG bar chart
+
+**Files:**
+- Modify: `apps/docs-site/docs/comparison.md`
+
+- [ ] **Step 20.1: Locate the SVG**
+
+The bar chart starts around line 58. It currently has 7 bars (6 competitors + Kalyx). Extend to 9 bars (8 competitors + Kalyx).
+
+- [ ] **Step 20.2: Update viewBox + spacing**
+
+Change the SVG viewBox height from `280` to `360` to fit 9 rows at 32px each + padding.
+
+Each row is 32px tall. Y positions: 22, 54, 86, 118, 150, 182, 214, 246, 278. Add labels for react-calendar (between react-day-picker and ark-ui — order by bundle size) and react-native-calendars.
+
+Use the actual gzip values fetched in Task 18 to redraw the bar widths. Formula: `width = (kb / 90) * 410` where 90 is the new chart max (since react-native-calendars at ~85 KB pushes the upper bound).
+
+Example layout:
+```
+| react-native-calendars | 85 KB |
+| react-datepicker       | 62 KB |
+| @mui/x-date-pickers    | 45 KB |
+| @mantine/dates         | 30 KB |
+| react-aria             | 28 KB |
+| react-day-picker       | 22 KB |
+| ark-ui                 | 20 KB |
+| react-calendar         | 17 KB |
+| **Kalyx**              | 15 KB |
+```
+
+- [ ] **Step 20.3: Update the SVG aria-label**
+
+Change the title:
+```
+aria-label="Bundle size comparison in KB gzip — Kalyx is among the smallest, alongside react-calendar and ark-ui"
+```
+
+- [ ] **Step 20.4: Render check**
+
+Run: `pnpm --filter docs-site build && pnpm --filter docs-site serve`
+Open: `http://localhost:3000/docs/comparison`
+Expected: feature matrix scrolls horizontally if needed (existing `overflowX: auto` wrapper handles this), bar chart renders with all 9 bars, Kalyx bar still highlighted via `.barKalyx` class.
+
+---
+
+### Task 21: Refresh "Why Kalyx" copy in README files
+
+**Files:**
+- Modify: `README.md`, `README.ko.md`, `packages/react/README.md`, `packages/core/README.md`
+
+- [ ] **Step 21.1: Refresh root `README.md`**
+
+Find the `## Why Kalyx` section (around line 30). The current text references the comparison page. Tighten the language per the user-voice convention (see memory: `feedback_user_voice_writing.md` — no "I'd recommend" hedging).
+
+Replace the existing `## Why Kalyx` section with:
+
+```markdown
+## Why Kalyx
+
+In 2026, the React date-picker landscape forces a trade-off: integrated-but-heavy (react-datepicker ~62 KB, MUI ~45 KB) or headless-but-partial (react-day-picker, react-aria, ark-ui — calendar grid only). React-calendar covers single dates and ranges but stops short of time, RSC, and timezone-aware storage. React-native-calendars is mobile-first.
+
+Kalyx ships **seven primitives** — single date, range, time, date+time, month, year, week — under one composition API. Headless, ~15 KB gzip, SSR-safe, ISO strings in / ISO strings out, adapter pattern for date-fns / dayjs / luxon.
+
+[See the full comparison →](https://kalyx-docs-site.vercel.app/docs/comparison)
+```
+
+- [ ] **Step 21.2: Refresh `README.ko.md`**
+
+Open `README.ko.md`. Find the equivalent Korean section (likely `## Kalyx를 쓰는 이유` or similar). Translate the new copy:
+
+```markdown
+## Kalyx를 쓰는 이유
+
+2026년 React 데이트 피커 시장은 둘 중 하나를 강요한다: 통합됐지만 무거운 것(react-datepicker ~62 KB, MUI ~45 KB), 또는 가볍지만 부분적인 것(react-day-picker · react-aria · ark-ui — calendar grid만). react-calendar는 단일 날짜·범위는 다루지만 time·RSC·timezone 저장이 빠지고, react-native-calendars는 모바일 우선이다.
+
+Kalyx는 **7개 프리미티브** — 단일 날짜, 범위, 시간, 날짜+시간, 월, 연, 주 — 를 하나의 composition API로 묶는다. Headless, ~15 KB gzip, SSR 안전, ISO 문자열 입출력, date-fns/dayjs/luxon용 adapter 패턴.
+
+[전체 비교 표 →](https://kalyx-docs-site.vercel.app/ko/docs/comparison)
+```
+
+- [ ] **Step 21.3: Refresh `packages/react/README.md`**
+
+The package README is shorter. Find the first paragraph (around line 11). It currently reads "Composable React primitives for single dates, date ranges, time, and date + time." Update to mention all seven:
+
+```markdown
+Composable React primitives for **seven date-related surfaces** — single date, date range, time, date+time, month, year, and week — under one Radix-style dot-notation API. Pair with Tailwind, shadcn/ui, Chakra, or any CSS.
+```
+
+Then below the install block, add a one-line link to the comparison page:
+
+```markdown
+> Comparing alternatives? See the [feature matrix](https://kalyx-docs-site.vercel.app/docs/comparison) — we hold every cell honestly, including where react-datepicker / react-aria / MUI win.
+```
+
+- [ ] **Step 21.4: Refresh `packages/core/README.md`**
+
+Same treatment — tighten the intro paragraph if needed; do not change the API examples.
+
+- [ ] **Step 21.5: Verify the bundle-size badge in the root README**
+
+The root README has `[![Bundle](https://img.shields.io/badge/gzip-15.01KB-brightgreen)]`. Confirm the current measured value (run `pnpm check-bundle` if uncertain). Update the badge URL to match.
+
+---
+
+### Task 22: Run PR-4 validation + commit
+
+- [ ] **Step 22.1: Markdown sanity check**
+
+Run: `pnpm --filter docs-site build`
+Expected: comparison.md renders without MDX errors. Open `http://localhost:3000/docs/comparison` and verify the table + bar chart.
+
+- [ ] **Step 22.2: GitHub README preview**
+
+Push the README changes to a draft branch and use GitHub's "preview" view (or `gh pr view --web`) to confirm the hero image still resolves and the new copy renders.
+
+- [ ] **Step 22.3: Commit + PR**
+
+```bash
+git checkout -b docs/aurora-comparison
+git add apps/docs-site/docs/comparison.md \
+        README.md README.ko.md \
+        packages/react/README.md packages/core/README.md
+git commit -m "$(cat <<'EOF'
+docs(comparison): add react-calendar, react-native-calendars + popularity
+
+- comparison.md: added rows for react-calendar (wojtekmaj/react-calendar)
+  and react-native-calendars (wix/react-native-calendars).
+- Added a new "Popularity at a glance" table with GitHub stars and npm
+  weekly downloads, alongside the existing feature matrix.
+- Updated the bundle-size SVG to include both new libraries; Kalyx
+  remains among the smallest.
+- Refreshed measurement date stamp.
+- Tightened "Why Kalyx" copy in root README.md, README.ko.md, and
+  the package READMEs so the new comparison page is the primary
+  reference for the landscape framing.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin docs/aurora-comparison
+gh pr create --title "docs(comparison): react-calendar, react-native-calendars + popularity table" --body "$(cat <<'EOF'
+## Summary
+- Added 2 new libraries the user explicitly named (react-calendar, react-native-calendars).
+- New "Popularity at a glance" table with stars + weekly downloads.
+- Updated SVG bar chart to include both.
+- Refreshed README "Why Kalyx" copy across root, ko, and package READMEs.
+
+## Test plan
+- [ ] pnpm --filter docs-site build
+- [ ] Manual: /docs/comparison renders correctly (table, popularity, bar chart)
+- [ ] GitHub README preview shows refreshed copy and hero
+- [ ] Verify fetched stat values match live npmjs.com / github.com on PR date (not stale)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Post-merge — Verification matrix
+
+Once all 4 PRs are merged, do a final sweep before declaring done:
+
+- [ ] **Lighthouse — Vercel real (not localhost simulate)**
+
+Per `feedback_lighthouse_localhost_vs_vercel.md`: localhost simulate gives misleading numbers. Wait for the Vercel deploy preview to publish, then run Lighthouse against the real URL: `https://kalyx-docs-site.vercel.app/` and `/docs/components/datepicker`. Compare against the pre-PR baseline. Acceptable threshold: no Lighthouse score regression > 5 points.
+
+- [ ] **e2e Playwright on main**
+
+After PR-1+2+3 land:
+```bash
+pnpm --filter docs-site exec playwright test
+```
+Expected: all browsers PASS (chromium / firefox / webkit per the workflow).
+
+- [ ] **axe across themes**
+
+For each `/docs/components/*` page, toggle light + dark, run axe DevTools.
+Expected: 0 violations.
+
+- [ ] **README check on GitHub**
+
+After PR-4 lands and PR-2's hero images are deployed, refresh the GitHub README and confirm:
+- Light hero shows in light-mode browsers
+- Dark hero shows in dark-mode browsers (via `<picture>` `prefers-color-scheme`)
+- Comparison link works
+- All badges resolve
+
+- [ ] **Bundle size**
+
+Run: `pnpm check-bundle`
+Expected: ≤ 16 KB ceiling. No library changes were made, so this should be unchanged from main.
+
+---
+
+## Self-review checklist (run before declaring plan ready)
+
+- ✅ Every section of `2026-06-11-aurora-visual-overhaul-design.md` is covered by at least one task.
+  - §4.1 tokens → Task 1
+  - §4.2 surface primitives → Task 2
+  - §4.3 grid → Task 2
+  - §4.4 range → Task 3
+  - §4.5 TimePicker → Task 4
+  - §4.6 MonthGrid/YearGrid → Task 5
+  - §4.7 Infima reset → Task 6
+  - §5.1 tokens & live-example → Tasks 1–7
+  - §5.2 HeroDemo → Tasks 9–11
+  - §5.3 Playground → Tasks 14, 15
+  - §5.4 PickerGrid → Task 16
+  - §5.5 hero images → Task 12
+  - §5.6 comparison Track A → Tasks 18–20
+  - §5.7 README → Task 21
+  - §6 PR breakdown → 4 PR groups
+  - §7 testing → Tasks 8, 17, 22 + post-merge sweep
+  - §8 risks → addressed inline (Infima scope `[role='grid']`, contrast verified, snapshot tests in Task 11, hero images use deterministic recorder)
+
+- ✅ No "TBD", "TODO", "implement later", "similar to Task N" placeholders.
+- ✅ Class names used in PR-2 (HeroDemo classNames) match the keys defined in PR-1 CSS (Task 10 includes a sanity-check step against the picker source types).
+- ✅ Branch + commit messages are written out verbatim, not described.
+- ✅ Each PR can be reviewed and merged independently (with the dependency order stated up top).
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-11-aurora-visual-overhaul.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks, fast iteration; matches the user's parallel-PR convention well since PR-2/3/4 can each be its own worktree-isolated subagent.
+
+**2. Inline Execution** — execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-06-11-aurora-visual-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-11-aurora-visual-overhaul-design.md
@@ -1,0 +1,417 @@
+# Aurora Visual Overhaul — Design Spec
+
+**Date**: 2026-06-11
+**Status**: Brainstorming complete · ready for implementation plan
+**Scope**: docs-site (Docusaurus public docs), README set, hero images
+**Out of scope**: apps/docs (deprecated internal Next.js demo — keep as-is)
+**Library code (`packages/core`, `packages/react`)**: not touched. Zero-CSS API stays.
+
+---
+
+## 1. Problem
+
+Three reported screenshots ([live preview in dark mode at docs-site](https://kalyx-docs-site.vercel.app)) showed a Calendar / DateTimePicker / MonthPicker that look unpolished — visible grid lines, cramped MonthPicker, harsh contrast on the indigo selection.
+
+Root cause (verified by reading `apps/docs-site/src/css/custom.css` and `HeroDemo.module.css`):
+
+1. **Grid hairlines** — HeroDemo uses `:global([role='grid'])` and never resets Docusaurus Infima's default `table th, td { border: 1px solid }`. The `.kx-live-*` system patched this locally (issue #35) but the hero never picked it up.
+2. **MonthPicker cramped** — HeroDemo renders `<MonthPicker.Grid />` raw without the `.kx-live-month-grid` 3-column rule, so the underlying `<table>` falls through to a single horizontal row.
+3. **DateTimePicker columns** — inline `style={{ display: 'flex', gap: 8 }}` with no width hint, so hour/minute columns are jammed together.
+4. **Dark mode harshness** — solid `#000000`-ish background + sharp solid-colored selections without breathing room read as "cheap" against polished references (react-calendar, react-native-calendars).
+
+In short: it's *two CSS systems that diverged* (`.kx-live-*` got polished via #35, HeroDemo and a few other surfaces didn't), not a fundamental design failure. The fix is **unify around one Aurora token system + apply a real polish pass**, not a ground-up rebuild.
+
+---
+
+## 2. Goals & Non-goals
+
+### Goals
+- Pick a single visual direction (Aurora — brand-violet polished) and apply it to every docs-site surface that renders a Kalyx picker.
+- Replace the divergent `:global([role='grid'])` selectors in `HeroDemo.module.css` with the same `.kx-live-*` classes used by every other live example.
+- Fix the three concrete visual bugs (grid hairlines, MonthPicker layout, DateTimePicker spacing) by closing the styling-system gap, not by patching one site at a time.
+- Refresh the competitive comparison (`comparison.md`) with two libraries the user named (react-calendar, react-native-calendars) and add GitHub stars + npm weekly downloads columns.
+- Regenerate hero images (`img/hero-light.webp`, `img/hero-dark.webp`) so the README first-impression reflects the new system.
+
+### Non-goals
+- No changes to the public library API (`@kalyx/react`, `@kalyx/core`). Zero-CSS guarantee stays. classNames prop unchanged.
+- No bundle-size impact on the library (~15.63 KB ESM unchanged, 16 KB ceiling untouched).
+- No `apps/docs` rework. It's not deployed and adding it triples the scope for zero user impact.
+- No new design-system page or `.kx-aurora-*` parallel class system. We *upgrade* `.kx-live-*` in place.
+
+---
+
+## 3. Decisions (from brainstorming)
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **Visual direction: B. Aurora** — refined brand violet, no grid lines, primary-glow on selection, rings on today | Chosen over react-calendar clone (A) and Editorial (C). Keeps existing `#5b4fe1` brand identity, modern shadcn/Linear feel, polished light + dark. |
+| 2 | **Scope: docs-site + README** (apps/docs excluded) | apps/docs isn't deployed — only docs-site is on Vercel. Excluding apps/docs keeps the change surface area focused. |
+| 3 | **Strategy: unified tokens + polish** (not a ground-up rebuild) | The "ugly" screenshots trace to CSS leaks + style-system divergence. Unifying `.kx-live-*` tokens and applying them to HeroDemo solves the symptoms by fixing the cause. |
+| 4 | **Hero images: regenerate** via `recorder.tsx` once HeroDemo picks up the new classes | README's first impression is the biggest marketing lever. The recorder is already wired in. |
+| 5 | **Glow strength**: `0 3px 12px /32` (between v1-strong and v2-soft) | User feedback: v1 too strong, v2 too soft. v3 middle picked. |
+| 6 | **TimePicker option**: `padding: 6px 12px` + `margin-block: 1px` | User wanted breathing between options but full button height retained. |
+| 7 | **RangePicker shape**: middle cells full 8px radius (primary-weak); start cell left-only radius; end cell right-only radius | start/end anchor visually to the band; middle cells read as pills inside a soft band. |
+| 8 | **Grid columns**: `grid-template-columns: repeat(7, var(--kx-cell))` (not `1fr`) | Fixes weekday ↔ day vertical misalignment caused by 32px buttons sitting in `1fr` columns wider than 32px. |
+| 9 | **Picker card width**: `width: fit-content` | Card hugs the 224px (7×32) calendar grid + 28px padding = 252px. Eliminates the head/arrow overhang the user spotted. |
+
+---
+
+## 4. Aurora visual system (final values)
+
+### 4.1 Tokens
+
+All tokens live in `apps/docs-site/src/css/custom.css`. They replace the existing `--kx-ex-*` block.
+
+```css
+:root {
+  /* Aurora — light */
+  --kx-bg:            #ffffff;
+  --kx-bg-quiet:      #fafafa;
+  --kx-fg:            #18181b;
+  --kx-fg-muted:      #71717a;
+  --kx-fg-subtle:     #a1a1aa;
+  --kx-border:        rgba(91, 79, 225, 0.10);
+  --kx-primary:       #5b4fe1;
+  --kx-primary-fg:    #ffffff;
+  --kx-primary-weak:  rgba(91, 79, 225, 0.12);
+  --kx-primary-hover: rgba(91, 79, 225, 0.06);
+  --kx-glow:          0 3px 12px rgba(91, 79, 225, 0.32);
+  --kx-shadow-card:   0 8px 24px rgba(91, 79, 225, 0.06), 0 1px 2px rgba(0,0,0,0.04);
+  --kx-radius-cell:   8px;
+  --kx-radius-card:   14px;
+  --kx-radius-input:  8px;
+  --kx-cell:          32px;
+}
+
+[data-theme='dark'] {
+  --kx-bg:            #111117;
+  --kx-bg-quiet:      #0a0a0f;
+  --kx-fg:            #f4f4f5;
+  --kx-fg-muted:      #a1a1aa;
+  --kx-fg-subtle:     #71717a;
+  --kx-border:        rgba(255, 255, 255, 0.08);
+  --kx-primary:       #8b80ff;
+  --kx-primary-fg:    #0a0a0f;
+  --kx-primary-weak:  rgba(139, 128, 255, 0.18);
+  --kx-primary-hover: rgba(139, 128, 255, 0.12);
+  --kx-glow:          0 3px 12px rgba(139, 128, 255, 0.32);
+  --kx-shadow-card:   0 12px 30px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255,255,255,0.02);
+}
+```
+
+### 4.2 Surface primitives
+
+```css
+/* Picker card — hugs content */
+.kx-live-popover {
+  width: fit-content;            /* was: 280px hardcoded — see issue #35 */
+  padding: 14px;
+  border: 1px solid var(--kx-border);
+  border-radius: var(--kx-radius-card);
+  background: var(--kx-bg);
+  box-shadow: var(--kx-shadow-card);
+  margin-top: 6px;
+  z-index: 50;
+}
+
+.kx-live-popover--split { display: flex; gap: 12px; align-items: stretch; }
+
+/* Header */
+.kx-live-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
+.kx-live-title  { flex: 1; text-align: center; font-weight: 600; font-size: 13.5px; padding: 4px 8px; border-radius: 6px; }
+.kx-live-nav    { width: 26px; height: 26px; display: inline-flex; align-items: center; justify-content: center; border-radius: 6px; background: transparent; color: var(--kx-fg-muted); }
+.kx-live-nav:hover, .kx-live-title:hover { background: var(--kx-primary-hover); color: var(--kx-primary); }
+```
+
+### 4.3 Calendar grid
+
+```css
+.kx-live-grid {
+  display: grid;
+  grid-template-columns: repeat(7, var(--kx-cell));  /* was: width:100% on table */
+  gap: 0;                                            /* range continuity */
+}
+
+.kx-live-weekday {
+  width: var(--kx-cell);
+  text-align: center;
+  font-size: 10px;
+  padding: 6px 0 8px;                                /* deliberate header rhythm */
+  color: var(--kx-fg-subtle);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.kx-live-cell { padding: 0; }                        /* td reset */
+
+.kx-live-day, .kx-live-day-range {
+  width: var(--kx-cell);
+  height: var(--kx-cell);
+  display: flex; align-items: center; justify-content: center;
+  border: 0;
+  border-radius: var(--kx-radius-cell);
+  background: transparent;
+  color: inherit;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: background 120ms;
+}
+
+.kx-live-day:hover:not(.kx-live-day-selected) { background: var(--kx-primary-hover); }
+
+.kx-live-day-today {
+  box-shadow: inset 0 0 0 1.5px var(--kx-primary);
+  color: var(--kx-primary);
+  font-weight: 600;
+}
+
+.kx-live-day-selected, .kx-live-my-selected, .kx-live-option-selected {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  font-weight: 600;
+  box-shadow: var(--kx-glow);
+}
+```
+
+### 4.4 Range visualization (key change)
+
+```css
+.kx-live-inrange {
+  background: var(--kx-primary-weak) !important;
+  border-radius: var(--kx-radius-cell) !important;   /* v7: middle cells fully rounded */
+}
+
+.kx-live-range-start {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  box-shadow: var(--kx-glow);
+  border-top-left-radius:    var(--kx-radius-cell) !important;
+  border-bottom-left-radius: var(--kx-radius-cell) !important;
+  border-top-right-radius:    0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.kx-live-range-end {
+  background: var(--kx-primary) !important;
+  color: var(--kx-primary-fg) !important;
+  box-shadow: var(--kx-glow);
+  border-top-right-radius:    var(--kx-radius-cell) !important;
+  border-bottom-right-radius: var(--kx-radius-cell) !important;
+  border-top-left-radius:    0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.kx-live-range-start.kx-live-range-end {
+  border-radius: var(--kx-radius-cell) !important;   /* same-day range */
+}
+```
+
+### 4.5 TimePicker
+
+```css
+.kx-live-list {
+  max-height: 176px; overflow-y: auto;
+  margin: 0; padding: 4px;
+  list-style: none;
+  border: 1px solid var(--kx-border);
+  border-radius: 10px;
+  background: var(--kx-bg);
+  min-width: 56px;
+}
+
+.kx-live-option {
+  padding: 6px 12px;                                 /* full height retained */
+  margin-block: 1px;                                 /* 1px breathing between options */
+  border-radius: 6px;
+  text-align: center;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: inherit;
+  list-style: none;
+}
+.kx-live-option:hover { background: var(--kx-primary-hover); }
+```
+
+### 4.6 MonthGrid / YearGrid
+
+```css
+.kx-live-month-grid, .kx-live-year-grid {
+  display: grid;
+  /* 224 - 2×6 gap = 212, /3 ≈ 70.67 — matches calendar grid width exactly */
+  grid-template-columns: repeat(3, calc((7 * var(--kx-cell) - 2 * 6px) / 3));
+  gap: 6px;
+  padding: 4px 0;
+}
+
+/* React row wrappers (ARIA) must not become grid items */
+.kx-live-month-grid > [role='row'],
+.kx-live-year-grid > [role='row'] { display: contents !important; }
+
+.kx-live-my-cell {
+  padding: 10px 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: inherit;
+  cursor: pointer;
+}
+.kx-live-my-cell:hover:not(.kx-live-my-selected) { background: var(--kx-primary-hover); }
+.kx-live-my-current { box-shadow: inset 0 0 0 1.5px var(--kx-primary); color: var(--kx-primary); }
+```
+
+### 4.7 Global Infima table reset (root fix for grid hairlines)
+
+```css
+/* Infima injects `table th, table td { border: 1px solid }` (no `.markdown` prefix),
+ * which leaks into every Kalyx grid that renders as <table>. Currently patched per-
+ * surface (.kx-live-grid, .kx-tw-grid). Add a global reset for any [role='grid']
+ * <table> so HeroDemo, future surfaces, and any consumer page is protected. */
+[data-theme] [role='grid'] th,
+[data-theme] [role='grid'] td {
+  border: 0;
+  padding: 0;
+}
+```
+
+---
+
+## 5. Component mapping (file → change)
+
+### 5.1 Aurora tokens & live-example styles
+**File**: `apps/docs-site/src/css/custom.css`
+- Replace `--kx-ex-*` token block with the values in §4.1.
+- Update `.kx-live-popover` (width: fit-content), `.kx-live-grid` (columns), `.kx-live-weekday` (padding 6 0 8, width), `.kx-live-day*` (32 × 32, full radius), `.kx-live-inrange`, `.kx-live-range-start`, `.kx-live-range-end`, `.kx-live-option` (padding + margin), `.kx-live-month-grid`, `.kx-live-year-grid`, `.kx-live-my-*` to match §4.
+- Add the global Infima reset in §4.7.
+- Keep existing comments referencing issue #35 — they explain the historical context for the table-border guards.
+
+### 5.2 HeroDemo (largest visible change)
+**Files**:
+- `apps/docs-site/src/components/HeroDemo/HeroDemo.module.css` — delete `:global([role='grid'])` block and the gridcell/listbox/thead styles. The new tokens make them redundant.
+- `apps/docs-site/src/components/HeroDemo/index.tsx` — pass `classNames` to every picker so each frame renders with the same `.kx-live-*` system used elsewhere:
+  - `<DatePicker.Calendar classNames={{ grid: 'kx-live-grid', /* ... */ }} />`
+  - Add the missing `<MonthPicker.Grid classNames={{ root: 'kx-live-month-grid', cell: 'kx-live-my-cell', /* ... */ }} />`
+  - Same for YearPicker, WeekPicker, TimePicker, DateTimePicker (each gets the right sub-component classNames).
+  - Remove inline `style={{ display: 'flex', gap: 8 }}` on time/datetime layouts — replace with a small CSS module class (e.g., `.timeRow`) that uses gap 6px.
+- Keep the cycle hint and frame transition logic in `HeroDemo` — they're orthogonal to styling.
+
+### 5.3 Playground page
+**Files**:
+- `apps/docs-site/src/components/Playground/PreviewPanel.tsx` — replace `style={{ display: 'flex', gap: 8 }}` inline with classes referencing the same Aurora tokens.
+- `apps/docs-site/src/components/Playground/Playground.module.css` — refresh card surface to use `--kx-bg`, `--kx-border`, `--kx-shadow-card`.
+
+### 5.4 PickerGrid (landing)
+**File**: `apps/docs-site/src/components/PickerGrid/PickerGrid.module.css`
+- Card backgrounds, borders, shadows to Aurora tokens.
+
+### 5.5 Hero images
+**Process**:
+1. Land 5.1 + 5.2 first (HeroDemo now uses Aurora classes).
+2. `pnpm --filter docs-site dev` → open `/recorder?frame=0…6` for both light and dark themes.
+3. Capture each frame with the existing recorder tooling, encode to webp.
+4. Overwrite `img/hero-light.webp` and `img/hero-dark.webp`.
+5. Verify README renders the new images (light + dark via `<picture>` `prefers-color-scheme`).
+
+### 5.6 Competitive analysis (Track A)
+**File**: `apps/docs-site/docs/comparison.md`
+- **Add rows** to the feature matrix: `react-calendar` (wojtekmaj), `react-native-calendars` (wix).
+- **Add columns**: GitHub stars, npm weekly downloads.
+- **Fetch fresh values** from npmjs.com and github.com — do not fill from memory. The current "_Last measured 2026-06-11_" stamp must be replaced with the actual fetch date.
+- For each new library: note one-line "when to use" (react-calendar = simple read-only calendar; react-native-calendars = mobile-first React Native, web shim partial).
+- Update the SVG bar chart to include the two new libraries.
+
+### 5.7 README set
+**Files**: `README.md`, `README.ko.md`, `packages/react/README.md`, `packages/core/README.md`
+- Hero image references already point to `img/hero-{light,dark}.webp` — no change needed once images are regenerated.
+- "Why Kalyx" section: tighten copy in user voice (no "I'd recommend" / "you might want to" hedging — follow `feedback_user_voice_writing.md`).
+- Link the refreshed comparison table.
+- Bump the badge line if applicable (no version bump from this work).
+
+---
+
+## 6. PR breakdown
+
+Four PRs, ordered by dependency. Each lands independently; the next one rebases on top.
+
+| PR | Title | Files | Risk | Validation |
+|---|---|---|---|---|
+| **PR-1** | `feat(docs-site): Aurora tokens + .kx-live-* polish` | `custom.css` (tokens + live classes + Infima reset) | Medium — every docs page changes visually | docs-site build, e2e Playwright (chromium/firefox/webkit), manual: every recipe page, every component doc, both themes |
+| **PR-2** | `feat(docs-site): HeroDemo Aurora classes + hero image regen` | `HeroDemo.module.css`, `HeroDemo/index.tsx`, `img/hero-{light,dark}.webp` | Low — depends on PR-1, isolated to landing | manual frame 0–6 light + dark, README rendering on GitHub |
+| **PR-3** | `feat(docs-site): Playground + PickerGrid polish` | `Playground.module.css`, `PreviewPanel.tsx`, `PickerGrid.module.css` | Low | manual: `/playground` interactive, landing card grid |
+| **PR-4** | `docs(comparison): add react-calendar, react-native-calendars + stars/downloads` | `comparison.md`, README hero/Why sections | Low — content only | spec → fetched values must match live npmjs.com / github.com on PR date |
+
+PR-2 → PR-3 → PR-4 can in principle land in any order after PR-1, but PR-2 should ship together with the hero image swap to avoid a window where the README hero looks dated relative to the live docs.
+
+---
+
+## 7. Testing & verification
+
+### Automated
+- `pnpm typecheck` — TypeScript compiles. HeroDemo classNames refactor needs `ClassNames` types from `@kalyx/react` re-export verified.
+- `pnpm test:run` — Vitest unit suite (462+ cases). No library code changes → expect green.
+- `pnpm --filter docs-site build` — Docusaurus build must succeed (i18n, sidebars, MDX).
+- `pnpm check-bundle` — library bundle unchanged; 16 KB ceiling untouched.
+- Playwright e2e (`e2e-and-docs.yml`) — cross-browser regression on chromium/firefox/webkit. **Watch for selector regressions** in tests that target `.kx-live-*` (they shouldn't break since class names stay the same; values change).
+- axe — every page that currently passes must still pass under both light and dark.
+
+### Manual
+- Every component doc page (`/docs/components/{datepicker,…,weekpicker}`) renders correctly in light + dark.
+- Every recipe page (`/docs/recipes/{tailwind,shadcn,react-hook-form,testing}`) renders correctly. The Tailwind recipe uses Tailwind Play CDN — verify the `.tw-enable` reset still works.
+- Landing page hero animates through all 7 frames without flicker.
+- Playground PreviewPanel for all 7 picker types renders correctly.
+- README on GitHub: hero image (light + dark) renders, comparison link works.
+- Korean docs (`/ko/...`) inherit the same Aurora tokens (no per-locale CSS).
+
+### Bundle / performance budget
+- The library code is not touched. No bundle change expected.
+- Docs-site bundle: CSS may grow slightly (new Infima reset, hero classNames in JSX), but shouldn't affect Lighthouse score materially. Verify against Vercel real (per `feedback_lighthouse_localhost_vs_vercel.md` — localhost simulate ≠ Vercel real, +/-10 points).
+
+---
+
+## 8. Risks & rollback
+
+| Risk | Mitigation |
+|---|---|
+| `.kx-live-*` class API is consumed by recipe pages and reads as "internal API" — but external users may have copy-pasted | Class names stay identical. Only token values change. Anyone copying the recipe styles gets the new look automatically (probably what they'd want). |
+| Infima global reset (§4.7) is broader than the current `:not()`-guarded rule | Limit reset to `[role='grid']` only — Markdown prose tables stay unaffected because they don't carry `role="grid"`. |
+| HeroDemo refactor changes JSX structure → snapshot tests | If any HeroDemo snapshot tests exist (`apps/docs-site/src/components/HeroDemo/__tests__/`), update them with the new className structure. |
+| Hero image regeneration involves taking screenshots — non-deterministic | Use the existing `recorder.tsx` with `?frame=N` deterministic values (frozen dates in `sequence.ts`) so frames are byte-stable. |
+| Light/dark token mismatch (e.g., contrast failure in dark) | Run axe over every page on both themes. The Aurora dark glow is the highest-risk single change — verify contrast ratio on `--kx-primary` (#8b80ff) against `--kx-bg` (#111117) is ≥ 4.5:1. |
+
+Rollback strategy per PR:
+- PR-1: revert single commit, all sites snap back to current style.
+- PR-2: revert two files + restore prior hero webp (committed to git history).
+- PR-3: independent, revertable.
+- PR-4: content-only, easy revert.
+
+---
+
+## 9. Open questions
+
+None blocking. All design decisions resolved during brainstorming. Implementation plan to follow via `writing-plans` skill.
+
+---
+
+## 10. Related
+
+- Issue #35 — earlier live-example styling bug; this spec finishes what that PR started by unifying HeroDemo into the same system.
+- `apps/docs-site/src/components/HeroDemo/sequence.ts` — frame sequence used by both HeroDemo and recorder; do not touch (frozen for byte-determinism).
+- `feedback_user_voice_writing.md` — applies to README copy refresh in PR-4.
+- `feedback_lighthouse_localhost_vs_vercel.md` — applies to performance verification.
+- `feedback_avoid_brew_install_mid_session.md` — image encoding (webp) should use existing tooling, not new brew installs.
+
+---
+
+## Appendix: Aurora v1 → v7 iteration log
+
+Captured for future reference. The visual companion screens (in `.superpowers/brainstorm/82824-1781157567/content/`) record each step:
+
+- **v1** — initial Aurora draft: violet brand, light + dark, gridless calendar
+- **v2** — toned-down glow (`0 2px 8px /22` from v1's `0 4px 18px /45 + ring`) + visible hover state baked into static mockup
+- **v3** — TimePicker padding tightened (3px 10px + margin-block 1px), Range gap 0 (continuous band)
+- **v4** — TimePicker height restored (padding back to 6×12, margin 1px kept); RangePicker middle cells get full 8px radius; weekday padding 6/0/8 for header rhythm
+- **v5** — Range start = left-only radius, end = right-only radius (anchor visual); day width 100% for weekday alignment (turned out to overshoot)
+- **v6** — `--kx-cell: 32px` and `grid-template-columns: repeat(7, var(--kx-cell))` so weekday columns and day cells are the same fixed width
+- **v7** (final) — `picker { width: fit-content }` so the picker card hugs the 7×32 grid; head no longer overhangs the calendar; MonthGrid 3-column width = calendar width

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @kalyx/core
 
-> Platform-independent date logic powering [Kalyx](https://github.com/jiji-hoon96/kalyx). Types, adapters, and UTC-safe utilities.
+> Platform-independent date logic powering the seven [Kalyx](https://github.com/jiji-hoon96/kalyx) pickers — single date, range, time, date+time, month, year, week. Types, adapters, and UTC-safe utilities.
 
 [![npm](https://img.shields.io/npm/v/@kalyx/core?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/core)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,7 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 
-Composable React primitives for single dates, date ranges, time, and date + time. Radix-style dot notation. Pair with Tailwind, shadcn/ui, Chakra, or any CSS.
+Composable React primitives for **seven date-related surfaces** — single date, date range, time, date+time, month, year, and week — under one Radix-style dot-notation API. Pair with Tailwind, shadcn/ui, Chakra, or any CSS.
 
 **📚 Full docs:** [kalyx-docs-site.vercel.app](https://kalyx-docs-site.vercel.app) · [한국어](https://kalyx-docs-site.vercel.app/ko)
 
@@ -20,6 +20,8 @@ pnpm add @kalyx/react
 ```
 
 Requires React ≥ 19.
+
+> Comparing alternatives? See the [feature matrix](https://kalyx-docs-site.vercel.app/docs/comparison) — we hold every cell honestly, including where react-datepicker / react-aria / MUI win.
 
 ## Quick example
 


### PR DESCRIPTION
## Summary

PR-4 of the Aurora visual overhaul (content-only, independent of PR-1/2/3).

- **Added 2 libraries** the user explicitly named: `react-calendar` (wojtekmaj) and `react-native-calendars` (wix). Inserted between `react-day-picker` and `react-aria` in the feature matrix.
- **New "Popularity at a glance" table** showing GitHub stars + npm weekly downloads for all 9 libraries (live-fetched 2026-06-11 from github.com + npm public API).
- **Refreshed SVG bar chart**: 7 → 9 bars, viewBox 640×360, sorted by bundle size descending. Kalyx still highlighted via `.barKalyx`.
- **3 new footnotes** ([^11], [^12], [^13]) explaining view/defaultView drilldown limitations, RN web shim caveats, and inline-style escape hatch.
- **2 review-driven follow-up footnotes/notes**: monorepo-stars caveat for react-aria / ark-ui / @mui/x-date-pickers / @mantine/dates, plus a footnote on react-day-picker's 39M weekly explaining the shadcn/ui `Calendar` dependency context.
- **"Why Kalyx" copy refreshed** across `README.md`, `README.ko.md`, `packages/react/README.md`, `packages/core/README.md` in user-voice (no AI hedging).
- **Bundle badge** corrected: 15.01 KB (stale) → 15.63 KB (actual measurement).
- **KO comparison source synced** to match the EN diff (in `apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md`).

Spec: [`docs/superpowers/specs/2026-06-11-aurora-visual-overhaul-design.md`](./docs/superpowers/specs/2026-06-11-aurora-visual-overhaul-design.md) §5.6 + §5.7
Plan: [`docs/superpowers/plans/2026-06-11-aurora-visual-overhaul.md`](./docs/superpowers/plans/2026-06-11-aurora-visual-overhaul.md) (Tasks 18–22)

## Discovered (separate from this PR)

Cross-check revealed a **pre-existing Docusaurus i18n rendering bug**: KO doc pages on production currently serve EN content. `/ko/docs/intro` HTML has only ~6 hangul characters (locale switcher labels) — the body content is the English source. This affects every KO docs page, not just `/ko/docs/comparison`, and it predates this PR.

The KO comparison source in this PR is **structurally correct** — when the i18n bug is fixed, the page will render the new Korean content automatically. Will file a separate investigation issue for the i18n config (`docusaurus.config.ts` i18n + presets[].docs path resolution).

## Test plan
- [x] `pnpm --filter docs-site build` PASS for both `en` and `ko` locales, no MDX errors
- [x] Stats live-fetched (not from LLM memory): see commit body for sources
- [x] Number consistency between Popularity table, feature matrix Bundle row, and SVG bars verified
- [x] Footnote integrity ([^1]–[^14]) verified: every ref has a matching definition, contiguous numbering
- [x] Bundle badge measurement re-verified (`node scripts/check-bundle-size.js`): ESM 15.63 KB / CJS 15.76 KB
- [ ] User voice review of "Why Kalyx" copy in 4 READMEs
- [ ] EN comparison page renders correctly on Vercel preview (KO won't render Korean until the separate i18n bug is fixed)

## Concerns

1. `npmjs.com` package pages return 403 to fetch — used `api.npmjs.org/downloads/point/last-week/` (the official npm public API, same underlying data as the sidebar).
2. `bundlephobia.com` returned no-data — gzip values for react-calendar (~17 KB) and react-native-calendars (~85 KB RN) are estimates from the published `size-limit` configs in those repos, not independent measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 경쟁사 비교 라이브러리 범위 확대 (react-calendar, react-native-calendars 포함)
  * README에서 지원하는 날짜 관련 기능과 비교 페이지 링크 추가
  * 번들 크기 정보 최신화
  * Aurora 비주얼 오버홀 계획서 및 설계 명세 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->