### PR TITLE
chore(docs-site): refresh announcementBar + troubleshooting links for 1.0 stable

### DIFF
--- a/apps/docs-site/docs/troubleshooting.md
+++ b/apps/docs-site/docs/troubleshooting.md
@@ -198,4 +198,5 @@ Kalyx's `@kalyx/react` is ~15 KB gzipped (CI ceiling 16 KB). If your bundle is l
 
 - Search [existing issues](https://github.com/jiji-hoon96/kalyx/issues)
 - Open a [bug report](https://github.com/jiji-hoon96/kalyx/issues/new?template=bug_report.yml)
-- For v1.0 RC feedback, use the [RC feedback template](https://github.com/jiji-hoon96/kalyx/issues/new?template=v1-rc-feedback.yml)
+- Request a [feature](https://github.com/jiji-hoon96/kalyx/issues/new?template=feature_request.yml)
+- Ask a question in [Discussions](https://github.com/jiji-hoon96/kalyx/discussions)

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -90,9 +90,9 @@ const config: Config = {
 
   themeConfig: {
     announcementBar: {
-      id: 'v1-rc',
+      id: 'v1-stable',
       content:
-        'Kalyx v1.0 RC is out — try <code>pnpm add @kalyx/react@rc</code> and share feedback on <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/issues">GitHub</a>.',
+        'Kalyx 1.0 is out — <code>pnpm add @kalyx/react</code> · <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx">star on GitHub</a> · <a target="_blank" rel="noopener noreferrer" href="https://github.com/jiji-hoon96/kalyx/discussions">join Discussions</a>.',
       backgroundColor: '#5b4fe1',
       textColor: '#ffffff',
       isCloseable: true,

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
@@ -196,6 +196,7 @@ Kalyx's `@kalyx/react` is ~15 KB gzipped (CI ceiling 16 KB). If your bundle is l
 
 ## Still stuck?
 
-- Search [existing issues](https://github.com/jiji-hoon96/kalyx/issues)
-- Open a [bug report](https://github.com/jiji-hoon96/kalyx/issues/new?template=bug_report.yml)
-- For v1.0 RC feedback, use the [RC feedback template](https://github.com/jiji-hoon96/kalyx/issues/new?template=v1-rc-feedback.yml)
+- [기존 이슈](https://github.com/jiji-hoon96/kalyx/issues) 검색
+- [버그 리포트](https://github.com/jiji-hoon96/kalyx/issues/new?template=bug_report.yml) 작성
+- [기능 요청](https://github.com/jiji-hoon96/kalyx/issues/new?template=feature_request.yml) 보내기
+- [Discussions](https://github.com/jiji-hoon96/kalyx/discussions)에서 질문하기


### PR DESCRIPTION
## Summary

The site's announcement bar still advertised the **v1.0 RC** (`pnpm add @kalyx/react@rc`) and pointed feedback at GitHub Issues, even though v1.0.0 stable shipped 2026-06-08. New visitors landing on the docs site got a stale signal.

- Bar copy: RC install → `pnpm add @kalyx/react` + star on GitHub + join Discussions
- Bar `id`: `v1-rc` → `v1-stable` so anyone who dismissed the previous announcement sees the new one
- Dropped the stale "v1.0 RC feedback" link from `troubleshooting.md` (EN + KO mirror) in favour of feature requests + Discussions

## Test plan

- [ ] CI green
- [ ] Vercel preview shows the new bar text on `/` and `/ko/`

## Out of scope

- KO localization of the announcement bar itself (raw HTML from `themeConfig.announcementBar` is rendered on both locales — that's existing behaviour).
- `.github/ISSUE_TEMPLATE/v1-rc-feedback.yml` left in place for backward-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서화

* v1.0 정식 버전 출시에 따른 공식 문서 전체 업데이트: 공지사항 배너와 라이브러리 설치 명령어 현행화
* 사용자 지원 채널 확대: 문제 해결 가이드에 기능 요청, 버그 리포트, 기존 이슈 검색, 커뮤니티 Discussions 등 다양한 피드백 옵션 추가
* 한국어 및 영문 문서의 일관성 유지를 위한 동시 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->