### PR TITLE
docs(audit): 2026-06 competitive landscape + 1.0 functional audit + v1.1 roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@
 
 - **react-day-picker (41.7M/week, ~22KB gzip)**: Headless지만 Calendar Grid만. Input·TimePicker 없음. v9에서도 개발자가 3개 컴포넌트를 직접 조합해야 함.
 - **react-datepicker (4.7M/week, ~40-60KB gzip)**: 통합됐지만 CSS 필수 import, timezone 이슈(#1018, native Date 의존), Props 100개 이상.
-- **Ark UI**: Composition 패턴이지만 **TimePicker를 버그로 제거함**. 45개 이상 컴포넌트의 범용 UI 라이브러리.
+- **Ark UI**: Composition 패턴이지만 **standalone TimePicker 없음** — 시간은 `@internationalized/date`의 `CalendarDateTime`을 통해 DatePicker 내부에서만 다룬다. 45개 이상 컴포넌트의 범용 UI 라이브러리.
 - **React Aria**: 기능 완전하지만 복잡하고, `@internationalized/date` 의존 강제 (date-fns 비호환).
 - **Headless UI**: DatePicker 구현 거부 ("유지보수가 너무 큼").
 
@@ -582,9 +582,14 @@ pnpm changeset publish # npm 배포 (CI 자동)
 
 ---
 
-## 14. 현재 이니셔티브 (2026-06 기준 — v1.0.0 stable 출시 완료)
+## 14. 현재 이니셔티브 (2026-06-17 기준 — 1.0 stable + 1.0.x patch 준비)
 
-> v1.0.0 stable 출시 **완료** (2026-06-08). 이 섹션은 1.0 트랙 회고 + v1.1+ 다음 트랙으로 갱신됨.
+> v1.0.0 stable 출시 **완료** (2026-06-08). 2026-06-17 시점 외부 라이브러리 경쟁 리서치 + 내부 결함 audit 종합 결과는 별도 spec으로 분리.
+>
+> - **v1.1 로드맵 + 경쟁 라이브러리 분석**: [`docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md`](docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md)
+> - **1.0.x 결함/갭 카탈로그**: [`docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md`](docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md)
+>
+> 핵심 요약: 1.0 thesis (headless + 7 picker + adapter + ISO/UTC + ≤16KB) **그대로 유효**. Headless UI는 여전히 DatePicker 거부 (Discussion #289 open since 2021), react-day-picker v10.0.1은 cleanup release로 TimePicker/Input 없음, react-datepicker #1018은 docs-only "not a bug" 종결, MUI X 9.5.0은 58.2KB gzip에 Range가 Pro 유료. 새로 닫힌 갭은 Chakra v3.34 (March 2026) DatePicker 출시 — 단, Ark UI 경유 `@internationalized/date` 강결합 심화로 어댑터 패턴 비교 우위는 더 선명. 가장 큰 새 차원은 **Adobe stack의 Temporal-bound 아키텍처** — `@kalyx/adapter-temporal` 우선순위 상향.
 
 ### v1.0 완료 항목 (회고)
 
@@ -596,20 +601,64 @@ pnpm changeset publish # npm 배포 (CI 자동)
 - **번들**: ESM 15.63KB / CJS 15.76KB gzip (한계 16KB).
 - **테스트**: 497/497 unit pass, axe 14/14, e2e 31 scenarios.
 
-### v1.1+ 다음 트랙
+### Track A — 1.0.x patch (즉시, 2-4주)
 
-- **신규 어댑터 패키지**: `@kalyx/adapter-dayjs` (우선순위 1 — 사용자 약 절반이 dayjs), `@kalyx/adapter-luxon` (2 — enterprise/timezone 심화), `@kalyx/adapter-temporal` (Temporal API stable 도달 시).
-- **adapter conformance test suite**: 공통 24개 메서드 계약 검증을 `@kalyx/core/test-helpers`에 모듈화 (현재 adapter-date-fns 단독).
-- **`/headless` 가이드 한국어 번역**: `apps/docs-site/i18n/ko/.../guides/adapters.md` 현재 영문 그대로.
-- **번들 마진 모니터링**: default ESM 15.63KB / 한계 16KB. 새 기능 추가 시 17KB 상향 또는 다이어트 필요. 한계 수정 시 4파일 동기 (`scripts/check-bundle-size.js`, `tsup.config.ts`, `pr-check.yml`, `release.yml`).
-- **`verify-entry-split.mjs` CI 통합**: 현재 manual only. headless의 date-fns 부재는 핵심 약속 — PR check에 회귀 가드 권장.
+audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 이내. 자세한 근거는 `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md` 의 ID 참조.
 
-### v1.0 직후 처리 필요 (Follow-up)
+| # | 항목 | audit ID | 비고 |
+|---|---|---|---|
+| A1 | Escape 소비 + 이중 핸들러 수정 | A-D1, A-D2 | `usePopover.ts:92-96`, `Calendar.tsx:198-200` |
+| A2 | Popover 닫힐 때 focus restore | A-D3 | `usePopover.ts:58` guard 제거 (코멘트가 틀림) |
+| A3 | DST gap-time `setTimeInTimezone` snap-forward + JSDoc + 테스트 | T-D1 | `timezone.ts:199-225` |
+| A4 | DST ambiguous-time 명시 (`disambiguation: 'earlier'` 선언) + strict 테스트 | T-D2 | `timezone.test.ts:93-106` |
+| A5 | `verify-entry-split.mjs` PR check 통합 | B-D1 | `/headless` date-fns 부재 회귀 가드 |
+| A6 | gzip 측정 한 곳으로 통일 (Node `gzipSync`) | B-R1 | tsup / script / CI 한 소스 |
+| A7 | RangePicker hover preview 회귀 테스트 | TC-H1 | 0건 → 최소 1건 |
+| A8 | 롤링 커버리지: 반시간 offset (T-D3), `minDate`/`maxDate` × TZ (T-G1), value-on-disabled (TC-M1), controlled↔uncontrolled (TC-M2), props-during-open (TC-M3), DateTimePicker TZ round-trip (TC-M5), TimePicker step snap (TC-M6), WeekPicker year boundary (TC-M7) | various | 코드 변경 없이 테스트만 |
+
+### Track B — v1.1 minor (6-10주)
+
+어댑터 패턴을 "약속"에서 "검증된 실력"으로. 두 번째 어댑터 출시 + conformance suite + 누락 hook이 척추.
+
+| # | 항목 | 근거 |
+|---|---|---|
+| B1 | `@kalyx/adapter-dayjs` 출시 (P0) | Mantine + ~50% dayjs 사용자에게 drop-in headless 옵션 |
+| B2 | `@kalyx/core/test-helpers` 어댑터 conformance test suite | B1/B3/B6 unblock — adapter 작성자 테스트 부담 제거 |
+| B3 | `@kalyx/adapter-luxon` | B2 후 비용 낮음. enterprise/timezone 사용자 |
+| B4 | `useMonthPicker` / `useYearPicker` / `useWeekPicker` / `useDateTimePicker` hooks (`/headless` 전용) | audit API-G1. 기본 entry 번들 압력 회피 |
+| B5 | `DateTimePicker.Presets` (`/headless`에서 RangePicker.Presets 패턴 재사용) | audit API-G2 |
+| B6 | `@kalyx/adapter-temporal@0.x` (experimental, 별도 publish) | Adobe stack이 Temporal-bound — 늦으면 "Temporal-native"로 보이지 않음 |
+| B7 | `weekStartsOn` locale 자동 추론 (명시 prop override) | audit T-G2 |
+| B8 | `/headless` adapter guide 한국어 번역 | 주 성장 오디언스 KO 부재 |
+| B9 | 번들 margin 도구: `scripts/bundle-diff.mjs` + PR comment | audit B-D2 — ~380바이트 마진 가시화 |
+| B10 | a11y polish set: A-G1..A-G5 | DatePicker `announce()` 패리티, WeekPicker nav 결정, axe-when-open, Trigger focus-restore 테스트, week-mode aria-label |
+| B11 | docs-site comparison + MUI X Pro 유료 vs Kalyx "Free Range Picker, ≤16KB" 랜딩 비교 | research [R-6] — 마케팅 모먼트 |
+
+### Track C — v1.2 (다음 분기)
+
+- RTL 지원 + 테스트 (audit TC-M4)
+- `fast-check` property test 도입 (audit TC-H2)
+- `DisabledRule` 타입 narrowing per picker 또는 시맨틱 명시 (audit API-G3)
+- e2e 확장: mid-flight prop 변경, locale switch
+- per-dependency 번들 크기 리포트 (audit B-R2, 특히 `@floating-ui/react` 기여도)
+
+### Track D — Strategic watch (착수 보류)
+
+- **Persian/Buddhist/Islamic/Hebrew 등 비-Gregorian 캘린더**: 사용자 GitHub issue ≥3 또는 enterprise sponsor 1 시 착수. 현재 docs는 "Gregorian-only v1" 명시.
+- **React Native adapter**: 동일하게 보류.
+- **Storybook / visual regression**: 1.0.x ~ 1.1에서 시각 회귀 3건 이상 시 escalation.
+
+### v1.0 직후 처리 필요 (1.0 cleanup follow-up)
 
 1. `@kalyx/adapter-date-fns` npmjs.com Trusted Publisher 등록 — 1.0.0 publish는 토큰 수동이라 다음부터 OIDC + provenance 자동화.
 2. `@kalyx/adapter-date-fns@1.0.0` GitHub Release 수동 backfill (토큰 publish는 GH Release 미생성).
 3. `release.yml` 견고화 — ignored 패키지 changeset이 publish 차단 안 하도록 사전 검증 step.
 4. `apps/docs/CHANGELOG.md`, vitest lockfile drift refresh, `@floating-ui/react` 0.26→0.27 검토.
+
+### 카피 정정 (낮은 우선순위)
+
+- ~~**§1**: "Ark UI: TimePicker를 버그로 제거함" 문구~~ → **이 spec과 함께 정정 완료**: "standalone TimePicker 없음 — 시간은 `@internationalized/date`의 `CalendarDateTime`을 통해 DatePicker 내부에서만". 추가 README 정리는 README 다음 패스에서.
+- comparison.md / 마케팅: Adobe의 `@internationalized/date` 8KB/2.8KB는 Brotli이고 Kalyx 15.63KB는 gzip — 직접 비교 금지. 마케팅 카피에는 "~4× smaller than MUI X" (58.2/15.63 ≈ 3.7×) 정도가 정직한 한계.
 
 > 이전 RC 단계의 `.claude/skills/rc-announcement.md` 와 `.claude/skills/adapter-extraction.md` 는 회고 자료로 보존.
 

--- a/apps/docs-site/docs/comparison.md
+++ b/apps/docs-site/docs/comparison.md
@@ -13,6 +13,13 @@ cost, CSS lock-in vs missing primitives. Kalyx is built to occupy the middle:
 seven complete primitives, one composition API, no required stylesheet,
 ≤16 KB gzipped.
 
+Two updates since the table below was first compiled: Chakra UI v3.34 (March 2026)
+shipped a DatePicker built on Ark UI, and react-datepicker 9.1.0 (Nov 2025) added
+an optional `timeZone` IANA prop behind a `date-fns-tz` peer dependency. Neither
+changes Kalyx's position in the matrix — Chakra inherits Ark's
+`@internationalized/date` lock-in, and react-datepicker still uses native `Date`
+as its value type. Notes [^4] and [^15] below describe the deltas.
+
 ## Popularity at a glance
 
 Stars and weekly downloads move quickly — treat these as a snapshot, not a leaderboard.
@@ -37,13 +44,13 @@ For libraries that live in a monorepo (react-aria, ark-ui, @mui/x-date-pickers, 
 | Feature | react-datepicker | react-day-picker | react-calendar | react-native-calendars | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
-| RangePicker               | ✓ | partial[^1] | ✓ | ✓ | ✓ | partial[^1] | ✓ | ✓ | **✓** |
+| RangePicker               | ✓ | partial[^1] | ✓ | ✓ | ✓ | partial[^1] | Pro[^16] | ✓ | **✓** |
 | TimePicker                | partial[^2] | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
 | DateTimePicker            | partial[^2] | ✗ | ✗ | ✗ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
 | MonthPicker               | ✓ | ✗ | partial[^11] | ✓ | partial[^3] | ✗ | ✓ | ✓ | **✓** |
 | YearPicker                | ✓ | ✗ | partial[^11] | partial[^11] | ✗ | ✗ | ✓ | ✓ | **✓** |
 | WeekPicker                | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | **✓** |
-| Timezone-aware (IANA)     | partial[^4] | ✗ | ✗ | partial[^4] | ✓ | ✗ | ✓ | partial[^4] | **✓** |
+| Timezone-aware (IANA)     | partial[^4][^15] | ✗ | ✗ | partial[^4] | ✓ | ✗ | ✓ | partial[^4] | **✓** |
 | Zero CSS (no required import) | ✗ | ✓ | ✗ | partial[^12] | ✓ | ✓ | ✗ | ✗ | **✓** |
 | SSR-safe (App Router)     | partial[^5] | ✓ | ✓ | partial[^13] | ✓ | ✓ | partial[^5] | ✓ | **✓** |
 | RSC-friendly              | ✗ | ✓ | partial[^6] | ✗ | partial[^6] | ✓ | ✗ | partial[^6] | **✓** |
@@ -69,10 +76,14 @@ For libraries that live in a monorepo (react-aria, ark-ui, @mui/x-date-pickers, 
 [^12]: Inline styles by default; theme can be customized but there is no CSS-free escape hatch comparable to Kalyx.
 [^13]: React Native first; the web shim runs in browsers but the package isn't designed for Next.js App Router server boundaries.
 [^14]: shadcn/ui's `Calendar` component depends on react-day-picker; the count includes downstream adoption via shadcn rather than direct use only.
+[^15]: react-datepicker 9.1.0 (Nov 2025) added an optional `timeZone` prop accepting IANA identifiers, gated behind a `date-fns-tz` peer. Value type is still the native `Date` object, not an ISO string. Issue [#1018](https://github.com/Hacker0x01/react-datepicker/issues/1018) — open since 2017 — was closed 2025-12 as a docs-only resolution that classifies the original symptom as expected `Date` behavior.
+[^16]: MUI X DateRangePicker and TimeRangePicker live in `@mui/x-date-pickers-pro` and require a commercial Pro license. The free MIT `@mui/x-date-pickers` ships DatePicker, TimePicker, and DateTimePicker, but not the range pickers.
 
-> _Last measured 2026-06-11. Methodology: bundle sizes via bundlephobia + each
+> _Last measured 2026-06-17. Methodology: bundle sizes via bundlephobia + each
 > library's published `size-limit`; feature presence verified against each
-> library's v-latest docs at the time of writing._
+> library's v-latest docs at the time of writing. Adobe's `@internationalized/date`
+> size figures are reported in Brotli (not gzip) and are excluded from the bundle
+> chart to avoid mixing compression units._
 
 ## Bundle size at a glance
 
@@ -135,12 +146,27 @@ will never catch up on for its v1 line.
 **Use `react-aria`** if you're building a design system from scratch and want
 Adobe's a11y team standing behind every primitive. React Aria's accessibility
 guarantees and platform-aware behavior (selection models, focus rings, screen
-reader hints) are deeper than what we ship. The trade is more code to assemble
-and a strict dependency on `@internationalized/date`.
+reader hints) are deeper than what we ship. The trade is more code to assemble,
+a strict dependency on `@internationalized/date`, and inheriting whatever
+direction Adobe takes that package (which is positioned to be backed by TC39
+Temporal once browsers ship it — a feature, if you want it; a coupling, if you
+don't).
 
 **Use `@mui/x-date-pickers`** if your app already uses MUI. The visual / theme
 integration with MUI's design tokens is automatic; bringing Kalyx into a
-MUI codebase means rewriting `classNames` to map to MUI's class API.
+MUI codebase means rewriting `classNames` to map to MUI's class API. Note that
+the DateRangePicker and TimeRangePicker live in `@mui/x-date-pickers-pro` and
+require a commercial Pro license; Kalyx's RangePicker is MIT.
+
+**Use `ark-ui` (or Chakra UI v3.34+, which wraps it)** if you're committed to
+`@internationalized/date` for non-Gregorian calendars (Persian, Buddhist,
+Islamic, Hebrew). Ark v5.32 made that calendar story first-class; Kalyx is
+Gregorian-only in v1 and that's not changing soon.
+
+**Use `@mantine/dates`** if you've already standardized on dayjs and want
+Mantine's batteries-included form integration. Mantine declares dayjs as a
+non-negotiable peer; if dayjs isn't in your tree, the marginal install cost is
+real.
 
 In every other case — modern Next.js / Remix app, headless styling story, ISO
 strings as your storage primitive, single-digit-KB bundle target — Kalyx is

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/comparison.md
@@ -13,6 +13,13 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
 중간을 차지하도록 설계됐습니다 — 7개의 완전한 프리미티브, 하나의 조합 API,
 강제 스타일시트 없음, 16 KB gzip 이하.
 
+아래 표를 처음 작성한 뒤 두 가지 변화가 있었습니다. Chakra UI v3.34 (2026-03)
+가 Ark UI 기반 DatePicker를 출시했고, react-datepicker 9.1.0 (2025-11)
+이 `date-fns-tz` peer 뒤에 가려진 `timeZone` IANA prop을 선택적으로 추가했습니다.
+두 변화 모두 매트릭스 안에서의 Kalyx 위치를 바꾸지 않습니다 — Chakra는 Ark의
+`@internationalized/date` 강결합을 그대로 상속하고, react-datepicker는 여전히
+native `Date`를 값 타입으로 사용합니다. 자세한 차이는 각주 [^4]/[^15]/[^16].
+
 ## 인기도 한눈에
 
 별 수와 주간 다운로드는 빠르게 움직인다 — 리더보드가 아니라 스냅샷으로 받아들이면 된다.
@@ -37,13 +44,13 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
 | 기능 | react-datepicker | react-day-picker | react-calendar | react-native-calendars | react-aria | ark-ui | @mui/x-date-pickers | @mantine/dates | **Kalyx** |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | DatePicker                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **✓** |
-| RangePicker               | ✓ | 부분[^1] | ✓ | ✓ | ✓ | 부분[^1] | ✓ | ✓ | **✓** |
+| RangePicker               | ✓ | 부분[^1] | ✓ | ✓ | ✓ | 부분[^1] | Pro[^16] | ✓ | **✓** |
 | TimePicker                | 부분[^2] | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ | ✓ | **✓** |
 | DateTimePicker            | 부분[^2] | ✗ | ✗ | ✗ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
 | MonthPicker               | ✓ | ✗ | 부분[^11] | ✓ | 부분[^3] | ✗ | ✓ | ✓ | **✓** |
 | YearPicker                | ✓ | ✗ | 부분[^11] | 부분[^11] | ✗ | ✗ | ✓ | ✓ | **✓** |
 | WeekPicker                | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | **✓** |
-| Timezone (IANA)           | 부분[^4] | ✗ | ✗ | 부분[^4] | ✓ | ✗ | ✓ | 부분[^4] | **✓** |
+| Timezone (IANA)           | 부분[^4][^15] | ✗ | ✗ | 부분[^4] | ✓ | ✗ | ✓ | 부분[^4] | **✓** |
 | Zero CSS (강제 import 없음) | ✗ | ✓ | ✗ | 부분[^12] | ✓ | ✓ | ✗ | ✗ | **✓** |
 | SSR 안전 (App Router)     | 부분[^5] | ✓ | ✓ | 부분[^13] | ✓ | ✓ | 부분[^5] | ✓ | **✓** |
 | RSC 친화                  | ✗ | ✓ | 부분[^6] | ✗ | 부분[^6] | ✓ | ✗ | 부분[^6] | **✓** |
@@ -69,9 +76,13 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
 [^12]: 기본은 인라인 스타일이고, 테마 커스터마이징은 가능하지만 Kalyx 수준의 CSS-free 옵트아웃은 없다.
 [^13]: React Native 우선. 웹 shim으로 브라우저에서 동작하긴 하지만 Next.js App Router의 server boundary용으로 설계되지 않았다.
 [^14]: shadcn/ui의 `Calendar` 컴포넌트가 react-day-picker를 dependency로 쓴다 — 직접 사용자보다 다운스트림 채택분이 큰 비중.
+[^15]: react-datepicker 9.1.0 (2025-11)은 `date-fns-tz` peer 뒤에 가려진 선택적 `timeZone` prop을 추가했다. 값 타입은 여전히 native `Date` 객체이고 ISO string이 아니다. 2017년부터 열려있던 이슈 [#1018](https://github.com/Hacker0x01/react-datepicker/issues/1018)은 2025-12에 docs-only 결정으로 마감됐고, 원래 증상은 "expected `Date` behavior"라고 분류됐다.
+[^16]: MUI X DateRangePicker / TimeRangePicker는 `@mui/x-date-pickers-pro`에 들어있고 상업 Pro 라이선스가 필요하다. 무료 MIT `@mui/x-date-pickers`는 DatePicker, TimePicker, DateTimePicker는 포함하지만 range pickers는 포함하지 않는다.
 
-> _2026-06-11 기준 측정. 방법론: 번들 크기는 bundlephobia + 각 라이브러리의 공식
-> `size-limit`으로 측정, 기능 유무는 각 라이브러리의 v-latest 문서로 검증._
+> _2026-06-17 기준 측정. 방법론: 번들 크기는 bundlephobia + 각 라이브러리의 공식
+> `size-limit`으로 측정, 기능 유무는 각 라이브러리의 v-latest 문서로 검증.
+> Adobe의 `@internationalized/date` 크기 수치는 Brotli (gzip 아님)이고, 압축
+> 단위 혼동을 피하기 위해 번들 차트에서는 제외했다._
 
 ## 한 눈에 보는 번들 크기
 
@@ -134,12 +145,25 @@ CSS 강제 vs 빠진 프리미티브라는 실제 트레이드오프를 받아�
 **`react-aria`를 쓰세요** — 디자인 시스템을 처음부터 만들고 모든 프리미티브에
 Adobe의 접근성 팀이 보증해주길 원한다면. React Aria의 접근성 보장과 플랫폼
 인식 동작(선택 모델, focus ring, screen reader hint)은 우리가 제공하는 것보다
-깊습니다. 트레이드오프는 더 많은 조립 코드와 `@internationalized/date`에 대한
-엄격한 의존성입니다.
+깊습니다. 트레이드오프는 더 많은 조립 코드, `@internationalized/date`에 대한
+엄격한 의존성, 그리고 Adobe가 그 패키지를 어디로 끌고 가든 따라가야 한다는
+점입니다 (그 패키지는 브라우저가 TC39 Temporal을 출하하면 Temporal을 백엔드로
+삼도록 포지셔닝돼 있다 — 원한다면 기능, 원치 않는다면 결합).
 
 **`@mui/x-date-pickers`를 쓰세요** — 앱이 이미 MUI를 사용한다면. MUI 디자인
 토큰과의 시각/테마 통합이 자동입니다. MUI 코드베이스에 Kalyx를 도입하려면
-`classNames`를 MUI의 클래스 API로 매핑하는 재작성이 필요합니다.
+`classNames`를 MUI의 클래스 API로 매핑하는 재작성이 필요합니다. 단,
+DateRangePicker와 TimeRangePicker는 `@mui/x-date-pickers-pro`에 들어있고
+상업 Pro 라이선스가 필요합니다 — Kalyx의 RangePicker는 MIT입니다.
+
+**`ark-ui` (또는 그것을 wrap한 Chakra UI v3.34+)를 쓰세요** — Persian, Buddhist,
+Islamic, Hebrew 등 비-Gregorian 캘린더를 위해 `@internationalized/date`에
+이미 들어가 있다면. Ark v5.32부터 비-Gregorian 캘린더 스토리가 first-class가
+됐습니다. Kalyx는 v1 라인에서 Gregorian-only이고 가까운 시일 내에 바뀌지 않습니다.
+
+**`@mantine/dates`를 쓰세요** — dayjs로 표준화돼 있고 Mantine의 batteries-included
+폼 통합을 원한다면. Mantine은 dayjs를 협상 불가능한 peer로 선언합니다. dayjs가
+트리에 없다면 추가 설치 비용이 실제로 발생합니다.
 
 그 외 모든 경우 — 모던 Next.js / Remix 앱, headless 스타일링 스토리, 저장
 프리미티브로 ISO string, 한 자릿수 KB 번들 목표 — Kalyx가 올바른 선택이

--- a/docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md
+++ b/docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md
@@ -1,0 +1,217 @@
+# 2026-06 Competitive Landscape and v1.1+ Roadmap
+
+**Date.** 2026-06-17
+**Author.** Maintainer (with multi-agent research + audit synthesis)
+**Companion.** `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md` (internal defect/gap catalog).
+**Sources.** Multi-source primary-fetch with 3-vote adversarial verification (21 verified claims). Full research transcript: `/tmp/kalyx-research-report.md`.
+
+---
+
+## TL;DR
+
+The Kalyx 1.0 thesis — **headless + integrated DatePicker/TimePicker/Range/Input + adapter pattern + ISO/UTC strings + ≤16 KB gzip** — is structurally intact in mid-2026. None of the four library-shaped holes Kalyx targeted has closed:
+
+| 1.0 thesis | June 2026 status |
+|---|---|
+| Headless UI declines DatePicker | **Still declines.** Discussion #289 open since 2021, no maintainer answer, zero date components in source. |
+| react-day-picker has no Input/TimePicker | **Still doesn't.** v10.0.1 is a "cleanup release"; official docs explicitly say "DayPicker does not include a built-in time picker." |
+| react-datepicker has the #1018 timezone bug | **Closed as docs-only "not a bug."** 8-year issue resolved by `949cd8e` (Nov 2025, +2/+87 docs lines, zero source changes). Library still uses native `Date` as value. |
+| MUI X is heavy and partly paywalled | **Heavier and more paywalled.** 9.5.0 = 58.2 KB gzip, Range/Time-Range pickers explicitly require a commercial Pro license. |
+
+Two real shifts happened that should bend the roadmap:
+
+1. **Chakra UI v3.34 (March 2026) shipped a DatePicker** — but it inherits Ark UI's hard `@internationalized/date` dependency, which *deepened* in 2026 with `useDateFormatter` and Persian/Buddhist/Islamic/Hebrew calendar support all routed through that library. The "Chakra has nothing" narrative is dead; the "Adobe-stack lock-in" critique is sharper.
+2. **Adobe documents `@internationalized/date` as Temporal-bound** by design ("we hope to back the objects in this package with Temporal once browsers ship it"). The entire React Aria / Ark / Chakra stack is pre-positioned to inherit Temporal correctness for free. Kalyx's date-fns core is not.
+
+Combined with the internal audit's findings, the recommended v1.1+ ordering is below.
+
+---
+
+## Section 1 — What the 1.0 thesis got right (still moat)
+
+### 1.1 Headless DatePicker for Tailwind ecosystem
+Headless UI Discussion [#289](https://github.com/tailwindlabs/headlessui/discussions/289) remains open since 2021-03-25 with 118 +1 reactions, no maintainer answer, and verified-empty `packages/@headlessui-react/src/components` (retrieved 2026-06-17). Recent community comments (April 2025, February 2026) reaffirm the gap. Tailwind users still get redirected to React Aria.
+
+**Hold.** Kalyx is the only "headless + integrated + ≤16KB" option for that audience. Marketing investment here pays.
+
+### 1.2 Integrated TimePicker + DateTimePicker + RangePicker
+react-day-picker v10's "guides/timepicker" page (retrieved 2026-06-17) verbatim: "DayPicker does not include a built-in time picker." v10 added Hijri calendar, `resetOnSelect`, and `@daypicker/*` scoped add-ons — nothing on time selection or input integration.
+
+Ark UI does **not** have a standalone TimePicker as of v5.32.0 (the audit's prior CLAUDE.md claim "Ark UI removed TimePicker" was technically loose; more precisely, Ark folds time into DatePicker via `CalendarDateTime` from `@internationalized/date` — not a standalone component a Tailwind user can compose).
+
+**Hold.** Composition story remains uniquely complete in the headless category.
+
+### 1.3 ISO 8601 UTC string in/out + IANA timezone
+react-datepicker 9.1.0 (Nov 2025) added an optional `timeZone` IANA prop gated behind `date-fns-tz` peer (commit `2cd1b36`). But the library still uses `Date` as the value type, still ships CSS as side-effect, and #1018 was explicitly classified as "expected JavaScript `Date` behavior" rather than fixed.
+
+**Partially eroded but still distinctive.** Kalyx's ISO-string-everywhere + DST-aware civil-midnight is architecturally separate from "opt into date-fns-tz." Worth keeping the moat sharp; see §2 audit follow-ups (T-D1, T-D2).
+
+### 1.4 Free Range Picker
+MUI X 9.5.0 = 58.2 KB gzip ([bundlephobia, retrieved 2026-06-17](https://bundlephobia.com/package/@mui/x-date-pickers)); `DateRangePicker` and `TimeRangePicker` ship only in `@mui/x-date-pickers-pro` and require a commercial Pro license. That license is the strongest single positioning argument Kalyx has gained since 1.0.
+
+**Lean in.** Marketing/comparison work (see §3 item M1) should explicitly contrast.
+
+### 1.5 Adapter pattern + Headless entry
+@mantine/dates@9.3.2 declares `dayjs` as a non-negotiable peer ("dayjs is a required dependency – you cannot change it to another date library"). Ark UI 5.32 made `@internationalized/date` deeper, not shallower. **No mainstream React date library other than Kalyx offers adapter pluggability.** The `/headless` entry split (1.0.0 ship) and the standalone `@kalyx/adapter-date-fns` package mean Kalyx is the only mainstream option whose date library is a build-time choice.
+
+**Hold and extend.** This is the single most defensible architectural choice. v1.1 should make the implicit promise explicit by shipping a second adapter.
+
+---
+
+## Section 2 — What the 1.0 thesis underweighted (new dimensions)
+
+### 2.1 Temporal-readiness as a future feature
+The single most important dimension that didn't exist when Kalyx was scoped: **Adobe explicitly documents that `@internationalized/date` is Temporal-shaped and will be backed by Temporal once browsers ship it** ([Adobe docs, retrieved 2026-06-17](https://react-aria.adobe.com/internationalized/date/)). The whole React Aria + Ark + Chakra ecosystem is positioned to inherit Temporal correctness without API change.
+
+Kalyx's adapter pattern is the right shape to absorb this, but only if an experimental `@kalyx/adapter-temporal` exists before Temporal ships. Adobe's stack will appear "Temporal-native" to a market unfamiliar with the polyfill timing.
+
+**Implication.** Promote Temporal adapter from "v1.1+ when Temporal stabilizes" (current CLAUDE.md §14) to **v1.1 experimental track** — even pre-shipping, it can target polyfilled environments and Node 22+. The optionality matters more than the immediate user count.
+
+### 2.2 The Adobe-stack as a single competitor
+React Aria, Ark UI, and Chakra UI v3.34 now all compose `@internationalized/date`. They share a 2.8–8 KB Brotli (not gzip) tax for the date library plus their UI primitives. This is a **single bloc**, not three separate competitors. The architectural critique — date-library lock-in, Brotli-only size claim, calendar-system feature surface routed through one third-party — applies to all three at once.
+
+**Implication.** Comparison-page copy should treat them as a category, not enumerate separately. (Mantine + dayjs is its own bloc.)
+
+### 2.3 Non-Gregorian calendar feature creep
+Ark v5.32.0 (2026-02-21) added Persian / Buddhist / Islamic / Hebrew calendars via `@internationalized/date`. react-day-picker v10 added Hijri + `@daypicker/persian|hebrew|buddhist|ethiopic|islamic` packages. This is a market signal — non-Gregorian calendar support is now table-stakes in the high-end of the market.
+
+**Implication.** Kalyx should be **explicit** that Gregorian-only is the v1 line. Don't compete on calendar count; acknowledge the gap on comparison page so it doesn't read as undisclosed limitation.
+
+### 2.4 React 19 RSC, but not yet a date-picker story
+React 19 adoption is mainstream by mid-2026 but no major picker has shipped meaningful RSC server-component primitives (all major libraries remain `'use client'`). RSC compat for Kalyx today means "works behind a client boundary" — which is what every competitor also does. **Not a v1.1 differentiator.** Worth a docs note ("use behind `'use client'`"), not engineering work.
+
+### 2.5 AI/LLM agent integration
+Not surfaced in this round of research as a date-picker-specific category. **No action.**
+
+---
+
+## Section 3 — Recommended v1.1+ roadmap (impact × effort)
+
+Priorities are derived from intersecting research findings with the internal audit (`2026-06-17-kalyx-1.0-functional-audit.md`). Each item references either the research finding `[R-n]` or the audit ID (`A-Dx`, `T-Dx`, `B-Dx`, etc.) — or both.
+
+### Track A — 1.0.x patch (next 2-4 weeks)
+
+Items below are correctness or contract enforcement. No public API change.
+
+| # | Item | Refs | Effort |
+|---|---|---|---|
+| A1 | Escape consumption + double-handler fix | A-D1, A-D2 | XS |
+| A2 | Focus restoration on popover close | A-D3 | S |
+| A3 | DST gap-time: snap-forward + document + test | T-D1 | M |
+| A4 | DST ambiguous-time: document choice + strict test | T-D2 | XS |
+| A5 | `verify-entry-split.mjs` in `pr-check.yml` | B-D1, [R-4] | XS |
+| A6 | Gzip-measurement single source of truth | B-R1 | XS |
+| A7 | RangePicker hover preview regression test | TC-H1 | S |
+| A8 | Rolling coverage adds: fractional offsets (T-D3), `minDate`/`maxDate` × TZ (T-G1), value-on-disabled (TC-M1), controlled↔uncontrolled (TC-M2), props-during-open (TC-M3), DateTimePicker TZ round-trip (TC-M5), TimePicker step snap (TC-M6), WeekPicker year boundary (TC-M7) | various | XS each |
+
+Bundle impact target: **zero new code paths, ≤50 bytes net.**
+
+### Track B — v1.1 minor (next 6-10 weeks)
+
+The minor that turns the adapter pattern from a promise into a demonstrated capability. Anchor: **two real adapters in npm + the conformance suite that proves they're interchangeable.**
+
+| # | Item | Refs | Effort | Impact |
+|---|---|---|---|---|
+| B1 | `@kalyx/adapter-dayjs` package | CLAUDE.md §14 (existing), [R-7] | M | High |
+| B2 | `@kalyx/core/test-helpers` adapter conformance suite | CLAUDE.md §14 (existing) | M | High (unblocks B1, B3, B6) |
+| B3 | `@kalyx/adapter-luxon` package | CLAUDE.md §14 (existing) | S-M (after B2) | Med |
+| B4 | `useMonthPicker` / `useYearPicker` / `useWeekPicker` / `useDateTimePicker` hooks (ship under `/headless` only) | API-G1 | M | Med |
+| B5 | `DateTimePicker.Presets` (compose existing Presets pattern) | API-G2 | M | Med |
+| B6 | `@kalyx/adapter-temporal` (experimental flag) | [R-5], CLAUDE.md §14 | M-L | Strategic |
+| B7 | `weekStartsOn` locale inference (explicit prop overrides) | T-G2 | XS | Low-Med |
+| B8 | Korean translation of `/headless` adapter guide | CLAUDE.md §14 (existing), [R-7] | S | Med |
+| B9 | Bundle margin tooling: `scripts/bundle-diff.mjs` + PR comment | B-D2, CLAUDE.md §14 (existing) | M | Med |
+| B10 | a11y polish set: A-G1 (`announce()` parity), A-G2 (WeekPicker nav decision), A-G3 (axe-when-open for DatePicker), A-G4 (Trigger focus-restore tests), A-G5 (week-mode aria-label) | various | S | Low-Med |
+| B11 | Public docs: comparison page refresh + landing comparison vs MUI X Pro paywall | [R-6] | S | High |
+
+Bundle impact target: hooks (B4) and Presets (B5) **must ship under `/headless` exports only**, leaving the default entry untouched. Margin pressure on the default entry must not increase.
+
+### Track C — v1.2 minor (next quarter)
+
+Items that need a clear user signal or that depend on Track B landing.
+
+| # | Item | Refs | Effort | Impact |
+|---|---|---|---|---|
+| C1 | RTL support + tests | TC-M4 | M | Med (i18n market) |
+| C2 | Adopt `fast-check` for `@kalyx/core` date math | TC-H2 | M | Med (correctness) |
+| C3 | `DisabledRule` type narrowing per picker, OR documented semantics | API-G3 | S | Low |
+| C4 | More e2e: mid-flight prop changes, locale switch | structural | M | Low-Med |
+| C5 | Per-dependency bundle size report (`@floating-ui/react` etc.) | B-R2 | S | Low |
+
+### Track D — Strategic watch (no commitment yet)
+
+| # | Item | Trigger |
+|---|---|---|
+| D1 | Persian/Buddhist/Islamic/Hebrew calendar support | A concrete user request, OR competitor catches up enough that omission becomes a marketing liability. (Currently: Kalyx is honest about Gregorian-only; that's enough.) |
+| D2 | React Native adapter | Already deferred in CLAUDE.md §14. Hold. |
+| D3 | Storybook / visual regression | If 3+ a11y or visual regressions slip through in 1.0.x or 1.1, escalate. |
+
+### Marketing / non-engineering
+
+| # | Item | Refs |
+|---|---|---|
+| M1 | "Free MIT Range Picker, ≤16KB, headless, no Pro license" landing comparison | [R-6] |
+| M2 | Soften CLAUDE.md §1 line about "Ark UI removed TimePicker." More accurate: "Ark UI has no standalone TimePicker; time is folded into DatePicker via `@internationalized/date`." | [R-4] |
+| M3 | Add note on Brotli vs gzip when citing `@internationalized/date` 8 KB / 2.8 KB figures. Don't put a Brotli number next to a gzip number without normalizing. | research caveat |
+| M4 | Adobe-stack as a single category in comparison copy (React Aria + Ark + Chakra v3.34+ all share the `@internationalized/date` tax). | [R-4], [R-5] |
+| M5 | Honest disclosure: Gregorian-only for v1; non-Gregorian on D1. | [R-2], [R-4] |
+
+---
+
+## Section 4 — Reordering CLAUDE.md §14 (next track)
+
+Current §14 lists four v1.1+ tracks (`@kalyx/adapter-dayjs`, conformance suite, KO `/headless` translation, bundle margin monitoring) plus four "1.0 follow-ups" (Trusted Publisher registration, GitHub release backfill, release.yml hardening, docs CHANGELOG / lockfile refresh).
+
+This spec recommends keeping all eight items and adding the rest. Updated §14 (see "Section 5" below) should:
+
+1. Move the 1.0 follow-ups (Trusted Publisher etc.) to a dedicated "1.0 cleanup" subsection — they're still live but tactically narrow.
+2. Promote `@kalyx/adapter-dayjs` + adapter conformance suite to "1.1 P0" — they're the spine of the minor.
+3. Add **1.0.x patch** items (A1-A8 from this spec) as a new immediate subsection.
+4. Add `@kalyx/adapter-temporal` (experimental) as a 1.1 strategic track.
+5. Add B11 (marketing comparison vs MUI X Pro) as a near-term marketing item.
+
+---
+
+## Section 5 — Decisions to make before starting Track B
+
+These are forks where I should not start work without a decision:
+
+1. **B6 (Temporal adapter) flag plumbing.** Ship as `@kalyx/adapter-temporal@0.x` separately published, OR `@kalyx/adapter-temporal` published but with a runtime guard that throws unless `globalThis.Temporal` exists? **Recommendation:** separately published `@kalyx/adapter-temporal@0.x` (matches the adapter package pattern; no surprises in the default install).
+2. **B4 (missing hooks) entry placement.** Headless-only, OR default entry too? **Recommendation:** headless-only. The default entry is for users who want components; if they want hooks, they're already on `/headless`. Saves bundle pressure.
+3. **B11 marketing claim shape.** Claim "5× smaller than MUI X" using 58.2 / 15.63 ≈ 3.7× — **NOT 5×**. Keep it accurate; "nearly 4× smaller" is fine. Don't put the Brotli number from Adobe next to gzip.
+4. **A3 (DST gap-time) policy.** Snap-forward (recommended) vs. throw. **Recommendation:** snap-forward. Matches `@internationalized/date` / Temporal `disambiguation: 'earlier'`-then-forward; least surprising for a UI picker.
+5. **D1 trigger threshold.** What signal moves non-Gregorian from "watch" to "do"? **Recommendation:** ≥3 distinct GitHub issues asking for it, OR a single enterprise sponsor.
+
+---
+
+## Section 6 — What this spec does NOT cover
+
+- Pricing / commercial Kalyx offering. Out of scope.
+- Detailed designs for each adapter package — those become their own specs at execution time.
+- Per-PR work breakdown for Track A. Treated as a single patch series; will be planned with writing-plans skill when starting.
+- React Native adapter. Deferred per CLAUDE.md §14.
+
+---
+
+## Section 7 — Followups
+
+When Track A patches ship, revisit:
+
+1. Does the ~380-byte bundle margin hold? If so, defer B9 (bundle-diff tooling).
+2. Did A3's snap-forward policy generate user feedback? If users want `disambiguation` as a configurable option, fold into B6/B7.
+3. Re-check Radix UI date-picker status (research caveat #1) and `react-calendar` / `react-native-calendars` (research caveat #4) — they were not fetched this round.
+4. Re-check TC39 Temporal stage / Chromium intent-to-ship. If Temporal hits Stage 4 in 2026 H2, B6 moves from "experimental" to "stabilize."
+
+---
+
+## Source ledger
+
+Primary-source URLs retrieved 2026-06-17 (full transcript in `/tmp/kalyx-research-report.md`):
+
+- Headless UI: `tailwindlabs/headlessui` Discussion #289, components source tree.
+- react-day-picker: `daypicker.dev/upgrading`, `/guides/timepicker`, `/guides/input-fields`.
+- react-datepicker: GitHub issue #1018, commit `949cd8e`, `docs/timezone.md`, npm registry, weekly downloads API.
+- Chakra UI v3.34: blog post, `chakra-ui.com/docs/components/date-picker`, `ark-ui.com/docs/components/date-picker`, Ark UI v5.32.0 changelog.
+- React Aria: `react-aria.adobe.com/internationalized/date/`.
+- MUI X: `mui.com/x/introduction/licensing/`, bundlephobia API, npm registry.
+- Mantine: `mantine.dev/dates/getting-started`, npm registry, bundlephobia.

--- a/docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md
+++ b/docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md
@@ -1,0 +1,327 @@
+# Kalyx 1.0.x Functional Audit (2026-06-17)
+
+**Scope.** Audit Kalyx (`@kalyx/react@1.0.1`, `@kalyx/core@1.0.0`, `@kalyx/adapter-date-fns@1.0.0`) for defects, gaps, and risks across 5 dimensions: a11y/keyboard, timezone/DST, bundle/tree-shake, 7-picker API consistency, test coverage.
+
+**Method.** 5 parallel Explore agents on commit `4adef81`, with selected claims hand-verified against source.
+
+**Audience.** Kalyx maintainers planning 1.0.x patch + 1.1 minor + later tracks.
+
+**Bottom line.** No correctness bugs that block production for the documented happy path. Three confirmed user-visible defects (Escape focus drop, Escape bubbling, silent DST gap-time corruption) and one CI safety gap (split-entry verification not gated). The 1.0 surface is honest about what it shipped, but a ~2.4% bundle margin and the absence of property-based testing make the next minor risky without active mitigation.
+
+---
+
+## 1. a11y / Keyboard
+
+### Defects (must fix before next release)
+
+#### A-D1 — Escape keydown is not consumed
+**Where.** `packages/react/src/hooks/usePopover.ts:92-96`
+
+```ts
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    close();
+  }
+}
+document.addEventListener('keydown', handleKeyDown);
+```
+
+**Problem.** Escape is captured at the document level and `close()` is called, but neither `e.preventDefault()` nor `e.stopPropagation()` is invoked. A parent dialog or form with its own Escape handler — common in modals (`<dialog>`, Radix Dialog, modal route patterns) — fires simultaneously and closes the outer container.
+
+**Reproduction.**
+```tsx
+<Modal onClose={...}>          // also listens for Escape
+  <DatePicker.Root> ... </DatePicker.Root>
+</Modal>
+// User opens picker → presses Esc → BOTH picker AND modal close.
+```
+
+**Fix.** Inside `handleKeyDown` add `e.preventDefault(); e.stopPropagation();` when `isOpen` and `e.key === 'Escape'`. Document the boundary semantics in the JSDoc.
+
+**Severity.** Patch (1.0.x).
+
+#### A-D2 — Calendar grid Escape also unguarded
+**Where.** `packages/react/src/components/DatePicker/Calendar.tsx:198-200`
+
+```ts
+case 'Escape':
+  ctx.close();
+  return;
+```
+
+**Problem.** Same shape as A-D1 — the grid's own keydown listener consumes nothing. With the document-level handler also active, both fire (once on capture, once on bubble) and there is double work; combined with A-D1 the result is observably wrong (parent listeners run).
+
+**Fix.** Call `e.preventDefault()` and `e.stopPropagation()`. Tied to A-D1.
+
+**Severity.** Patch (1.0.x).
+
+#### A-D3 — Focus is dropped after closing the popover with the keyboard
+**Where.** `packages/react/src/hooks/usePopover.ts:50-62`
+
+```ts
+useEffect(() => {
+  if (isOpen) {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+  } else if (previousFocusRef.current) {
+    const el = previousFocusRef.current;
+    previousFocusRef.current = null;
+    if (el !== referenceRef.current && typeof el.focus === 'function') {
+      el.focus({ preventScroll: true });        // skipped when el === Input
+    }
+  }
+}, [isOpen, referenceRef]);
+```
+
+The justification comment reads "Input auto-opens on focus, which would immediately reopen the popover." That premise is wrong — verified in `packages/react/src/components/DatePicker/Input.tsx:60-69`:
+
+```ts
+// Open on an explicit pointer click, not on focus — tabbing between form
+// fields should not pop the calendar open, and restoring focus after a
+// selection would otherwise loop us back to open.
+const handleClick = useCallback(...)
+```
+
+`Input` opens on **click**, not focus. Restoring focus to it after close would *not* reopen the popover. The skip exists for an obsolete reason and produces an actual a11y regression for keyboard users:
+
+1. User clicks Input → focus on Input → popover opens.
+2. User arrow-keys into the calendar → focus moves onto a day button inside the popover.
+3. User presses Esc → popover unmounts → restoration runs.
+4. Restoration sees `previousFocusRef === Input (= referenceRef)` → **skips restore**.
+5. The day button is gone, the Input is unfocused; focus falls back to `<body>`.
+
+**Fix.** Remove the `el !== referenceRef.current` guard, OR replace it with a stricter test (only skip when the document focus didn't leave the reference during open). The minimal fix is to restore unconditionally — tabs from a closed popover land on the Input, which is the correct keyboard recovery point.
+
+**Severity.** Patch (1.0.x).
+
+### Gaps (worth fixing in 1.1)
+
+- **A-G1** — `DatePickerContext` has no `announce()` method. `RangePickerContext` does. Symmetrize.
+- **A-G2** — WeekPicker reuses `RangePicker.Calendar` with `selectionMode="week"` but keyboard navigation still moves day-by-day. Either implement week-stride navigation (Shift+Arrow → ±1 week) or document the design choice and lock it with a test.
+- **A-G3** — `axe` runs on closed-popover state for `DatePicker` but not on open. `RangePicker` tests both. Equalize.
+- **A-G4** — No test verifies that `Trigger` regains focus after popover close on any picker.
+- **A-G5** — In `selectionMode="week"`, day-button `aria-label` (`Calendar.tsx:412`) still describes a single day. Vary by selection mode so screen readers narrate the week span.
+
+### Risks
+
+- **A-R1** — Month-change announcement fires only on `Calendar` keyboard navigation, not on direct `setViewMonth()` from a parent. Edge but reachable.
+
+---
+
+## 2. Timezone / DST
+
+### Defects
+
+#### T-D1 — `setTimeInTimezone` silently corrupts non-existent civil times
+**Where.** `packages/core/src/utils/timezone.ts:199-225`
+
+**Behaviour observed.**
+```ts
+setTimeInTimezone(
+  '2026-03-08T12:00:00.000Z',    // base
+  { hours: 2, minutes: 30 },     // 2:30 AM in America/New_York doesn't exist
+  'America/New_York'
+)
+// → '2026-03-08T06:30:00.000Z'  (= 1:30 AM EST, BEFORE the gap)
+```
+
+The DST spring-forward at 02:00 → 03:00 means `02:30` never occurs. The function returns a value before the gap with no warning. The user picked "2:30 AM" and got "1:30 AM" back.
+
+**Possible policies.**
+1. **Snap-forward.** Return the equivalent post-DST instant (`03:30 EDT`).
+2. **Throw.** Surface the impossible time as an error.
+3. **Document and ignore.** Keep current behaviour; document it as "earliest valid offset" semantics.
+
+**Recommendation.** Snap-forward (option 1). It's what `@internationalized/date` does and what users intuitively expect ("the picker said 2:30, I get 2:30-ish"). Throwing is too aggressive for what looks like a normal click. Document in JSDoc + add a regression test.
+
+**Severity.** Patch (1.0.1 → 1.0.2). Decide and ship.
+
+#### T-D2 — Ambiguous fall-back times are silently implementation-dependent
+**Where.** `packages/core/src/__tests__/timezone.test.ts:93-106`
+
+```ts
+expect(['2026-11-01T05:30:00.000Z', '2026-11-01T06:30:00.000Z']).toContain(result);
+```
+
+The test acknowledges both EDT (first 1:30) and EST (second 1:30) are "valid", but doesn't enforce a choice. Callers cannot rely on deterministic output.
+
+**Recommendation.** Document the choice (earlier-offset is the conventional default — matches `Intl.DateTimeFormat` round-trip and Temporal's `disambiguation: 'earlier'`). Replace `.toContain` with a strict equality assertion.
+
+**Severity.** Patch.
+
+#### T-D3 — Half-hour and 45-minute timezones untested
+**Where.** `packages/core/src/__tests__/timezone.test.ts` (no coverage).
+
+`getTimezoneOffsetMinutes` uses `Math.round((asUtcEpoch - utc.getTime()) / 60_000)` which handles fractional offsets correctly in principle, but Asia/Kolkata (+5:30), Asia/Kathmandu (+5:45), and Australia/Eucla (+8:45) are unverified. India alone is ~280M+ React users — this is not a niche locale.
+
+**Fix.** Add three tests; no code change expected.
+
+**Severity.** Patch (test only).
+
+### Gaps
+
+- **T-G1** — `minDate`/`maxDate` always compare UTC instants (`packages/core/src/utils/calendar.ts:211-220`). The docs don't clarify whether `minDate="2026-06-17T00:00:00.000Z"` with `displayTimezone="Asia/Seoul"` means "≥ that UTC instant" or "≥ display-timezone midnight of that day". Pick one (UTC-only is simpler and matches the ISO-string-everywhere story), document it, and lock with a test that exercises a near-midnight value across +9:00.
+- **T-G2** — `weekStartsOn` is required prop, never inferred from `locale`. `en-US`→0, `fr-FR`→1, `ar-SA`→6 are well-known. Adding inference (with explicit override) is a small DX win.
+- **T-G3** — Pacific/Niue (UTC−11) and similar negative offsets that cross UTC day boundaries are not tested for `todayInTimezone` / `isSameDayInTimezone`.
+
+### Risks
+
+- **T-R1** — Europe/London March-29 DST transition lands on a month boundary in some years; month-navigation arithmetic across it is unverified.
+- **T-R2** — Feb 29 in a non-UTC timezone (civil Feb 29 ≠ UTC Feb 29) round-trip untested.
+
+---
+
+## 3. Bundle / Tree-shake
+
+### Defects
+
+#### B-D1 — Split-entry verification is not in CI
+**Where.** `packages/react/scripts/verify-entry-split.mjs:19` reads:
+
+> "Manual verification only — not wired into CI."
+
+`apps/.github/workflows/pr-check.yml` measures default-entry gzip but never runs `verify-entry-split.mjs` or `scripts/check-tree-shaking.js`. The `/headless` entry's "zero date-fns" promise — Kalyx's core marketing line for 2026 — is only guarded by a script developers may forget to run.
+
+**Fix.** Add a CI step in `pr-check.yml`:
+
+```yaml
+- name: Verify headless entry isolation
+  run: pnpm --filter @kalyx/react exec node scripts/verify-entry-split.mjs
+```
+
+CLAUDE.md §14 already flags this; this audit elevates it from "v1.1+ track" to **defect/patch** because the contract is shipped but not enforced.
+
+**Severity.** Patch.
+
+#### B-D2 — Bundle margin is ~2.4% (≈ 380 bytes)
+**Where.** Default ESM = 15.63 KB gzip = ~16,005 bytes / 16,384 byte limit (verified `pnpm --filter @kalyx/react build` 2026-06-17). Margin ≈ 380 bytes.
+
+A single typical feature addition costs 50-400 bytes; multiple recent features (`filterTime`, MonthPicker disabled month, YearPicker disabled year) each consumed ~1 KB and triggered the 12→13→14→15→16 KB limit walks documented in CLAUDE.md §2. The next minor feature is highly likely to breach 16 KB. The current mitigation is developer discipline — no automated "this PR added X bytes" report.
+
+**Recommendation (1.1).** Build `scripts/bundle-diff.mjs` invoked in CI that posts a PR comment with per-export and per-feature size deltas. Same idea as `size-limit`'s comparison output but specific to Kalyx's entry split.
+
+**Severity.** Risk → 1.1 track.
+
+### Risks
+
+- **B-R1** — Three gzip implementations measure the bundle:
+  - `tsup.config.ts` and `scripts/check-bundle-size.js`: Node `gzipSync` (level 6 default).
+  - `pr-check.yml` lines 103-104: shell `gzip -c` (also level 6, different implementation).
+  - Variance: estimated 10-30 bytes. Material against a ~380-byte margin. Standardize on one (Node `gzipSync`) by having the CI step invoke `check-bundle-size.js` directly.
+- **B-R2** — `@floating-ui/react`'s contribution to the 16 KB is unmeasured. Add a per-dependency size report.
+
+### OK
+
+- Public surface in `packages/react/src/index.ts` is clean — no internal Context leakage.
+- `sideEffects: false` set on every package.
+- `verify-entry-split.mjs` (when run manually) confirms `/headless` has zero `date-fns` / `adapter-date-fns` imports.
+- `pnpm` workspace dedupe handles the `@kalyx/core` instance shared by `@kalyx/react` and `@kalyx/adapter-date-fns`.
+
+---
+
+## 4. 7-Picker API Consistency
+
+### Justified divergences (no change)
+
+- TimePicker's `disabled: boolean` (no `DisabledRule[]`) — time has no date context for the rule types.
+- TimePicker has no `.Trigger` / `.Popover` — inline by design.
+- RangePicker has no `.Trigger` — two `.Input`s replace the single-trigger pattern.
+- MonthPicker / YearPicker reuse `DatePickerTrigger` rather than defining their own.
+
+### Gaps (1.1 track)
+
+- **API-G1 — Missing hooks.** The headless story (`/headless` entry, "use any UI you want") promises hook parity. Reality:
+  - Shipped: `useDatePicker`, `useRangePicker`, `useTimePicker`.
+  - Missing: `useMonthPicker`, `useYearPicker`, `useWeekPicker`, `useDateTimePicker`.
+  Add the four missing hooks for 1.1. Each is a small wrapper over the existing context + minimal logic. Estimated cost: ~400 bytes if all four are added to the default entry; should ship under `/headless` only with appropriate `exports` slicing.
+- **API-G2 — `DateTimePicker.Presets` absent.** Common use case ("Tomorrow 9 AM", "End of week 17:00") unsupported despite RangePicker and DatePicker shipping the pattern.
+- **API-G3 — `DisabledRule` is type-unsafe at month/year granularity.** `MonthPicker` accepts `{ dayOfWeek: [0] }` but the rule doesn't map to month selection. Either narrow types per picker or document the semantics ("rule applies to constituent days; month is disabled when all its days are").
+
+### OK
+
+- onChange signatures uniform within their category (`ISODateString | null` or `DateRange`).
+- classNames structure consistent within semantic role (grid vs. listbox).
+- Labels inheritance (`DatePickerLabels` → `RangePickerLabels` / `DateTimePickerLabels`) is clean.
+- All `Input`s `forwardRef` — native form integration works.
+
+---
+
+## 5. Test Coverage Blind Spots
+
+### High-severity gaps
+
+- **TC-H1 — RangePicker hover preview untested.** Zero `mouseEnter` / `onMouseEnter` assertions in `packages/react/src/components/RangePicker/`. The single most distinctive RangePicker UX has no regression test. Patch (1.0.x).
+- **TC-H2 — No property-based testing.** Neither `fast-check` nor `stryker` is in any `package.json`. Date arithmetic, DST, and leap-year logic are textbook property-test territory. Adopt `fast-check` in `@kalyx/core` for `utils/timezone.ts`, `utils/calendar.ts`, `utils/date.ts` in 1.1.
+
+### Medium-severity gaps
+
+- **TC-M1** — Initial `value` falling on a disabled day: rendering behaviour unspecified and untested for any picker.
+- **TC-M2** — Controlled ↔ uncontrolled mid-flight prop switch (React warns; Kalyx response untested).
+- **TC-M3** — Changing `minDate` / `maxDate` while popover is open — does the visible month re-render?
+- **TC-M4** — No RTL tests. `dir="rtl"` + Arabic locale + arrow-key logical inversion all unverified.
+- **TC-M5** — DateTimePicker with non-UTC `displayTimezone` only verified for ISO emission; the round-trip date → time → date edit untested.
+- **TC-M6** — TimePicker `step` snap behaviour for off-step manual input untested.
+- **TC-M7** — WeekPicker week-spanning Dec 31 → Jan 1 (year boundary) untested.
+
+### Low-severity
+
+- **TC-L1** — Year extremes (1 / 9999) untested in `YearGrid`.
+- **TC-L2** — "All cells disabled in current view" fallback untested.
+
+### Structural
+
+- e2e: 31 scenarios across 8 files. Coverage skews to SSR + happy paths. No mid-flight prop change e2e, no locale-switch e2e. Add 5-7 scenarios in 1.1.
+
+---
+
+## Severity Matrix
+
+| ID | Severity | Track | Effort |
+|---|---|---|---|
+| A-D1 | Defect | 1.0.x patch | XS (2 lines + test) |
+| A-D2 | Defect | 1.0.x patch | XS (with A-D1) |
+| A-D3 | Defect | 1.0.x patch | S (remove guard, add 2 focus-restore tests) |
+| T-D1 | Defect | 1.0.x patch | M (snap-forward logic + doc + tests) |
+| T-D2 | Defect | 1.0.x patch | XS (document choice + strict test) |
+| T-D3 | Defect | 1.0.x patch | XS (tests only) |
+| B-D1 | Defect | 1.0.x patch | XS (one CI step) |
+| TC-H1 | Defect | 1.0.x patch | S (one test file) |
+| T-G1 | Gap | 1.0.x patch | XS (doc + test) |
+| A-G1 | Gap | 1.1 minor | S |
+| A-G2 | Gap | 1.1 minor | M (decide + implement or document) |
+| A-G3, A-G4, A-G5 | Gap | 1.1 minor | S (tests) |
+| API-G1 | Gap | 1.1 minor | M (4 hooks + tests) |
+| API-G2 | Gap | 1.1 minor | M (compose existing Presets pattern) |
+| API-G3 | Type polish | 1.1 minor | S |
+| TC-H2 | Quality | 1.1 minor | M (fast-check adoption + properties) |
+| TC-M4 | Quality | 1.1 minor | M (RTL audit + tests) |
+| B-D2 | Risk | 1.1 minor | M (bundle-diff CI tool) |
+| B-R1 | Risk | 1.0.x patch | XS (one source of truth) |
+| B-R2 | Risk | 1.1 minor | S (per-dep size report) |
+| T-G2, T-G3 | Gap | 1.1 minor | XS (tests + small inference) |
+| T-R1, T-R2 | Risk | 1.0.x patch | XS (tests) |
+| TC-M1..M7 | Coverage | 1.0.x patch rolling | XS each |
+| TC-L1, TC-L2 | Coverage | 1.1 minor | XS |
+| A-R1 | Risk | 1.1 minor | XS |
+
+**Targeted 1.0.2 patch contents** (recommended sequencing): A-D1+A-D2 (Escape bubbling), A-D3 (focus restore), T-D1 (DST gap), T-D2 (DST ambiguity), T-D3 (fractional offsets — tests only), B-D1 (CI gate), B-R1 (gzip source unification), TC-H1 (RangePicker hover test). Plus the rolling coverage adds (T-G1, T-R1, T-R2, TC-M1-M7).
+
+**1.1 minor** brings the missing hooks (API-G1), `DateTimePicker.Presets` (API-G2), `weekStartsOn` locale inference (T-G2), RTL (TC-M4), fast-check adoption (TC-H2), bundle-diff CI (B-D2), and the a11y polish set (A-G1..A-G5).
+
+---
+
+## What this audit did NOT examine
+
+- React Native adapter (deferred to a separate spec).
+- Adapter packages other than `@kalyx/adapter-date-fns`.
+- Documentation site itself (links, copy, Playground).
+- Performance under stress (1000+ disabled rules, 50-year YearGrid, etc.).
+- Storybook / visual regression — none exists at the time of this audit.
+
+These should each get their own audit if the work targets them.
+
+---
+
+## Companion documents
+
+- Competitive landscape + v1.1 roadmap rationale: `docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md`
+- v1.1+ track table: `CLAUDE.md` §14 (updated alongside this audit).


### PR DESCRIPTION
## Summary

Refreshes Kalyx's strategic direction with a 2026-06-17 snapshot of the React date-picker ecosystem and a 5-dimension internal audit of the 1.0.x line.

- **New spec**: `docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md` — 21 verified primary-source claims (multi-agent fetch + 3-vote adversarial verification) drive a 4-track roadmap (1.0.x patch / v1.1 / v1.2 / strategic watch).
- **New spec**: `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md` — defect/gap catalog across a11y/keyboard, timezone/DST, bundle/tree-shake, 7-picker API consistency, test coverage. 3 user-visible defects + 1 CI safety gap confirmed by source inspection.
- **`CLAUDE.md` §14** rewritten as Track A/B/C/D with audit-ID cross-refs.
- **`CLAUDE.md` §1** Ark UI line corrected ("no standalone TimePicker; time via `@internationalized/date` `CalendarDateTime` inside DatePicker" — more accurate than the prior "removed TimePicker as a bug" wording).
- **`comparison.md`** (EN + KO) reflects Chakra v3.34 DatePicker launch (Mar 2026), react-datepicker 9.1.0 optional `timeZone` prop, MUI X RangePicker behind Pro paywall; "When NOT to use Kalyx" section gains ark-ui/Chakra and Mantine entries.

Key landscape findings (full citations in the spec):

- Headless UI Discussion #289 still open since 2021, no maintainer answer — gap intact.
- react-day-picker v10.0.1 is a cleanup release — still no built-in TimePicker / Input.
- react-datepicker issue #1018 (8-year timezone bug) closed 2025-12 as docs-only "not a bug" — native `Date` value type unchanged.
- MUI X 9.5.0 = 58.2 KB gzip; DateRangePicker/TimeRangePicker live in `@mui/x-date-pickers-pro` (commercial license).
- Adobe documents `@internationalized/date` as Temporal-bound — strategic watch item for the adapter strategy.

## Test plan

- [x] No source-code changes — docs-only PR
- [x] Bundle build sanity (`pnpm --filter @kalyx/react build`) — ESM 15.63 KB / CJS 15.76 KB gzip (within 16 KB limit)
- [ ] CI: typecheck / lint / test / bundle / SSR all green
- [ ] Docusaurus build of `/comparison` page (EN + KO) renders new footnotes [^15], [^16] correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 경쟁사 라이브러리(Chakra UI, react-datepicker 등) 최신 버전 반영으로 비교 문서 업데이트
  * v1.1 및 향후 버전 로드맵 문서 공개
  * Kalyx 1.0 기능 감사 보고서 추가 (접근성, 시간대 처리, 번들 크기 등 5개 영역 검토)
  * 한국어 비교 문서 동기화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->