### PR TITLE
test(core): property-based timezone hardening + T-G3/T-R2 coverage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,8 @@
 		"clean": "rm -rf dist"
 	},
 	"devDependencies": {
-		"@kalyx/adapter-date-fns": "workspace:*"
+		"@kalyx/adapter-date-fns": "workspace:*",
+		"fast-check": "^3.23.2"
 	},
 	"engines": {
 		"node": ">=20.0.0"

--- a/packages/core/src/__tests__/timezone.property.test.ts
+++ b/packages/core/src/__tests__/timezone.property.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  startOfDayInTimezone,
+  isSameDayInTimezone,
+  getTimeInTimezone,
+  setTimeInTimezone,
+  civilMidnightFromUtcDay,
+  formatInTimezone,
+  todayInTimezone,
+} from '../utils/timezone.js';
+
+// Property-based hardening of the crown-jewel timezone utilities. The
+// example-based DST tests in `timezone.test.ts` pin specific transitions; these
+// properties assert the invariants must hold across thousands of random
+// instants and zones — exactly where example tests have blind spots.
+//
+// Zone set: whole + fractional offsets, both hemispheres, DST + non-DST, and
+// the extreme +14 / -11 ends. Deliberately EXCLUDES zones with a *midnight* DST
+// transition in 2020-2045 (e.g. historical America/Sao_Paulo), because
+// `startOfDayInTimezone` does not gap-snap and a non-existent civil midnight is
+// a separate, out-of-scope edge — including such a zone would make the
+// "reads as 00:00:00" invariant a false positive rather than a real find.
+const ZONES = [
+  'UTC',
+  'America/New_York',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Europe/Berlin',
+  'Australia/Sydney',
+  'Asia/Seoul',
+  'Asia/Kolkata', // +5:30
+  'Asia/Kathmandu', // +5:45
+  'Australia/Eucla', // +8:45
+  'Pacific/Niue', // -11
+  'Pacific/Kiritimati', // +14
+] as const;
+
+const zone = () => fc.constantFrom(...ZONES);
+
+const isoInstant = () =>
+  fc
+    .date({
+      min: new Date('2020-01-01T00:00:00.000Z'),
+      max: new Date('2045-01-01T00:00:00.000Z'),
+      noInvalidDate: true,
+    })
+    .map((d) => d.toISOString());
+
+const timeOfDay = () =>
+  fc.record({
+    hours: fc.integer({ min: 0, max: 23 }),
+    minutes: fc.integer({ min: 0, max: 59 }),
+    seconds: fc.integer({ min: 0, max: 59 }),
+  });
+
+const RUNS = { numRuns: 300 };
+
+describe('timezone invariants (property-based)', () => {
+  it('startOfDayInTimezone is idempotent', () => {
+    fc.assert(
+      fc.property(isoInstant(), zone(), (iso, tz) => {
+        const once = startOfDayInTimezone(iso, tz);
+        expect(startOfDayInTimezone(once, tz)).toBe(once);
+      }),
+      RUNS,
+    );
+  });
+
+  it('startOfDayInTimezone lands on the same civil day as its input', () => {
+    fc.assert(
+      fc.property(isoInstant(), zone(), (iso, tz) => {
+        expect(isSameDayInTimezone(iso, startOfDayInTimezone(iso, tz), tz)).toBe(true);
+      }),
+      RUNS,
+    );
+  });
+
+  it('startOfDayInTimezone reads back as 00:00:00 in the zone', () => {
+    fc.assert(
+      fc.property(isoInstant(), zone(), (iso, tz) => {
+        expect(getTimeInTimezone(startOfDayInTimezone(iso, tz), tz)).toEqual({
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        });
+      }),
+      RUNS,
+    );
+  });
+
+  it('setTimeInTimezone preserves the civil day (time-only edit never crosses a date boundary)', () => {
+    fc.assert(
+      fc.property(isoInstant(), zone(), timeOfDay(), (iso, tz, t) => {
+        expect(isSameDayInTimezone(iso, setTimeInTimezone(iso, t, tz), tz)).toBe(true);
+      }),
+      RUNS,
+    );
+  });
+
+  it('setTimeInTimezone round-trips a midday time exactly (noon is never a DST gap/ambiguity)', () => {
+    fc.assert(
+      fc.property(
+        isoInstant(),
+        zone(),
+        fc.integer({ min: 0, max: 59 }),
+        fc.integer({ min: 0, max: 59 }),
+        (iso, tz, minutes, seconds) => {
+          const t = { hours: 12, minutes, seconds };
+          expect(getTimeInTimezone(setTimeInTimezone(iso, t, tz), tz)).toEqual(t);
+        },
+      ),
+      RUNS,
+    );
+  });
+
+  it('setTimeInTimezone to an already-set midday time is stable (idempotent)', () => {
+    fc.assert(
+      fc.property(isoInstant(), zone(), (iso, tz) => {
+        const t = { hours: 12, minutes: 0, seconds: 0 };
+        const once = setTimeInTimezone(iso, t, tz);
+        expect(setTimeInTimezone(once, t, tz)).toBe(once);
+      }),
+      RUNS,
+    );
+  });
+});
+
+describe('todayInTimezone (T-G3 — was zero-coverage public API)', () => {
+  it('returns the civil-midnight of "today" in the zone', () => {
+    const now = new Date().toISOString();
+    for (const tz of [
+      'Asia/Seoul',
+      'America/New_York',
+      'Pacific/Niue',
+      'Pacific/Kiritimati',
+    ] as const) {
+      const today = todayInTimezone(tz);
+      expect(getTimeInTimezone(today, tz)).toEqual({ hours: 0, minutes: 0, seconds: 0 });
+      expect(isSameDayInTimezone(today, now, tz)).toBe(true);
+    }
+  });
+
+  it('yields distinct civil days across the extreme +14 / -11 zones', () => {
+    // Kiritimati (UTC+14) and Niue (UTC-11) are 25h apart, so their civil
+    // "today" midnights can never resolve to the same UTC instant.
+    expect(todayInTimezone('Pacific/Kiritimati')).not.toBe(todayInTimezone('Pacific/Niue'));
+  });
+});
+
+describe('Feb 29 round-trip where the civil date differs from the UTC date (T-R2)', () => {
+  it('maps the UTC grid day to civil Feb 29 midnight in Asia/Seoul', () => {
+    // Grid iterates in UTC; clicking the 2024-02-29 cell under displayTimezone
+    // Asia/Seoul must emit Seoul's civil Feb-29 midnight = UTC Feb-28 15:00.
+    const seoulFeb29 = civilMidnightFromUtcDay('2024-02-29T00:00:00.000Z', 'Asia/Seoul');
+    expect(seoulFeb29).toBe('2024-02-28T15:00:00.000Z');
+    expect(getTimeInTimezone(seoulFeb29, 'Asia/Seoul')).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+    expect(formatInTimezone(seoulFeb29, 'yyyy-MM-dd', 'Asia/Seoul')).toBe('2024-02-29');
+  });
+
+  it('keeps Feb 29 a leap-day instant when set to a wall-clock time in Asia/Seoul', () => {
+    const seoulFeb29 = civilMidnightFromUtcDay('2024-02-29T00:00:00.000Z', 'Asia/Seoul');
+    const at0930 = setTimeInTimezone(
+      seoulFeb29,
+      { hours: 9, minutes: 30, seconds: 0 },
+      'Asia/Seoul',
+    );
+    expect(formatInTimezone(at0930, 'yyyy-MM-dd HH:mm', 'Asia/Seoul')).toBe('2024-02-29 09:30');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@kalyx/adapter-date-fns':
         specifier: workspace:*
         version: link:../adapter-date-fns
+      fast-check:
+        specifier: ^3.23.2
+        version: 3.23.2
 
   packages/react:
     dependencies:
@@ -4558,6 +4561,10 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6600,6 +6607,9 @@ packages:
   pupa@3.3.0:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -13316,6 +13326,10 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -15709,6 +15723,8 @@ snapshots:
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
+
+  pure-rand@6.1.0: {}
 
   pvtsutils@1.3.6:
     dependencies:


### PR DESCRIPTION
"정확성 먼저" 방향(#138)의 **#1 빌드 착수**. crown-jewel 타임존 유틸을 속성테스트로 fuzz하고 최고가치 미커버 audit 갭을 메움. **Tests only** — fast-check는 devDependency라 published 번들 불변(changeset 없음, #134와 동일).

## 추가
- **fast-check 속성 6종 × 300런**, 12-zone 세트(정수+분수 offset, 양반구, DST/비DST, +14/−11 극단):
  - `startOfDayInTimezone` 멱등성 / 같은 civil-day / 00:00:00 read-back
  - `setTimeInTimezone` civil-day 보존 / 정오 정확 라운드트립 / set-stability
  - midnight DST zone은 의도적 제외(non-gap-snapping startOfDay의 out-of-scope 엣지 — 오탐 방지)
- **T-G3**: `todayInTimezone` (이전 **0 커버리지** 공개 API) — in-zone civil midnight 반환 + +14/−11 극단 civil-day 구분
- **T-R2**: civil date ≠ UTC date인 Feb-29 라운드트립 (Asia/Seoul civil Feb-29 midnight = UTC Feb-28 15:00, wall-clock set이 leap day 보존)

## 검증 (이빨 확인)
`setTimeInTimezone`에 +1분 오프셋 버그 주입 → 라운드트립 + leap-day 테스트가 **shrink된 반례**(`["2020-01-01T00:00:00.000Z","UTC",0,0]`)와 함께 RED → 소스 복원 시 10/10 GREEN. 속성테스트가 실제 타임존 산술 버그를 잡음을 입증.

core suite 150 pass, `tsc -b` + lint clean. 버그 미발견 → 버전 범프 없음.

> 향후(같은 트랙): T-G1(컴포넌트레벨 minDate×TZ), T-R1(Europe/London 2026-03-29 month-nav), calendar/date 모듈 속성테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 시간대 유틸리티에 대한 확장된 테스트 커버리지 추가

* **Chores**
  * 개발 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->