### PR TITLE
fix(a11y): restore focus to trigger on popover close when focus was lost (A-D3)

### DIFF
--- a/.changeset/restore-focus-on-popover-close.md
+++ b/.changeset/restore-focus-on-popover-close.md
@@ -1,0 +1,21 @@
+---
+'@kalyx/react': patch
+---
+
+fix(a11y): restore focus to the trigger when a picker popover closes and focus was lost
+
+When a keyboard user opened a picker, moved into the calendar grid, and pressed
+Escape, focus fell to `<body>` instead of returning to the Input/Trigger — a
+WAI-ARIA recovery failure that left keyboard users stranded.
+
+Root cause (the prior `el !== referenceRef.current` guard's premise was wrong):
+the grid auto-focuses the selected day on open, and because `usePopover` runs
+its capture effect *after* the child grid's focus effect, the "previously
+focused" element it recorded was the day button — not the Input. On close that
+button unmounts, so the old restore either skipped (guard) or focused a detached
+node, dropping focus to `<body>`.
+
+The popover now restores focus only when it was actually lost
+(`document.activeElement === document.body`), targeting the still-connected
+captured element or falling back to the reference control. Closing by clicking
+another field leaves that field focused — restoration no longer steals it.

--- a/docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md
+++ b/docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md
@@ -86,10 +86,11 @@ const handleClick = useCallback(...)
 1. User clicks Input → focus on Input → popover opens.
 2. User arrow-keys into the calendar → focus moves onto a day button inside the popover.
 3. User presses Esc → popover unmounts → restoration runs.
-4. Restoration sees `previousFocusRef === Input (= referenceRef)` → **skips restore**.
-5. The day button is gone, the Input is unfocused; focus falls back to `<body>`.
+4. Restoration runs but the day button is gone; the Input is unfocused; focus falls back to `<body>`.
 
-**Fix.** Remove the `el !== referenceRef.current` guard, OR replace it with a stricter test (only skip when the document focus didn't leave the reference during open). The minimal fix is to restore unconditionally — tabs from a closed popover land on the Input, which is the correct keyboard recovery point.
+> **Resolved 2026-06-18 (PR fix/a-d3-focus-restore).** The mechanism stated above was incomplete. `previousFocusRef` does **not** hold the Input: the grid auto-focuses the selected day on open (`Calendar.tsx:125`), and because `usePopover`'s capture effect (parent) runs *after* the grid's focus effect (child), the recorded "previous" element is the **day button**, not the Input. Simply removing the `el !== referenceRef.current` guard therefore does **not** fix it (verified by a RED test that still landed on `<body>`) — the restore would target a now-detached day button.
+>
+> **Actual fix.** Restore only when focus was genuinely lost (`document.activeElement === document.body`); target the captured element if still connected, else fall back to the reference control (Input/Trigger). The `activeElement===body` gate is also necessary to avoid stealing focus on outside-click close (where focus deliberately moved to another field — a regression that jsdom's event timing hides but real browsers expose).
 
 **Severity.** Patch (1.0.x).
 

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -143,6 +143,59 @@ describe('DatePicker — basic interactions', () => {
     expect(escapeBubbles.length).toBeGreaterThan(0);
   });
 
+  it('restores focus to the input after closing with Escape from inside the grid', async () => {
+    // A-D3: a keyboard user opens the picker (focus on Input), arrow-keys into
+    // the calendar grid, then presses Escape. The day button unmounts, so focus
+    // must return to the Input — not fall back to <body>. The old focus-restore
+    // guard skipped restoration whenever the previous element was the Input,
+    // which is exactly this case.
+    const user = userEvent.setup();
+    renderDatePicker({ value: '2026-01-15T00:00:00.000Z' });
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Move focus off the Input and onto a day button inside the popover.
+    await user.keyboard('{ArrowRight}');
+    expect(input).not.toHaveFocus();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(input).toHaveFocus();
+  });
+
+  it('does not steal focus to the input when closing by clicking another field', async () => {
+    // The focus-restore fix must only recover lost focus (Escape unmounts the
+    // focused day → focus falls to <body>). When the user closes the popover by
+    // clicking a different field, focus already moved there deliberately and
+    // must be left alone. (jsdom flushes the native-mousedown close before the
+    // click focuses `other`, so this passed even before the activeElement===body
+    // guard; the guard makes it correct in real browsers, where React batches
+    // the close and restore would otherwise run after `other` is focused.)
+    const user = userEvent.setup();
+    render(
+      <>
+        <DatePicker onChange={vi.fn()}>
+          <DatePicker.Input aria-label="날짜 선택" />
+          <DatePicker.Popover>
+            <DatePicker.Calendar />
+          </DatePicker.Popover>
+        </DatePicker>
+        <input aria-label="다른 입력" />
+      </>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    const other = screen.getByLabelText('다른 입력');
+    await user.click(other);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(other).toHaveFocus();
+  });
+
   it('shows the selected value in the input', () => {
     renderDatePicker({ value: '2026-01-15T00:00:00.000Z' });
     expect(screen.getByRole('combobox')).toHaveValue('2026-01-15');

--- a/packages/react/src/hooks/usePopover.ts
+++ b/packages/react/src/hooks/usePopover.ts
@@ -46,17 +46,31 @@ export function usePopover({
     }
   }, [referenceRef, refs, isOpen]);
 
-  // Focus restoration: restore focus to the previous element on close.
-  // Skip restoration to the reference element itself (Input auto-opens on
-  // focus, which would immediately reopen the popover).
+  // Focus restoration on close — but only to recover focus that was actually
+  // lost. The calendar grid auto-focuses the selected day on open, so the
+  // captured element is usually a day button inside the popover; when the
+  // popover unmounts that button detaches and the browser drops focus to
+  // <body>. In that case we restore to the captured element if it's still
+  // connected, otherwise to the reference control (the Input / Trigger) — the
+  // correct keyboard recovery point per WAI-ARIA. Opening is bound to a pointer
+  // click, not focus (see Input's handleClick), so this does NOT reopen.
+  //
+  // If focus already moved elsewhere (e.g. the user closed the popover by
+  // clicking another field), `document.activeElement` is that element, not
+  // <body>, and we leave it alone — stealing it back would be a regression.
   useEffect(() => {
     if (isOpen) {
       previousFocusRef.current = document.activeElement as HTMLElement;
     } else if (previousFocusRef.current) {
-      const el = previousFocusRef.current;
+      const captured = previousFocusRef.current;
       previousFocusRef.current = null;
-      if (el !== referenceRef.current && typeof el.focus === 'function') {
-        el.focus({ preventScroll: true });
+      const active = document.activeElement;
+      const focusWasLost = active === null || active === document.body;
+      if (focusWasLost) {
+        const target = captured.isConnected ? captured : referenceRef.current;
+        if (target && typeof target.focus === 'function') {
+          target.focus({ preventScroll: true });
+        }
       }
     }
   }, [isOpen, referenceRef]);


### PR DESCRIPTION
## What

Closes audit item **A-D3** (Track A). When a keyboard user opened a picker, arrowed into the calendar grid, and pressed **Escape**, focus fell to `<body>` instead of returning to the Input/Trigger — a WAI-ARIA recovery failure leaving keyboard users stranded.

## Why the audit's stated fix was wrong

The audit assumed `previousFocusRef === Input` and that simply removing the `el !== referenceRef.current` guard would fix it. It doesn't:

- The grid **auto-focuses the selected day** on open (`Calendar.tsx:125`).
- `usePopover`'s capture effect (parent) runs **after** the grid's focus effect (child), so `previousFocusRef` records the **day button**, not the Input.
- On close that button unmounts → restoring to it drops focus to `<body>`.

Verified with a RED test that still landed on `<body>` after the naive guard removal.

## Fix

Restore focus only when it was genuinely **lost** (`document.activeElement === document.body`), targeting the captured element if still connected, else the reference control (Input/Trigger). The `activeElement === body` gate also prevents **stealing focus on outside-click close** — where the user deliberately moved focus to another field (a regression jsdom's event timing hides but real browsers expose).

## Tests

- ✅ `restores focus to the input after closing with Escape from inside the grid` (was RED before fix)
- ✅ `does not steal focus to the input when closing by clicking another field` (regression guard; comment documents the jsdom-vs-browser timing caveat)
- ✅ Full suite 562/562, typecheck, lint, axe all green
- Bundle: ESM 15.78 / CJS 15.88 KB gzip (≤16KB; +~70B for the a11y fix)

Shared `usePopover` → one DatePicker test covers all 7 pickers.

Changeset: `@kalyx/react` patch. Audit doc A-D3 corrected with the real mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * DatePicker popover 닫기 시 키보드 포커스 복원 개선
  * popover 닫은 후 포커스가 입력 필드로 올바르게 돌아가도록 수정
  * 다른 필드 클릭 시 포커스 탈취 문제 해결
  * 접근성(WAI-ARIA) 준수 개선

* **테스트**
  * 키보드 포커스 복구 동작 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->