### PR TITLE
fix(security): bump webpack-dev-server to >=5.2.5 (GHSA-mx8g-39q3-5c79)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 			"@babel/plugin-transform-modules-systemjs": ">=7.29.4",
 			"next": ">=15.5.18",
 			"brace-expansion@5": ">=5.0.6",
-			"webpack-dev-server": ">=5.2.4",
+			"webpack-dev-server": ">=5.2.5",
 			"ws@8": ">=8.21.0",
 			"qs@6": ">=6.15.2",
 			"shell-quote": ">=1.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   next: '>=15.5.18'
   brace-expansion@5: '>=5.0.6'
-  webpack-dev-server: '>=5.2.4'
+  webpack-dev-server: '>=5.2.5'
   ws@8: '>=8.21.0'
   qs@6: '>=6.15.2'
   shell-quote: '>=1.8.4'
@@ -7740,8 +7740,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.4:
-    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
+  webpack-dev-server@5.2.5:
+    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -9486,7 +9486,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.15))(@swc/html@1.15.41)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.15))(@swc/html@1.15.41)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.41(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.15)(esbuild@0.28.1)(postcss@8.5.15)
@@ -16943,7 +16943,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.15))(@swc/html@1.15.41)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+  webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.41(@swc/helpers@0.5.15))(@swc/html@1.15.41)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
## Summary

OSV가 **GHSA-mx8g-39q3-5c79** (webpack-dev-server 5.2.4, 5.3 moderate — 비-Chromium 브라우저로 악성 사이트 방문 시 소스코드 노출)를 플래그. docusaurus docs-site의 **transitive dev 전용** 의존성(`docusaurus start`에서만 사용, npm 사용자 미배포)이고 **이미 main에 존재**하던 것 — 새로 게시된 advisory가 lockfile 건드린 #140에서 표면화.

패치 5.2.5가 존재하므로 osv-scanner.toml 억제가 아니라 기존 `pnpm.overrides` floor를 **`>=5.2.4` → `>=5.2.5`** 로 상향. lockfile이 webpack-dev-server@5.2.5로 resolve, 5.2.4 완전 제거.

- 번들 0, 공개 패키지 미영향(dev 도구), docs-site build 미영향(build는 dev server 미사용).
- 이 PR의 목적이 OSV 게이트 해소이므로 OSV 통과 확인 후 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)