### PR TITLE
feat(docs-site): finish Aurora migration — DRY classNames + PickerGrid colors

### DIFF
--- a/apps/docs-site/src/components/PickerGrid/PickerGrid.module.css
+++ b/apps/docs-site/src/components/PickerGrid/PickerGrid.module.css
@@ -17,14 +17,14 @@
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--ifm-color-primary);
+  color: var(--kx-primary);
 }
 
 .heading {
   font-size: 2rem;
   margin: 0;
   font-weight: 700;
-  color: var(--ifm-heading-color);
+  color: var(--kx-fg);
 }
 
 .grid {
@@ -72,19 +72,19 @@
 .label {
   font-size: 1.05rem;
   font-weight: 700;
-  color: var(--ifm-heading-color);
+  color: var(--kx-fg);
 }
 
 .oneLine {
   font-size: 0.9rem;
   line-height: 1.5;
-  color: var(--ifm-color-emphasis-700);
+  color: var(--kx-fg-muted);
   flex: 1;
 }
 
 .cta {
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--ifm-color-primary);
+  color: var(--kx-primary);
   margin-top: 0.25rem;
 }

--- a/apps/docs-site/src/components/Playground/PreviewPanel.tsx
+++ b/apps/docs-site/src/components/Playground/PreviewPanel.tsx
@@ -13,6 +13,18 @@ const FROZEN_RANGE: DateRange = { start: '2026-06-15T00:00:00.000Z', end: '2026-
 const FROZEN_WEEK: DateRange = { start: '2026-06-14T00:00:00.000Z', end: '2026-06-20T00:00:00.000Z' };
 const FROZEN_TIME = '2026-06-15T14:30:00.000Z';
 
+const LIVE_LIST_CN = {
+  root: 'kx-live-list',
+  option: 'kx-live-option',
+  optionSelected: 'kx-live-option-selected',
+} as const;
+
+const LIVE_AMPM_CN = {
+  root: 'kx-live-ampm',
+  option: 'kx-live-ampm-btn',
+  optionSelected: 'kx-live-ampm-selected',
+} as const;
+
 export type PreviewPanelProps = {
   pickerId: PickerId;
   classNames: ClassNamesShape;
@@ -75,9 +87,9 @@ function TimePickerPreview({ timezone }: SubProps) {
     <TimePicker value={v} onChange={setV} format="12h" displayTimezone={timezone}>
       <TimePicker.Input className="kx-live-input" />
       <div className={styles.timeRow}>
-        <TimePicker.HourList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
-        <TimePicker.MinuteList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
-        <TimePicker.AmPmToggle classNames={{ root: 'kx-live-ampm', option: 'kx-live-ampm-btn', optionSelected: 'kx-live-ampm-selected' }} />
+        <TimePicker.HourList classNames={LIVE_LIST_CN} />
+        <TimePicker.MinuteList classNames={LIVE_LIST_CN} />
+        <TimePicker.AmPmToggle classNames={LIVE_AMPM_CN} />
       </div>
     </TimePicker>
   );
@@ -93,8 +105,8 @@ function DateTimePickerPreview({ classNames, locale, timezone }: SubProps) {
         <div className={styles.dateTimeRow}>
           <DateTimePicker.Calendar classNames={cn.calendar} />
           <div className={styles.timeRow}>
-            <DateTimePicker.HourList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
-            <DateTimePicker.MinuteList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+            <DateTimePicker.HourList classNames={LIVE_LIST_CN} />
+            <DateTimePicker.MinuteList classNames={LIVE_LIST_CN} />
           </div>
         </div>
       </DateTimePicker.Popover>


### PR DESCRIPTION
Two polish follow-ups from the PR-3 ([#113](https://github.com/jiji-hoon96/kalyx/pull/113)) code review. Library code untouched, no behavior change.

## 1. PreviewPanel.tsx — DRY classNames

The same \`{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }\` block was inlined 4× across TimePicker and DateTimePicker previews. Extracted to module constants:

\`\`\`tsx
const LIVE_LIST_CN = {
  root: 'kx-live-list',
  option: 'kx-live-option',
  optionSelected: 'kx-live-option-selected',
} as const;

const LIVE_AMPM_CN = {
  root: 'kx-live-ampm',
  option: 'kx-live-ampm-btn',
  optionSelected: 'kx-live-ampm-selected',
} as const;
\`\`\`

Runtime effect: identical. If \`.kx-live-*\` ever renames, future edits are one place instead of four.

## 2. PickerGrid.module.css — last 5 Infima → Aurora

PR-3 migrated \`.section / .card / .card:hover\` to Aurora tokens per plan §5.4 scope. The header/body strings (\`.eyebrow / .heading / .label / .oneLine / .cta\`) still referenced \`--ifm-*\`. Closing the gap:

| Class | Before | After |
|---|---|---|
| \`.eyebrow\` | \`var(--ifm-color-primary)\` | \`var(--kx-primary)\` |
| \`.heading\` | \`var(--ifm-heading-color)\` | \`var(--kx-fg)\` |
| \`.label\` | \`var(--ifm-heading-color)\` | \`var(--kx-fg)\` |
| \`.oneLine\` | \`var(--ifm-color-emphasis-700)\` | \`var(--kx-fg-muted)\` |
| \`.cta\` | \`var(--ifm-color-primary)\` | \`var(--kx-primary)\` |

## Test plan
- [x] \`pnpm typecheck\` PASS
- [x] \`pnpm build\` PASS (packages)
- [x] \`pnpm exec docusaurus build\` PASS (en + ko, after \`docusaurus clear\`)
- [ ] Vercel preview: landing PickerGrid section heading/eyebrow/cards still readable, hover effect intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)