### PR TITLE
chore(ci): wire verify-entry-split.mjs into PR check (B-D1)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -190,10 +190,28 @@ jobs:
           node-version: 22
       - run: node scripts/check-hero-freshness.mjs
 
+  entry-split:
+    name: Headless Entry Split (no date-fns)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Regression-guard for the `/headless` contract: the headless entry must
+      # NOT pull in date-fns or @kalyx/adapter-date-fns. The script bundles
+      # both entries with esbuild and asserts the headless metafile is
+      # date-fns-free + at least 5% smaller gzipped than the default entry.
+      - run: node scripts/verify-entry-split.mjs
+
   all-pass:
     name: All Checks Pass
     runs-on: ubuntu-latest
-    needs: [typecheck, lint, test, build, bundle-size, ssr-check, docs-site, hero-freshness]
+    needs:
+      [typecheck, lint, test, build, bundle-size, ssr-check, docs-site, hero-freshness, entry-split]
     if: always()
     steps:
       # `toJSON(needs)` serialises with `": "` (space after colon), so the

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -201,6 +201,12 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # esbuild resolves @kalyx/* through the workspace packages' `main`/
+      # `module` fields, which point at `dist/`. Pre-build those packages so
+      # esbuild can find them. We don't need @kalyx/react built — the script
+      # bundles its `src/` directly.
+      - run: pnpm --filter @kalyx/core build
+      - run: pnpm --filter @kalyx/adapter-date-fns build
       # Regression-guard for the `/headless` contract: the headless entry must
       # NOT pull in date-fns or @kalyx/adapter-date-fns. The script bundles
       # both entries with esbuild and asserts the headless metafile is

--- a/scripts/verify-entry-split.mjs
+++ b/scripts/verify-entry-split.mjs
@@ -15,8 +15,10 @@
 // is only ~2KB gzip after tree-shaking. Teams already shipping a date library
 // still benefit from skipping that ~2KB and avoiding the duplicate parse cost.
 //
-// Manual verification only — not wired into CI. Run after edits to either
-// entry, the `internal/defaultAdapter` module, or `tsup.config.ts`.
+// Runs in CI as the `entry-split` job in pr-check.yml — the primary contract
+// ("no date-fns in headless") is a hard pass/fail gate on every PR. Also
+// runnable locally after edits to either entry, the `internal/defaultAdapter`
+// module, or `tsup.config.ts`: `node scripts/verify-entry-split.mjs`.
 
 import { build } from "esbuild";
 import { gzipSync } from "node:zlib";


### PR DESCRIPTION
## Summary

Implements audit item **B-D1** from `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md`.

The `/headless` entry's "zero date-fns" contract — Kalyx's core marketing line for v1.0 and the spine of the adapter pattern — was guarded only by a manual script. A PR accidentally importing `@kalyx/adapter-date-fns` from `src/headless.ts` would slip through CI and only surface on the next manual run.

## Changes

- **`.github/workflows/pr-check.yml`**: new `entry-split` job that runs `scripts/verify-entry-split.mjs` on every PR. Added to `all-pass.needs` so a failure blocks the gate.
- **`scripts/verify-entry-split.mjs`**: leading comment updated — "Manual verification only — not wired into CI" → reflects new CI role.

## Verification

```
$ node scripts/verify-entry-split.mjs

📦 Entry-split bundle report
────────────────────────────────────────────────────────────
  default  (@kalyx/react)             gzip: 25.08KB  (includes date-fns)
  headless (@kalyx/react/headless)    gzip: 23.16KB  (no date-fns)
────────────────────────────────────────────────────────────
  headless vs default: -1.92KB gzip (7.6% smaller)

✅ Headless entry: date-fns absent + ≥5% gzip reduction sanity check passed.
```

## Test plan

- [x] Script passes locally on `main`
- [ ] New CI job appears in PR #128 checks and reports green
- [ ] `all-pass` reflects the new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * PR 체크 워크플로우에 엔트리 분할(`entry-split`) 검증 잡을 추가하고, 관련 스크립트를 실행해 번들 크기 조건 및 특정 의존성 회귀를 회귀 가드로 확인합니다.
  * “All Checks Pass” 게이트 통과를 위해 `all-pass` 잡의 선행 조건에 `entry-split` 검증을 포함하도록 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->