### PR TITLE
test(react): lock UTC-only before/after bounds under displayTimezone (T-G1)

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1070,6 +1070,45 @@ describe('DatePicker — date rules and edge cases (CLAUDE.md §7)', () => {
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-12T/));
   });
 
+  it('before/after bounds (minDate/maxDate) compare UTC instants and are unaffected by displayTimezone (T-G1)', async () => {
+    // The grid emits UTC-midnight ISO cells and isDateDisabled compares pure UTC
+    // instants, so a displayTimezone must NOT shift which day a UTC bound gates —
+    // even a +9:00 zone where the bound sits near the civil-midnight boundary.
+    const renderWith = (displayTimezone?: string) =>
+      render(
+        <DatePicker
+          value="2026-06-17T00:00:00.000Z"
+          disabled={[{ before: '2026-06-17T00:00:00.000Z' }, { after: '2026-06-20T00:00:00.000Z' }]}
+          displayTimezone={displayTimezone}
+        >
+          <DatePicker.Input aria-label="날짜 선택" />
+          <DatePicker.Popover>
+            <DatePicker.Calendar />
+          </DatePicker.Popover>
+        </DatePicker>,
+      );
+
+    const user = userEvent.setup();
+
+    // Asia/Seoul (+9): the boundary days are gated by the UTC instant, not the
+    // Seoul civil day. Equal-to-bound is enabled; strictly outside is disabled.
+    const seoul = renderWith('Asia/Seoul');
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('button', { name: /June 16, 2026/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /June 17, 2026/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /June 20, 2026/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /June 21, 2026/ })).toBeDisabled();
+    seoul.unmount();
+
+    // Identical disabled set without displayTimezone — proves the zone is inert
+    // for the bound comparison (locks the UTC-only semantics at the React boundary).
+    renderWith(undefined);
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('button', { name: /June 16, 2026/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /June 17, 2026/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /June 21, 2026/ })).toBeDisabled();
+  });
+
   it('blocks per-day disabled rules (dayOfWeek) and shows them as visually disabled', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();


### PR DESCRIPTION
#1(correctness-first)의 **마지막 커버리지 갭**. audit T-G1: minDate/maxDate(=before/after disabled 규칙)는 UTC instant 비교인데, `displayTimezone`이 경계를 이동시키지 않는다는 걸 컴포넌트레벨에서 lock한 테스트가 없었음.

## 추가
DatePicker에 before/after 경계 + `displayTimezone="Asia/Seoul"`(+9, 경계가 civil-midnight 근처) 렌더 → equal-to-bound enabled / strictly-outside disabled 검증 → **같은 설정을 displayTimezone 없이 재렌더해 동일 disabled 셋** 확인(zone이 경계 비교에 inert = UTC-only 시맨틱 React 경계 lock).

이빨 검증: 경계일 기대값 flip → RED. React 349 pass, tsc·lint clean. test-only.

## #1 완료
timezone(#140) + calendar/date(#143) + 컴포넌트 경계(이 PR), T-D3=#134. **correctness-first 강화 완료** → 다음 #2 conformance suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)