### PR TITLE
fix(timezone): DST gap snap-forward + deterministic ambiguous-hour policy

### DIFF
--- a/.changeset/dst-gap-snap-forward.md
+++ b/.changeset/dst-gap-snap-forward.md
@@ -1,0 +1,35 @@
+---
+'@kalyx/core': patch
+'@kalyx/react': patch
+---
+
+fix(timezone): snap forward for non-existent civil times in DST gaps; document deterministic disambiguation
+
+`setTimeInTimezone` previously returned a pre-transition instant when the
+requested civil time fell in a DST spring-forward gap. Asking for
+`2026-03-08 02:30 America/New_York` — which does not exist because clocks jump
+02:00 EST → 03:00 EDT — returned `2026-03-08T06:30:00.000Z` (= 01:30 EST, an
+hour before the gap), silently corrupting the user's intent.
+
+`setTimeInTimezone` now classifies its two-pass offset candidates by whether
+their civil round-trip matches the requested civil time, and:
+
+- **Spring-forward gap** (neither candidate matches): snap forward to the
+  later candidate — the first valid civil instant past the gap. `2026-03-08
+  02:30 America/New_York` now returns `2026-03-08T07:30:00.000Z` (= 03:30
+  EDT).
+- **Fall-back ambiguity** (both candidates match): pick the earlier instant
+  (EDT before EST in US Eastern, BST before GMT in Europe/London). Matches
+  `@internationalized/date` and the TC39 Temporal default
+  (`disambiguation: 'earlier'`).
+- **Single-match** (one candidate matches, near a transition): return the
+  matching candidate. This was the source of intermittent off-by-one-hour
+  drift near transitions.
+
+The JSDoc above `setTimeInTimezone` now documents the policy explicitly. The
+existing ambiguous-hour test was tightened from
+`expect([...]).toContain(result)` (two-valid-answers) to an exact-equality
+assertion against the documented choice.
+
+Audit reference: `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md`
+(items T-D1, T-D2).

--- a/packages/core/src/__tests__/timezone.test.ts
+++ b/packages/core/src/__tests__/timezone.test.ts
@@ -90,19 +90,15 @@ describe('DST transition — America/New_York fall back 2026-11-01', () => {
     );
   });
 
-  it('setTimeInTimezone for the ambiguous 01:30 hour on fall-back day picks one occurrence deterministically', () => {
-    // 2026-11-01 01:30 America/New_York occurs twice — once in EDT (UTC-4) and once
-    // in EST (UTC-5). Without disambiguation, applying setTime is undefined behavior.
-    // Lock the current implementation's choice so future regressions surface as test
-    // failures rather than silent drift.
-    // Base: 2026-11-01T12:00:00.000Z (UTC noon) is firmly inside the Nov 1 civil day
-    // in America/New_York (08:00 EST) — far away from the 01:00 transition window.
+  it('setTimeInTimezone picks the earlier offset for an ambiguous fall-back hour', () => {
+    // 2026-11-01 01:30 America/New_York occurs twice — once in EDT (UTC-4) and
+    // once in EST (UTC-5). The documented policy is `disambiguation: 'earlier'`
+    // (matches @internationalized/date + TC39 Temporal default): pick the EDT
+    // occurrence. Base 2026-11-01T12:00:00.000Z is far from the transition
+    // window so the choice isn't driven by the base's own offset.
     const base = '2026-11-01T12:00:00.000Z';
     const result = setTimeInTimezone(base, { hours: 1, minutes: 30 }, 'America/New_York');
-    // Either '2026-11-01T05:30:00.000Z' (EDT 01:30, pre-transition) or
-    // '2026-11-01T06:30:00.000Z' (EST 01:30, post-transition) are valid wall-clock
-    // interpretations of the ambiguous hour; we assert the result is one of them.
-    expect(['2026-11-01T05:30:00.000Z', '2026-11-01T06:30:00.000Z']).toContain(result);
+    expect(result).toBe('2026-11-01T05:30:00.000Z');
   });
 });
 
@@ -240,5 +236,35 @@ describe('setTimeInTimezone', () => {
     const { hours, minutes, seconds } = getTimeInTimezone(input, tz);
     const round = setTimeInTimezone(input, { hours, minutes, seconds }, tz);
     expect(round).toBe(input);
+  });
+
+  it('snaps forward when the civil time falls in a spring-forward gap (DST gap)', () => {
+    // 2026-03-08 02:30 in America/New_York doesn't exist — clocks jump
+    // 02:00 EST → 03:00 EDT. Without explicit handling, the two-pass offset
+    // algorithm lands on the pre-transition reading (01:30 EST = 06:30 UTC),
+    // silently corrupting the user's intent. The documented policy is
+    // snap-forward: return the equivalent post-transition instant
+    // (03:30 EDT = 07:30 UTC). This matches @internationalized/date and the
+    // TC39 Temporal default disambiguation behavior for non-existent times.
+    const base = '2026-03-08T12:00:00.000Z';
+    const result = setTimeInTimezone(base, { hours: 2, minutes: 30 }, 'America/New_York');
+    expect(result).toBe('2026-03-08T07:30:00.000Z');
+  });
+
+  it('snaps forward when the civil time falls in the Europe/London spring-forward gap', () => {
+    // 2026-03-29 01:30 in Europe/London doesn't exist — clocks jump
+    // 01:00 GMT → 02:00 BST. Snap forward to 02:30 BST = 01:30 UTC.
+    const base = '2026-03-29T12:00:00.000Z';
+    const result = setTimeInTimezone(base, { hours: 1, minutes: 30 }, 'Europe/London');
+    expect(result).toBe('2026-03-29T01:30:00.000Z');
+  });
+
+  it('leaves non-gap times unchanged near a DST transition', () => {
+    // 03:30 on spring-forward day in NY exists (it's after the gap, in EDT).
+    // Must NOT be modified by snap-forward logic.
+    const base = '2026-03-08T12:00:00.000Z';
+    const result = setTimeInTimezone(base, { hours: 3, minutes: 30 }, 'America/New_York');
+    // 03:30 EDT = 07:30 UTC
+    expect(result).toBe('2026-03-08T07:30:00.000Z');
   });
 });

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -195,6 +195,17 @@ export function getTimeInTimezone(
  * // In Asia/Seoul (UTC+9): set the hour to 10
  * setTimeInTimezone('2026-01-15T00:00:00.000Z', { hours: 10 }, 'Asia/Seoul');
  * // → '2026-01-15T01:00:00.000Z'   (Seoul Jan 15 10:00 = UTC 01:00)
+ *
+ * DST disambiguation policy:
+ *
+ * - **Spring-forward gaps** (non-existent civil time): the requested civil time
+ *   is snapped forward to the first valid instant past the gap. Asking for
+ *   2026-03-08 02:30 America/New_York — which doesn't exist because clocks
+ *   jump 02:00 EST → 03:00 EDT — returns 03:30 EDT (= 2026-03-08T07:30:00.000Z).
+ * - **Fall-back ambiguity** (civil time occurs twice): the earlier offset
+ *   (e.g. EDT before EST in US Eastern, BST before GMT in Europe/London) is
+ *   chosen, matching `@internationalized/date` and the TC39 Temporal default
+ *   (`disambiguation: 'earlier'`).
  */
 export function setTimeInTimezone(
   iso: ISODateString,
@@ -214,12 +225,46 @@ export function setTimeInTimezone(
     targetSeconds,
   );
 
-  // First pass: use the offset at the civil-as-UTC probe, correct once to absorb DST.
+  // Two-pass offset resolution: probe at civil-as-UTC, then re-probe at the
+  // first-pass result so the second probe sees the offset that actually applies
+  // at the resolved instant. The two candidate UTC instants are then classified
+  // by whether their civil round-trip in the target zone matches the requested
+  // civil time:
+  //
+  //   match1 && match2  → fall-back ambiguity, both are valid wall-clock
+  //                       interpretations → pick the earlier instant (matches
+  //                       @internationalized/date and TC39 Temporal default).
+  //   match1 ^ match2   → the matching candidate is the correct one. (This is
+  //                       the common case near a DST boundary where one of the
+  //                       two probes picked the wrong-side offset.)
+  //   neither match     → spring-forward gap: the requested civil time does not
+  //                       exist → snap forward to the later instant.
   const probe1 = new Date(civilEpoch).toISOString();
   const offset1 = getTimezoneOffsetMinutes(probe1, timeZone);
   const realEpoch1 = civilEpoch - offset1 * 60_000;
   const probe2 = new Date(realEpoch1).toISOString();
   const offset2 = getTimezoneOffsetMinutes(probe2, timeZone);
   const realEpoch2 = civilEpoch - offset2 * 60_000;
-  return new Date(realEpoch2).toISOString();
+
+  const civilMatches = (epoch: number) => {
+    const rt = partsInTimezone(new Date(epoch), timeZone);
+    return (
+      rt.year === p.year &&
+      rt.month === p.month &&
+      rt.day === p.day &&
+      rt.hour === targetHours &&
+      rt.minute === targetMinutes &&
+      rt.second === targetSeconds
+    );
+  };
+  const match1 = civilMatches(realEpoch1);
+  const match2 = civilMatches(realEpoch2);
+
+  let chosen: number;
+  if (match1 && match2) chosen = Math.min(realEpoch1, realEpoch2);
+  else if (match1) chosen = realEpoch1;
+  else if (match2) chosen = realEpoch2;
+  else chosen = Math.max(realEpoch1, realEpoch2);
+
+  return new Date(chosen).toISOString();
 }


### PR DESCRIPTION
## Summary

Implements audit items **T-D1** (silent DST gap-time corruption) and **T-D2** (ambiguous fall-back hour undocumented) from `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md`.

### Behavior change

`setTimeInTimezone` previously returned a pre-transition instant when the requested civil time fell in a DST spring-forward gap:

```
setTimeInTimezone('2026-03-08T12:00:00.000Z', { hours: 2, minutes: 30 }, 'America/New_York')
// Before: '2026-03-08T06:30:00.000Z'  ← 01:30 EST, BEFORE the non-existent 02:30 gap
// After:  '2026-03-08T07:30:00.000Z'  ← 03:30 EDT, snap-forward past the gap
```

The two-pass offset algorithm now classifies its candidate UTC instants by whether their civil round-trip in the target zone matches the requested civil time and picks accordingly:

| Case | Both candidates match? | Picked |
|---|---|---|
| Spring-forward gap (non-existent civil time) | neither | **later** = snap-forward |
| Fall-back ambiguity (civil time occurs twice) | both | **earlier** = matches `@internationalized/date` + TC39 Temporal `disambiguation: 'earlier'` |
| Near a DST transition, only one valid | one | **the matching one** (fixes intermittent off-by-one-hour drift) |
| Non-transition | both (and equal) | **either** = no-op |

JSDoc on `setTimeInTimezone` now documents the policy explicitly so callers can predict behavior without reading the implementation.

### Tightened tests

- The existing ambiguous-hour test (NY 2026-11-01 01:30) was tightened from `.toContain([...two valid answers...])` to an exact-equality assertion against the documented choice (EDT = `2026-11-01T05:30:00.000Z`).
- New tests cover NY spring-forward gap, London spring-forward gap, and a non-gap-but-on-transition-day case that's a regression guard for the off-by-one drift the previous implementation could produce.

## Verification

- `pnpm test:run` — 558/558 pass (was 555; +3 new gap/transition assertions)
- `pnpm typecheck` — clean
- `pnpm --filter @kalyx/react build` — ESM 15.71 KB / CJS 15.82 KB gzip (≤ 16 KB limit), unchanged

## Test plan

- [x] RED → GREEN verified locally
- [x] All existing tests still pass (including the previously-loose ambiguous test, now strict)
- [ ] CI: typecheck / lint / test (Node 20 + 22) / bundle / SSR all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)