### PR TITLE
fix(release): stop spurious adapter-date-fns major bump in the 1.1.0 release PR

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": ["@kalyx/docs", "docs-site"]
+	"ignore": ["@kalyx/docs", "docs-site"],
+	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+		"onlyUpdatePeerDependentsWhenOutOfRange": true
+	}
 }


### PR DESCRIPTION
## Problem
자동 생성된 1.1.0 release PR(#146)이 **@kalyx/adapter-date-fns를 2.0.0(major)** 로 올림 — 패키지 자체는 변경 0인데. 원인: adapter가 `@kalyx/core`를 **peerDependency**로 선언, Changesets 기본 동작이 **peer dep의 어떤 bump든 peer-dependent의 breaking(major)** 으로 취급. core minor(1.0.2→1.1.0)가 adapter major로 cascade.

## Fix
`onlyUpdatePeerDependentsWhenOutOfRange: true` 설정 → peer-dependent는 새 peer 버전이 **선언 범위를 벗어날 때만** bump. core 1.1.0은 adapter의 `workspace:^` peer 범위 안 → adapter는 **아예 안 올라감**(published `^1.x`가 1.1.0 수용). 진짜 core major면 adapter도 올바르게 major.

## Verify
적용 후 `changeset status`: core+react minor, **major 0건**. → release PR이 adapter 2.0.0 없이 재생성됨(core/react만 1.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)