### PR TITLE
chore(ci): unify gzip measurement via check-bundle-size.js (B-R1)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -92,38 +92,35 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - name: dist 다운로드
         uses: actions/download-artifact@v8
         with:
           name: dist-${{ github.run_id }}
           path: packages/react/dist/
+      # Single source of truth for gzip measurement: shell `gzip -c` and Node's
+      # zlib could drift apart inside the ~380-byte 16KB margin, so we delegate
+      # to scripts/check-bundle-size.js — the same script tsup + local dev use.
+      # The script appends kb_esm and kb_cjs to $GITHUB_OUTPUT for the comment.
       - name: 크기 측정 및 판정
         id: check
-        run: |
-          BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
-          KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=16
-          echo "gzip_kb=$KB" >> $GITHUB_OUTPUT
-          echo "📦 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
-          if (( $(echo "$KB > $MAX" | bc -l) )); then
-            echo "❌ 초과: ${KB}KB > ${MAX}KB"; exit 1
-          else
-            echo "✅ OK: ${KB}KB ≤ ${MAX}KB"
-          fi
+        run: node scripts/check-bundle-size.js
       - name: PR 코멘트
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
-            const kb   = '${{ steps.check.outputs.gzip_kb }}';
-            const ok   = parseFloat(kb) <= 16;
-            const icon = ok ? '✅' : '❌';
+            const kbEsm = '${{ steps.check.outputs.kb_esm }}';
+            const kbCjs = '${{ steps.check.outputs.kb_cjs }}';
+            const ok = parseFloat(kbEsm) <= 16 && parseFloat(kbCjs) <= 16;
             const body = [
-
               '',
-              '| | gzip |',
+              '| 번들 | gzip |',
               '|---|---|',
-              `| **현재** | **${kb}KB** |`,
+              `| **ESM** (\`dist/index.js\`) | **${kbEsm}KB** |`,
+              `| **CJS** (\`dist/index.cjs\`) | **${kbCjs}KB** |`,
               `| 목표 | ≤ 16KB |`,
               '',
               ok

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,8 +1,22 @@
 #!/usr/bin/env node
 // scripts/check-bundle-size.js
+//
+// Single source of truth for `@kalyx/react`'s gzip footprint:
+//
+// 1. Local dev: `pnpm check-bundle` invokes this script.
+// 2. tsup post-build hook (tsup.config.ts) imports the same Node `gzipSync`
+//    primitive on the same payload.
+// 3. CI (`.github/workflows/pr-check.yml` `bundle-size` job) invokes this
+//    script directly instead of running its own `gzip -c | wc -c` pipeline,
+//    so shell-gzip vs. Node-zlib defaults can't drift apart inside the
+//    ~380-byte 16KB margin.
+//
+// When `$GITHUB_OUTPUT` is set, the script appends per-bundle gzip KB values
+// (kb_esm, kb_cjs) so the workflow can read them back for the PR comment
+// without re-measuring.
 
 import { gzipSync } from "zlib";
-import { readFileSync, statSync } from "fs";
+import { readFileSync, statSync, appendFileSync } from "fs";
 
 // Bundle target. 12KB → 13KB after the v1.0-rc audit added user-facing
 // features (IME composition handling, popover focus-out, `name`/hidden-input
@@ -21,8 +35,8 @@ import { readFileSync, statSync } from "fs";
 const TARGET_KB = 16;
 
 const BUNDLES = [
-	{ label: "ESM", path: "packages/react/dist/index.js" },
-	{ label: "CJS", path: "packages/react/dist/index.cjs" },
+	{ label: "ESM", path: "packages/react/dist/index.js", outputKey: "kb_esm" },
+	{ label: "CJS", path: "packages/react/dist/index.cjs", outputKey: "kb_cjs" },
 ];
 
 function getGzipKB(filePath) {
@@ -35,13 +49,18 @@ function getRawKB(filePath) {
 	return (statSync(filePath).size / 1024).toFixed(2);
 }
 
+function emitGithubOutput(key, value) {
+	if (!process.env.GITHUB_OUTPUT) return;
+	appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+}
+
 try {
 	console.log("\n📦 Bundle Size Report");
 	console.log("─".repeat(48));
 
 	let allOk = true;
 
-	for (const { label, path } of BUNDLES) {
+	for (const { label, path, outputKey } of BUNDLES) {
 		const gzipKB = parseFloat(getGzipKB(path));
 		const rawKB = parseFloat(getRawKB(path));
 		const ok = gzipKB <= TARGET_KB;
@@ -49,6 +68,7 @@ try {
 
 		console.log(`  [${label}] ${path}`);
 		console.log(`    원본: ${rawKB}KB | gzip: ${gzipKB}KB | ${ok ? "✅" : "❌ 초과!"}`);
+		emitGithubOutput(outputKey, gzipKB);
 	}
 
 	console.log("─".repeat(48));


### PR DESCRIPTION
## Summary

Implements audit item **B-R1** from `docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md`.

The bundle was being measured in three places that could drift apart inside the ~380-byte 16KB margin:

- `tsup.config.ts` post-build hook → Node `gzipSync`
- `scripts/check-bundle-size.js` → Node `gzipSync`
- `.github/workflows/pr-check.yml` `bundle-size` job → shell `gzip -c | wc -c`

Shell-gzip and Node-zlib can vary by 10-30 bytes for an identical payload — material against ~380 bytes of headroom.

## Changes

- **`scripts/check-bundle-size.js`** — now appends per-bundle gzip KB values (`kb_esm`, `kb_cjs`) to `$GITHUB_OUTPUT` when the env var is set, and ships a leading block-comment documenting its single-source-of-truth role.
- **`.github/workflows/pr-check.yml`** — `bundle-size` job replaces the inline `gzip -c` pipeline with `node scripts/check-bundle-size.js`. PR-comment step now widened to cover both ESM and CJS rows (was: ESM only).

## Local verification

```
📦 Bundle Size Report
────────────────────────────────────────────────
  [ESM] packages/react/dist/index.js
    원본: 95.75KB | gzip: 15.71KB | ✅
  [CJS] packages/react/dist/index.cjs
    원본: 98.52KB | gzip: 15.82KB | ✅
```

```
$ GITHUB_OUTPUT=/tmp/out node scripts/check-bundle-size.js
$ cat /tmp/out
kb_esm=15.71
kb_cjs=15.82
```

## Test plan

- [x] Script runs locally and exits 0
- [x] Script emits `kb_esm` / `kb_cjs` to `$GITHUB_OUTPUT`
- [ ] CI `bundle-size` job invokes the script and the PR comment shows both rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)