### PR TITLE
feat(adapter-dayjs): dayjs adapter (#4) + drop unused date-fns-tz

### DIFF
--- a/.changeset/adapter-dayjs.md
+++ b/.changeset/adapter-dayjs.md
@@ -1,0 +1,5 @@
+---
+"@kalyx/adapter-dayjs": minor
+---
+
+New package: **`@kalyx/adapter-dayjs`** — a dayjs-backed `DateAdapter`, drop-in for the ~half of the ecosystem (Mantine and others) already shipping dayjs. It runs dayjs in UTC mode for the same UTC / ISO-8601 semantics as `@kalyx/adapter-date-fns`, delegates all timezone-aware operations to `@kalyx/core` (the correctness moat lives in core, not the adapter), and is validated against the full `@kalyx/core/test-helpers` conformance suite — the suite's first second implementation, proving the `DateAdapter` contract is portable rather than date-fns-specific.

--- a/.changeset/drop-date-fns-tz.md
+++ b/.changeset/drop-date-fns-tz.md
@@ -1,0 +1,5 @@
+---
+"@kalyx/adapter-date-fns": patch
+---
+
+Remove the unused `date-fns-tz` dependency. It was declared but never imported — all timezone work is delegated to `@kalyx/core`'s Intl-based utilities — so dropping it shrinks the install / supply-chain surface with no behavior change.

--- a/packages/adapter-dayjs/package.json
+++ b/packages/adapter-dayjs/package.json
@@ -1,26 +1,25 @@
 {
-	"name": "@kalyx/adapter-date-fns",
-	"version": "1.0.0",
-	"description": "date-fns adapter for @kalyx/core — implements the DateAdapter contract using date-fns (timezone work is delegated to @kalyx/core's Intl-based utilities).",
+	"name": "@kalyx/adapter-dayjs",
+	"version": "0.0.0",
+	"description": "dayjs adapter for @kalyx/core — implements the DateAdapter contract using dayjs (UTC mode). Timezone work is delegated to @kalyx/core's Intl-based utilities.",
 	"license": "MIT",
 	"author": "jiji-hoon96",
 	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/jiji-hoon96/kalyx.git",
-		"directory": "packages/adapter-date-fns"
+		"directory": "packages/adapter-dayjs"
 	},
 	"bugs": {
 		"url": "https://github.com/jiji-hoon96/kalyx/issues"
 	},
 	"keywords": [
-		"date-fns",
+		"dayjs",
 		"adapter",
 		"kalyx",
 		"datepicker"
 	],
 	"type": "module",
-	"sideEffects": false,
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -48,7 +47,7 @@
 	},
 	"dependencies": {
 		"@kalyx/core": "workspace:^",
-		"date-fns": "^4.0.0"
+		"dayjs": "^1.11.13"
 	},
 	"peerDependencies": {
 		"@kalyx/core": "workspace:^"
@@ -62,7 +61,6 @@
 		"node": ">=20.0.0"
 	},
 	"publishConfig": {
-		"access": "public",
-		"provenance": true
+		"access": "public"
 	}
 }

--- a/packages/adapter-dayjs/src/__tests__/conformance.test.ts
+++ b/packages/adapter-dayjs/src/__tests__/conformance.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { runAdapterConformanceTests } from '@kalyx/core/test-helpers';
+import { DayjsAdapter } from '../index.js';
+
+// The dayjs adapter must satisfy the exact same DateAdapter contract as the
+// reference date-fns adapter. This is the conformance suite's first SECOND
+// implementation — proving the contract is portable, not date-fns-specific.
+runAdapterConformanceTests(DayjsAdapter, { describe, it, expect });
+
+// A couple of dayjs-specific sanity checks beyond the shared contract.
+describe('DayjsAdapter — UTC mode sanity', () => {
+  it('operates in UTC regardless of host timezone', () => {
+    // 00:00 UTC must read back as day 15, not shifted into the local zone.
+    expect(DayjsAdapter.getDate('2026-01-15T00:00:00.000Z')).toBe(15);
+    expect(DayjsAdapter.format('2026-01-15T00:00:00.000Z', 'yyyy-MM-dd HH:mm')).toBe(
+      '2026-01-15 00:00',
+    );
+  });
+
+  it('round-trips a value through parse → format', () => {
+    expect(DayjsAdapter.format(DayjsAdapter.parse('2026-07-04'), 'yyyy-MM-dd')).toBe('2026-07-04');
+  });
+});

--- a/packages/adapter-dayjs/src/index.ts
+++ b/packages/adapter-dayjs/src/index.ts
@@ -1,0 +1,170 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import type { DateAdapter } from '@kalyx/core';
+import {
+  formatInTimezone,
+  isSameDayInTimezone,
+  startOfDayInTimezone,
+  todayInTimezone,
+} from '@kalyx/core';
+
+// Run dayjs in UTC mode so every operation matches Kalyx's UTC/ISO-8601
+// contract regardless of the host's local timezone. NOTE: this `extend` is a
+// load-time side effect — the package deliberately does NOT set
+// `"sideEffects": false`, otherwise a bundler could legally drop this call and
+// `dayjs.utc(...)` would throw in the consumer's build.
+dayjs.extend(utc);
+
+const d = (iso: string) => dayjs.utc(iso);
+
+/** Normalize an ISO date string: "YYYY-MM-DD" → "YYYY-MM-DDTHH:mm:ss.sssZ". */
+function normalize(value: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T00:00:00.000Z`;
+  }
+  return value;
+}
+
+/**
+ * DateAdapter implementation backed by dayjs (UTC mode). A drop-in alternative
+ * to `@kalyx/adapter-date-fns` for teams already shipping dayjs — same UTC
+ * semantics, validated against `@kalyx/core/test-helpers`. Timezone-aware
+ * operations delegate to `@kalyx/core`'s Intl-based utilities (the correctness
+ * moat lives in core, not the adapter).
+ *
+ * @example
+ * ```ts
+ * import { DayjsAdapter } from '@kalyx/adapter-dayjs';
+ * import { DatePicker } from '@kalyx/react/headless';
+ *
+ * <DatePicker adapter={DayjsAdapter} value={iso} onChange={setIso}>…</DatePicker>
+ * ```
+ */
+export const DayjsAdapter: DateAdapter = {
+  parse(value: string): string {
+    if (!value) return '';
+    return normalize(value);
+  },
+
+  format(iso: string, formatStr: string, timezone?: string): string {
+    if (timezone) {
+      return formatInTimezone(iso, formatStr, timezone);
+    }
+    const t = d(iso);
+    const tokens: Record<string, string> = {
+      yyyy: String(t.year()),
+      MM: String(t.month() + 1).padStart(2, '0'),
+      dd: String(t.date()).padStart(2, '0'),
+      HH: String(t.hour()).padStart(2, '0'),
+      mm: String(t.minute()).padStart(2, '0'),
+      ss: String(t.second()).padStart(2, '0'),
+      M: String(t.month() + 1),
+      d: String(t.date()),
+    };
+    let result = formatStr;
+    // Replace longer tokens first to prevent partial matches.
+    for (const [token, value] of Object.entries(tokens).sort((a, b) => b[0].length - a[0].length)) {
+      result = result.split(token).join(value);
+    }
+    return result;
+  },
+
+  addDays(iso: string, n: number): string {
+    return d(iso).add(n, 'day').toISOString();
+  },
+
+  addMonths(iso: string, n: number): string {
+    return d(iso).add(n, 'month').toISOString();
+  },
+
+  addYears(iso: string, n: number): string {
+    return d(iso).add(n, 'year').toISOString();
+  },
+
+  isBefore(a: string, b: string): boolean {
+    return d(a).isBefore(d(b));
+  },
+
+  isAfter(a: string, b: string): boolean {
+    return d(a).isAfter(d(b));
+  },
+
+  isSameDay(a: string, b: string, timezone?: string): boolean {
+    if (!a || !b) return false;
+    if (timezone) {
+      return isSameDayInTimezone(a, b, timezone);
+    }
+    const da = d(a);
+    const db = d(b);
+    return da.year() === db.year() && da.month() === db.month() && da.date() === db.date();
+  },
+
+  isSameMonth(a: string, b: string): boolean {
+    const da = d(a);
+    const db = d(b);
+    return da.year() === db.year() && da.month() === db.month();
+  },
+
+  startOfDay(iso: string, timezone?: string): string {
+    if (timezone) {
+      return startOfDayInTimezone(iso, timezone);
+    }
+    return d(iso).startOf('day').toISOString();
+  },
+
+  startOfMonth(iso: string): string {
+    return d(iso).startOf('month').toISOString();
+  },
+
+  endOfMonth(iso: string): string {
+    return d(iso).endOf('month').toISOString();
+  },
+
+  startOfWeek(iso: string, weekStartsOn: 0 | 1 = 0): string {
+    const t = d(iso);
+    const diff = (t.day() - weekStartsOn + 7) % 7;
+    return t.subtract(diff, 'day').startOf('day').toISOString();
+  },
+
+  endOfWeek(iso: string, weekStartsOn: 0 | 1 = 0): string {
+    const t = d(iso);
+    const diff = (t.day() - weekStartsOn + 7) % 7;
+    return t.subtract(diff, 'day').add(6, 'day').endOf('day').toISOString();
+  },
+
+  now(): string {
+    return dayjs.utc().toISOString();
+  },
+
+  today(timezone?: string): string {
+    if (timezone) {
+      return todayInTimezone(timezone);
+    }
+    return dayjs.utc().startOf('day').toISOString();
+  },
+
+  isValid(value: string): boolean {
+    if (!value) return false;
+    // dayjs parsing is lenient without customParseFormat strict mode (e.g.
+    // "2026-02-30" rolls over rather than failing). That's acceptable here —
+    // the DateAdapter contract only requires rejecting empty / unparseable
+    // input, which this satisfies.
+    return d(normalize(value)).isValid();
+  },
+
+  getYear(iso: string): number {
+    return d(iso).year();
+  },
+
+  getMonth(iso: string): number {
+    return d(iso).month();
+  },
+
+  getDate(iso: string): number {
+    return d(iso).date();
+  },
+
+  getDay(iso: string): number {
+    return d(iso).day();
+  },
+};

--- a/packages/adapter-dayjs/tsconfig.json
+++ b/packages/adapter-dayjs/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,9 +401,15 @@ importers:
       date-fns:
         specifier: ^4.0.0
         version: 4.4.0
-      date-fns-tz:
-        specifier: ^3.0.0
-        version: 3.2.0(date-fns@4.4.0)
+
+  packages/adapter-dayjs:
+    dependencies:
+      '@kalyx/core':
+        specifier: workspace:^
+        version: link:../core
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.21
 
   packages/core:
     devDependencies:
@@ -4128,13 +4134,11 @@ packages:
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
-  date-fns-tz@3.2.0:
-    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
-    peerDependencies:
-      date-fns: ^3.0.0 || ^4.0.0
-
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -12853,11 +12857,9 @@ snapshots:
 
   dataloader@1.4.0: {}
 
-  date-fns-tz@3.2.0(date-fns@4.4.0):
-    dependencies:
-      date-fns: 4.4.0
-
   date-fns@4.4.0: {}
+
+  dayjs@1.11.21: {}
 
   debounce@1.2.1: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 	"references": [
 		{ "path": "packages/core" },
 		{ "path": "packages/adapter-date-fns" },
+		{ "path": "packages/adapter-dayjs" },
 		{ "path": "packages/react" }
 	]
 }


### PR DESCRIPTION
로드맵 **#4** + 공급망 위생, 둘 다 1.1.0 release wave.

## `@kalyx/adapter-dayjs` (신규, 0.1.0)
- dayjs 기반 `DateAdapter` — 이미 dayjs를 쓰는 생태계(~절반, Mantine 등)에 drop-in. dayjs UTC 모드로 date-fns 어댑터와 동일 UTC/ISO 시맨틱, timezone은 전부 `@kalyx/core`로 위임(정확성 해자는 core).
- **`@kalyx/core/test-helpers` conformance suite 전체 통과(20 테스트)** — suite의 **첫 2번째 구현** → `DateAdapter` 계약이 date-fns 전용이 아니라 portable함을 입증(#2의 payoff 실현).
- ⚠️ **`sideEffects: false` 의도적 제외**: `dayjs.extend(utc)`가 load-time side effect라, side-effect-free로 표시하면 minifier가 drop→소비자 번들에서 `dayjs.utc()` 터짐. **미니파이 ESM 소비자 번들 실행으로 검증**.
- `provenance` first-publish 제외(OIDC/Trusted Publisher 미등록 — 아래 노트).
- core를 peerDependency로 선언(adapter-date-fns와 동일); #148 fix가 core minor의 major cascade 차단.
- 루트 tsconfig references 추가(tsc -b 타입체크).

## `@kalyx/adapter-date-fns` (patch) — "OSV"/위생
- 선언만 되고 import 0인 **`date-fns-tz` 제거**(tz는 core 위임). 설치/공급망 표면 축소, 동작 변경 없음.
- **OSV scan 깨끗**(lockfile 변경 후 dayjs 취약점 0, `osv-scanner` "No issues found").

## Release
changeset: core/react minor, adapter-dayjs **minor(0.1.0)**, adapter-date-fns **patch(1.0.1)**, **major 0건**.

⚠️ **Publish 노트(사용자 결정)**: adapter 패키지들(date-fns·dayjs)은 npm **Trusted Publisher 미등록** → CI OIDC publish 실패 가능. 첫 publish는 Trusted Publisher 등록 후 OR 수동 토큰(provenance 없이). 1.1.0 Version PR 머지 시 고려.

604 package 테스트 pass, `tsc -b`·lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)