### PR TITLE
docs(direction): confirm correctness-first direction, shelve promotion, drop adapter-temporal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,14 +582,19 @@ pnpm changeset publish # npm 배포 (CI 자동)
 
 ---
 
-## 14. 현재 이니셔티브 (2026-06-17 기준 — 1.0 stable + 1.0.x patch 준비)
+## 14. 현재 이니셔티브 (2026-06-18 기준 — Track A 종료, "정확성 먼저" 방향 확정)
 
-> v1.0.0 stable 출시 **완료** (2026-06-08). 2026-06-17 시점 외부 라이브러리 경쟁 리서치 + 내부 결함 audit 종합 결과는 별도 spec으로 분리.
+> **🧭 2026-06-18 확정 방향 (single source of truth):** [`docs/superpowers/specs/2026-06-18-current-state-analysis-and-correctness-first-direction.md`](docs/superpowers/specs/2026-06-18-current-state-analysis-and-correctness-first-direction.md)
+> 10-에이전트 멀티에이전트 현 시점 분석(7차원 → 적대적 검증 → 종합, 1차 출처 검증)으로 선행 방향을 validate. 결론:
+> - **홍보는 접는다** (사용자 결정 — 외부 사용자 0, HN 신규계정 auto-dead). 라이브 홍보 콘텐츠(블로그·announcementBar·comparison) 제거. → 아래 Track 우선순위는 이 spec을 따른다.
+> - **확정 실행 순서 (전부 bundle-0):** ①fast-check 속성테스트 `@kalyx/core` (1.0.4 patch, T-G3 리드) → ②`@kalyx/core/test-helpers` conformance suite → ③누락 hook 4종(`/headless`) → ④(선택) dayjs 어댑터.
+> - **`@kalyx/adapter-temporal` 근시일 드롭** (정확성 0 검증 — 어댑터는 core Intl로 재위임. 인터페이스가 ISO-string이라 Temporal 역량 운반 불가). Temporal **전략**은 core 레벨 Track D demand-gate로 보존.
+> - **번들 마진 = CJS 126 B / ESM 221 B** (binding=CJS). 런타임 기능 추가 = CI 깸. (이전 "~380 B" 표기는 stale.)
 >
-> - **v1.1 로드맵 + 경쟁 라이브러리 분석**: [`docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md`](docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md)
-> - **1.0.x 결함/갭 카탈로그**: [`docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md`](docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md)
+> 이전 spec (2026-06-17, 여전히 유효한 근거 카탈로그):
+> - **경쟁 분석 + 결함 audit**: [`2026-06-17-competitive-landscape-and-v1.1-roadmap.md`](docs/superpowers/specs/2026-06-17-competitive-landscape-and-v1.1-roadmap.md) · [`2026-06-17-kalyx-1.0-functional-audit.md`](docs/superpowers/specs/2026-06-17-kalyx-1.0-functional-audit.md)
 >
-> 핵심 요약: 1.0 thesis (headless + 7 picker + adapter + ISO/UTC + ≤16KB) **그대로 유효**. Headless UI는 여전히 DatePicker 거부 (Discussion #289 open since 2021), react-day-picker v10.0.1은 cleanup release로 TimePicker/Input 없음, react-datepicker #1018은 docs-only "not a bug" 종결, MUI X 9.5.0은 58.2KB gzip에 Range가 Pro 유료. 새로 닫힌 갭은 Chakra v3.34 (March 2026) DatePicker 출시 — 단, Ark UI 경유 `@internationalized/date` 강결합 심화로 어댑터 패턴 비교 우위는 더 선명. 가장 큰 새 차원은 **Adobe stack의 Temporal-bound 아키텍처** — `@kalyx/adapter-temporal` 우선순위 상향.
+> 핵심 요약: 1.0 thesis (headless + 7 picker + adapter + ISO/UTC + ≤16KB) **그대로 유효** (2026-06 적대적 재검증 통과). Headless UI는 여전히 DatePicker 거부, react-day-picker v10.0.1은 cleanup release로 TimePicker/Input 없음, react-datepicker #1018은 "not a bug" 종결(native Date 유지), MUI X 9.5.0은 58.2KB gzip에 Range가 Pro 유료, Chakra v3.34 (March 2026) DatePicker는 Ark UI/`@internationalized/date` 강결합 심화 → **포지셔닝 승리**. Adobe stack은 Temporal-bound이나, Temporal 역량은 어댑터가 아니라 **core**에 속함(위 드롭 근거).
 
 ### v1.0 완료 항목 (회고)
 
@@ -620,6 +625,8 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 
 어댑터 패턴을 "약속"에서 "검증된 실력"으로. 두 번째 어댑터 출시 + conformance suite + 누락 hook이 척추.
 
+> **⚠️ 실행 순서는 2026-06-18 spec을 따른다** (위 §14 intro): ①fast-check 속성테스트(1.0.4, 아래 Track C에서 끌어올림) → ②B2 conformance → ③B4 hooks → ④(선택) B1 dayjs. **B6 temporal·B11 comparison 랜딩은 드롭됨** (아래 표 참조).
+
 | # | 항목 | 근거 |
 |---|---|---|
 | B1 | `@kalyx/adapter-dayjs` 출시 (P0) | Mantine + ~50% dayjs 사용자에게 drop-in headless 옵션 |
@@ -627,17 +634,17 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 | B3 | `@kalyx/adapter-luxon` | B2 후 비용 낮음. enterprise/timezone 사용자 |
 | B4 | `useMonthPicker` / `useYearPicker` / `useWeekPicker` / `useDateTimePicker` hooks (`/headless` 전용) | audit API-G1. 기본 entry 번들 압력 회피 |
 | B5 | `DateTimePicker.Presets` (`/headless`에서 RangePicker.Presets 패턴 재사용) | audit API-G2 |
-| B6 | `@kalyx/adapter-temporal@0.x` (experimental, 별도 publish) | Adobe stack이 Temporal-bound — 늦으면 "Temporal-native"로 보이지 않음 |
+| ~~B6~~ | ~~`@kalyx/adapter-temporal@0.x`~~ → **드롭** (2026-06-18) | 정확성 0 검증: 어댑터 인터페이스는 ISO-string in/out이라 Temporal 역량 운반 불가, core Intl로 재위임. 홍보 접어 optics 청중도 없음. Temporal **전략**은 core 레벨 Track D demand-gate로 보존 |
 | B7 | `weekStartsOn` locale 자동 추론 (명시 prop override) | audit T-G2 |
 | B8 | `/headless` adapter guide 한국어 번역 | 주 성장 오디언스 KO 부재 |
-| B9 | 번들 margin 도구: `scripts/bundle-diff.mjs` + PR comment | audit B-D2 — ~380바이트 마진 가시화 |
+| B9 | 번들 margin 도구: `scripts/bundle-diff.mjs` + PR comment | audit B-D2 — **CJS 126 B / ESM 221 B** 마진 가시화 (이전 "~380 B"는 stale; binding=CJS) |
 | B10 | a11y polish set: A-G1..A-G5 | DatePicker `announce()` 패리티, WeekPicker nav 결정, axe-when-open, Trigger focus-restore 테스트, week-mode aria-label |
-| B11 | docs-site comparison + MUI X Pro 유료 vs Kalyx "Free Range Picker, ≤16KB" 랜딩 비교 | research [R-6] — 마케팅 모먼트 |
+| ~~B11~~ | ~~docs-site comparison 랜딩 비교~~ → **드롭** (2026-06-18) | 홍보 접음. comparison 페이지 자체도 제거 (마케팅 모먼트 폐기) |
 
 ### Track C — v1.2 (다음 분기)
 
 - RTL 지원 + 테스트 (audit TC-M4)
-- `fast-check` property test 도입 (audit TC-H2)
+- ~~`fast-check` property test 도입 (audit TC-H2)~~ → **#1로 끌어올림** (2026-06-18, 1.0.4 patch — 해자 강화 최우선). 2026-06-18 spec 참조
 - `DisabledRule` 타입 narrowing per picker 또는 시맨틱 명시 (audit API-G3)
 - e2e 확장: mid-flight prop 변경, locale switch
 - per-dependency 번들 크기 리포트 (audit B-R2, 특히 `@floating-ui/react` 기여도)
@@ -653,7 +660,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 1. `@kalyx/adapter-date-fns` npmjs.com Trusted Publisher 등록 — 1.0.0 publish는 토큰 수동이라 다음부터 OIDC + provenance 자동화.
 2. `@kalyx/adapter-date-fns@1.0.0` GitHub Release 수동 backfill (토큰 publish는 GH Release 미생성).
 3. `release.yml` 견고화 — ignored 패키지 changeset이 publish 차단 안 하도록 사전 검증 step.
-4. `apps/docs/CHANGELOG.md`, vitest lockfile drift refresh, `@floating-ui/react` 0.26→0.27 검토.
+4. `apps/docs/CHANGELOG.md`, vitest lockfile drift refresh. (~~`@floating-ui/react` 0.26→0.27 검토~~ → **완료**: package.json 이미 `^0.27.0`. docs-site `api/react.md` 의 0.26 표기만 정정 대상 — 2026-06-18 stale-fact 스윕)
 
 ### 카피 정정 (낮은 우선순위)
 

--- a/docs/superpowers/specs/2026-06-18-current-state-analysis-and-correctness-first-direction.md
+++ b/docs/superpowers/specs/2026-06-18-current-state-analysis-and-correctness-first-direction.md
@@ -1,0 +1,143 @@
+# Kalyx 현 시점 분석 + "정확성 먼저" 방향 확정 (2026-06-18)
+
+> **상태:** 확정 (사용자 승인). 이 문서가 2026-06-18 시점의 방향성 single source of truth다.
+> CLAUDE.md §14 의 Track 우선순위와 cleanup 항목은 이 문서를 따라 갱신된다.
+>
+> **근거:** 10-에이전트 멀티에이전트 현 시점 분석 (7 차원 점검 → 2 적대적 검증 → 종합). 모든 전략 주장은
+> 1차 출처(코드 file:line + 경쟁사 웹 URL)로 검증됨. 선행 분석(같은 날, 메모리에만 존재)을
+> "validate-or-challenge" 프레임으로 재검증한 결과 **confirmed-with-adjustments**.
+>
+> 관련: [`2026-06-17-competitive-landscape-and-v1.1-roadmap.md`](2026-06-17-competitive-landscape-and-v1.1-roadmap.md),
+> [`2026-06-17-kalyx-1.0-functional-audit.md`](2026-06-17-kalyx-1.0-functional-audit.md)
+
+---
+
+## 0. 한 줄 요약
+
+홍보는 접는다(사용자 결정). 다음 작업은 **검증된 해자(`@kalyx/core` 정확성)를 강화**하는 bundle-0 작업 순서:
+**①fast-check 속성테스트(1.0.4 patch) → ②conformance suite → ③누락 hook 4종(`/headless`) → ④(선택) dayjs 어댑터**.
+`@kalyx/adapter-temporal` 은 **근시일 드롭**(정확성 0 검증). 동시에 라이브 홍보 콘텐츠 제거 + stale fact 일괄 정정.
+
+---
+
+## 1. 현 시점 분석 (검증된 사실)
+
+### 1.1 번들 — 마진 고갈, CJS가 binding (🔴 제약)
+
+- 현재 측정값(on-disk dist = fresh build 동일, 3개 측정 경로 일치): **ESM 15.78KB (16163 B, 마진 221 B) / CJS 15.88KB (16258 B, 마진 126 B)**. 16KB = 16384 B.
+- **CJS 126 B 가 진짜 working headroom.** `scripts/check-bundle-size.js:12` 와 CLAUDE.md §14 B9 의 "~380 B 마진"은 **위험한 stale** — 다음 담당자가 380 B 믿고 천장 깬다.
+- **유일한 판별 기준 = 런타임 value-export가 어느 ENTRY에 올라타는가** (소비자 tree-shaking 아님). 예산은 `index.js`/`index.cjs` 전체 gzip로 측정되므로, `src/index.ts` 에 export 추가 = 소비자가 안 써도 bundle-positive.
+  - **Bundle-0:** 테스트/devDep(fast-check), 별도 패키지(어댑터), `@kalyx/core/test-helpers` subpath, `/headless` 엔트리(tsup `splitting:false` 로 물리적 분리, 예산 미측정).
+  - **Bundle-positive:** `src/index.ts` 그래프에 올라가는 모든 런타임 코드 (B10 a11y polish, B7 weekStartsOn 자동추론 등).
+  - `B5 DateTimePicker.Presets` 는 **배치 의존** — `/headless` 전용이면 0, 기본 엔트리면 positive. 명시 결정 필요.
+
+### 1.2 해자 = `@kalyx/core`, 어댑터 아님 (🟢 전략 축)
+
+- `DateAdapter` 인터페이스(`packages/core/src/types.ts:71-102`)는 **ISO-UTC 문자열 in/out**. ~24 메서드 중 `timezone?` 받는 건 **4개뿐**(format/isSameDay/startOfDay/today).
+- 그 4개조차 reference 어댑터에서 전부 core로 위임(`packages/adapter-date-fns/src/index.ts:84-85,130-131,149-150,176-177`). 어댑터는 ~200줄 얇은 shim.
+- 모든 hard TZ/DST 로직(`setTimeInTimezone`, `civilMidnightFromUtcDay`, `getTimezoneOffsetMinutes`, `startOfDayInTimezone` …)은 인터페이스에 **없고** core의 Intl 기반 `timezone.ts` 에 있음. core production src에 date-fns 참조 0건.
+- **결론:** 새 어댑터(dayjs/luxon/temporal)는 같은 core Intl 코드로 재위임 → 정확성 델타 0. 어댑터의 가치는 **생태계 도달(drop-in 친숙함)**, 정확성 아님.
+
+### 1.3 경쟁 thesis 완전 유효 (적대적 검증 통과)
+
+| 라이브러리 | 2026-06 상태 | Kalyx 갭 |
+|---|---|---|
+| react-day-picker 10.0.1 (~42M/wk) | v10은 cleanup 릴리즈. Calendar grid only, Input/TimePicker 없음(가이드만) | **열림** |
+| react-datepicker 9.1.0 (~4.7M/wk) | CSS import 필수, value=native Date 유지. #1018 "not a bug"로 종결. `timeZone` prop은 생겼으나 onChange는 여전히 Date | **열림** |
+| MUI X 9.5.0 | **58.2 KB gzip**(bundlephobia), Range/Time-Range는 Pro(유료) | **열림** (~3.7× 큼) |
+| Chakra UI v3.34 DatePicker (2026-03) | **신규** — Ark UI/`@internationalized/date` 강결합, standalone TimePicker 없음 | **열림 — 포지셔닝 승리** (강결합 축 심화) |
+| Adobe React Aria | `@internationalized/date` 결합 유지, Temporal 지향(미전환) | **열림** |
+
+→ 어느 경쟁사도 (headless + 7 primitive incl. standalone TimePicker + date-fns 호환 어댑터 + ISO/UTC + ≤16KB) 갭을 닫지 못함.
+
+### 1.4 테스트 커버리지 갭
+
+- 총 587 테스트. 분포 편중: DatePicker 82 … **WeekPicker 16 (최약)**, 키보드 nav 테스트 3개뿐.
+- **fast-check 속성테스트 0건, RTL 테스트 0건.**
+- `todayInTimezone` = **공개 API인데 테스트 0건** (최대 단일 갭).
+- audit TZ 항목: T-D3 **이미 완료**(#134). T-G1 부분만(UTC-only characterization). T-G3/T-R1/T-R2 사실상 미커버.
+
+### 1.5 API 비대칭
+
+- headless hook은 Date/Range/Time 3종만. Month/Year/Week/DateTime **없음**(B4).
+- `announce()` 패리티 불균일: RangePicker만 context-level live region(올바름), DatePicker는 Calendar-local useState, WeekPicker는 region 있으나 호출 안 함(무음), Month/Year/Time은 없음.
+- `getISOWeekNumber` 등 core util 함수가 `@kalyx/react`에서 re-export 안 됨(이미 번들 내 존재 → 추가는 ~0 B이나 **측정 후** 진행).
+- `resolveAdapter` 는 하드코딩 아님(파라미터화). 단 Month/Year/Week가 DatePicker/RangePicker Root를 wrapping → no-adapter 에러가 컴포넌트명 오표기. low severity.
+
+---
+
+## 2. adapter-temporal 모순 해결 → **근시일 드롭**
+
+> **충돌:** 커밋된 CLAUDE.md §14 Track B **B6 = "우선순위 상향"** vs 오늘 승인 방향 = "드롭". 이 문서가 B6를 덮어쓴다.
+
+- **정확성 다리 (검증, 결정적):** Temporal 어댑터는 인터페이스를 통해 TZ 정확성을 *물리적으로 운반 불가* — 같은 core Intl 코드로 재위임, 동일 결과. core는 이미 Temporal 기본 DST 정책(gap→snap-forward via `Math.max`, ambiguous→earlier via `Math.min`, `timezone.ts:199-208,264`)과 일치 → edge에서도 차별화 0. ISO 사용자는 `.toString()`으로 **어댑터 없이** 사용 → 인터롭 이득도 0(dayjs/luxon보다 약함).
+- **포지셔닝 다리 (근시일 무효):** (a) 홍보 접음(오늘 재확인) → optics 청중 없음; (b) 얇은 @0.x glue 어댑터는 "Temporal-native" 신뢰도 못 얻음(평가자는 같은 core 코드임을 봄); (c) 진짜 Temporal 역량은 core 레벨이고 이미 Track D로 demand-gate.
+- **결정:** `@kalyx/adapter-temporal` **근시일 드롭**. Temporal **전략**은 core 레벨에서 Track D 보존(사용자 issue ≥3 또는 enterprise sponsor 시 착수).
+- **과장 금지:** "Temporal 영원히 가치 0" 아님 — *Gregorian ISO 어댑터*가 정확성 0. 진짜 역량은 core에 속함.
+
+---
+
+## 3. 확정 로드맵 (순서·bundle 영향)
+
+| 순서 | 항목 | bundle | 근거 |
+|---|---|---|---|
+| **1** | **1.0.4 patch: fast-check 속성테스트 `@kalyx/core`** (timezone→calendar→date). **T-G3 리드**(`todayInTimezone` 0커버 + Pacific/Niue UTC−11 day-boundary) + T-G1 컴포넌트레벨(minDate×displayTimezone civil-midnight) + T-R1(Europe/London 2026-03-29 month-nav, 실제 산술) + T-R2(Feb-29 non-UTC round-trip). **T-D3 제외**(#134 완료) | 0 (devDep/test) | 즉시 착수 가능, 정확성 ROI 최고. `setTimeInTimezone` 2-pass DST가 crown-jewel·최고위험 → 속성테스트가 example test 이김. **단** 속성테스트가 발견한 *수정*이 `src/index.ts` 그래프 건드리면 126 B 마진 측정 필수 |
+| **2** | **`@kalyx/core/test-helpers` conformance suite** (새 exports subpath) | 0 (subpath) | 해자를 "검증된 계약"으로. 미래 어댑터 작성 부담 제거 |
+| **3** | **누락 hook 4종** useMonthPicker/useYearPicker/useWeekPicker/useDateTimePicker (`/headless` **전용**, DOM-free 유지=RN seam 보존) | 0 (entry 분리, **tree-shaking 아님**) | API 비대칭 해소(B4). `src/index.ts` 유출 시 bundle-positive — `verify-entry-split.mjs` CI 가드 유지 |
+| **4 (선택)** | **dayjs 어댑터**(P0, ~50% dayjs/Mantine 도달) — luxon보다 우선. **temporal 아님** | 0 (별도 pkg) | conformance suite 첫 외부 고객. 가치는 도달이지 정확성 아님 |
+
+**드롭/보류:** adapter-temporal(§2), 비그레고리력(Track D out-of-scope), RN("hook DOM-free 유지" 제약으로만 보존, 프로젝트 착수 X).
+
+---
+
+## 4. 홍보 제거 (라이브 콘텐츠 포함 — 사용자 결정)
+
+의존성 망 반영. 외부 사용자 0이라 실질 영향 미미하나 명시한다.
+
+| 항목 | 조치 |
+|---|---|
+| **블로그**(PR#122) | **원자적 1커밋 제거** — `docusaurus.config.ts` blog plugin(~79-99) + navbar Blog 링크(~151-155) + `authors.yml`(EN+KO i18n) + 두 글(EN+KO). ⚠️ `.mdx`만 삭제 시 dangling plugin/RSS로 **빌드 깨짐**. plugin 제거가 RSS/Atom도 깨끗이 제거. 라이브 `/blog/*` 404됨(명시) |
+| **announcementBar**(PR#120) | `docusaurus.config.ts` ~112-119 제거 |
+| **comparison 페이지**(EN+KO) | **완전 제거**(사용자 결정) — `apps/docs-site/docs/comparison.md` + `i18n/ko/.../comparison.md` + README 2곳 링크 + `docs.include` allowlist/navbar 참조. "홍보성 비교 없음" 일관 입장 |
+| 홍보 초안 | 이미 `docs/archive/promotion/`(완료) |
+| **og-hero.png**(PR#118) | ⚠️ **유지 필수** — 사이트 전역 og 이미지 + CI 강제(`check-hero-freshness.mjs:28`, `pr-check.yml:188`). 삭제 시 CI 하드 실패, 블로그 전용 아님 |
+
+---
+
+## 5. Stale fact 일괄 정정
+
+| # | 위치 | 틀림 → 맞음 |
+|---|---|---|
+| S1 | README.md:15,92 / README.ko.md:15,92 / CLAUDE.md:601 / `docusaurus.config.ts:126` / `docs/api/react.md:187`(+KO) / blog index.mdx(삭제됨) | 번들 15.63/15.76 → **15.78 ESM / 15.88 CJS** |
+| S2 | `scripts/check-bundle-size.js:12` + CLAUDE.md §14 B9 | "~380 B 마진" → **126 B CJS / 221 B ESM** (위험 stale) |
+| S3 | README.md:45 / README.ko.md:45 | MUI ~45 KB → **~58.2 KB gzip** (comparison.md는 삭제되므로 불필요) |
+| S4 | `docs/api/react.md:179`(+KO) + CLAUDE.md:657 item#4 | @floating-ui ^0.26.0 → **^0.27.0** (이미 done — cleanup 항목 종료 표기) |
+| S5 | README.md:92 / README.ko.md:92 / `docs/api/react.md:187`(+KO) | v1.0.0 / rc.14 → **1.0.3** (또는 버전-무관 표기로 drift 방지) |
+| S6 | `adapter-date-fns/package.json` | 미사용 `date-fns-tz` 의존성 **제거**(declared, import 0건) |
+| S7 | CLAUDE.md §14 B6 | "우선순위 상향" → **드롭 결정**(§2) 반영 |
+| — | 시장 수치 41.7M/4.7M | 일관(수정 불요), 단 undated → freshness 재확인 필요 표기 |
+
+---
+
+## 6. 실행 PR 구성
+
+| PR | 내용 | 비고 |
+|---|---|---|
+| **A** | 이 spec 문서 + CLAUDE.md §14 갱신(Track 재정렬, B6 드롭, floating-ui 종료, 380B→126B) | 기획/문서. **이 PR** |
+| **B** | 홍보 제거(블로그 원자적 + announcementBar + comparison EN+KO + README 링크) | docs-site 빌드 영향 → 격리해 CI 빌드 검증 |
+| **C** | stale fact 일괄(S1·S3·S4·S5) + date-fns-tz 제거(S6) | 텍스트/의존성 |
+| **D** | #1 fast-check 1.0.4 patch (TDD) | 별도 release |
+
+> B/C는 둘 다 docs-site/README 건드리므로 합칠 수 있으나, B는 빌드 위험 변경·C는 텍스트라 리뷰 분리가 깔끔. 최종 분할은 writing-plans에서.
+
+---
+
+## 7. 주요 리스크
+
+1. **번들 천장(126 B CJS):** 로드맵은 전부 bundle-0이나, #1 속성테스트가 발견한 *수정*이 런타임 그래프에 들어가면 천장 깸. 완화: `scripts/bundle-diff.mjs`(B9) 먼저, 모든 런타임 수정 단독 측정.
+2. **hook 유출:** #3의 0 보장은 entry 분리지 tree-shaking 아님. barrel-export 실수로 `src/index.ts` 유출 시 bundle-positive. 완화: `verify-entry-split.mjs` CI 가드 유지.
+3. **우발적 동작 고정:** WeekPicker 키보드 테스트는 **A-G2 nav 결정 후** 작성. 안 그러면 우발 동작을 계약으로 박제.
+4. **"free 윈" 미검증:** `getISOWeekNumber` re-export(F3)·컴포넌트명 threading(F4)은 "0 B" 미측정. 126 B에서 신뢰 금지 — **측정 우선**.
+5. **홍보 제거 원자성:** `.mdx`만 삭제/og-hero 삭제 = 빌드·CI 깸. all-or-nothing.
+6. **temporal 드롭 과장:** "영원히 0" 아님 — Gregorian ISO 어댑터만 0. core 역량은 Track D demand-gate.
+7. **솔로 처리량:** #2·#4 + 정정 + 제거는 1인 실작업. 엄격 순서화, #4는 진짜 선택.


### PR DESCRIPTION
## Summary

2026-06-18 멀티에이전트 현 시점 분석(10 에이전트, 7차원 → 적대적 검증 → 종합)을 방향성 single-source-of-truth로 커밋하고 CLAUDE.md §14를 정렬.

선행(같은 날, 메모리 한정) 방향을 validate-or-challenge → **confirmed-with-adjustments**. 모든 전략 주장은 코드 file:line + 경쟁사 웹 1차 출처로 검증.

### 확정 방향
- **홍보 접음** (사용자 결정, 외부 사용자 ~0). 라이브 홍보 콘텐츠는 후속 PR에서 제거.
- **bundle-0 실행 순서**: ①fast-check 속성테스트 `@kalyx/core` (1.0.4, T-G3 리드) → ②`@kalyx/core/test-helpers` conformance → ③누락 hook 4종(`/headless`) → ④(선택) dayjs 어댑터.
- **adapter-temporal 근시일 드롭**: 정확성 0 검증 — `DateAdapter` 인터페이스가 ISO-string in/out, 모든 TZ/DST가 core Intl `timezone.ts`에 있어 Temporal 어댑터는 동일 core 코드로 재위임. Temporal *전략*은 core 레벨 Track D demand-gate.
- **번들 마진 = CJS 126 B / ESM 221 B** (binding=CJS; 이전 "~380 B"는 stale).

### 변경
- 신규 spec `docs/superpowers/specs/2026-06-18-current-state-analysis-and-correctness-first-direction.md`
- CLAUDE.md §14: 방향 포인터+intro, B6(temporal)·B11(comparison) 드롭 표기, B9 마진 정정, fast-check #1로 승격, floating-ui cleanup 항목 종료

문서 전용. 코드/번들 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 정확성 우선 방향에 대한 현황 분석 및 로드맵 문서가 확정되었습니다.
  * 향후 개발 우선순위 및 실행 계획이 업데이트되었습니다.

* **계획 변경**
  * 특정 어댑터의 근단기 드롭이 결정되었습니다.
  * 번들 크기 기준이 재정의되었습니다.

**참고:** 사용자 대면 기능에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->