### PR TITLE
fix(timezone): UTC-stable date arithmetic across DST transitions

### DIFF
--- a/.changeset/fix-adapter-utc-arithmetic.md
+++ b/.changeset/fix-adapter-utc-arithmetic.md
@@ -1,0 +1,5 @@
+---
+"@kalyx/adapter-date-fns": patch
+---
+
+Make `addDays` / `addMonths` / `addYears` UTC-stable. They used date-fns, which mutates the LOCAL date field, so on a runtime whose timezone observed DST in the iterated range (e.g. Asia/Seoul in 1987–88) the day-by-day calendar-grid iteration drifted by an hour and duplicated/skipped a UTC day. The adapter now adds in UTC (a UTC day is exactly 86_400_000 ms, with month/year clamping preserved), so calendar grids are identical regardless of the user's `process.env.TZ` / browser timezone. Surfaced by the new calendar property suite.

--- a/.changeset/fix-startofday-dst.md
+++ b/.changeset/fix-startofday-dst.md
@@ -1,0 +1,5 @@
+---
+"@kalyx/core": patch
+---
+
+Fix `startOfDayInTimezone` returning an instant one hour early on a DST-transition day. It took a single UTC-offset probe at "civil-midnight-as-UTC", which can land on the wrong side of a transition (e.g. Australia/Sydney springing forward on Oct 1: 00:00 local is still AEST +10, but 00:00 UTC reads as post-transition AEDT +11). It now delegates to `setTimeInTimezone`'s two-pass DST disambiguation, so civil midnight is correct on transition days; this also flows through `todayInTimezone` and `civilMidnightFromUtcDay`. Surfaced by the new fast-check property suite.

--- a/packages/adapter-date-fns/src/__tests__/date-fns-adapter.test.ts
+++ b/packages/adapter-date-fns/src/__tests__/date-fns-adapter.test.ts
@@ -216,4 +216,31 @@ describe('DateFnsAdapter', () => {
       expect(adapter.startOfDay('2026-01-15T14:30:00.000Z')).toBe('2026-01-15T00:00:00.000Z');
     });
   });
+
+  describe('UTC-stable arithmetic across a historical local DST (regression)', () => {
+    // date-fns' add* mutate the LOCAL date field, so on a runtime whose zone
+    // observed DST in the iterated range (Asia/Seoul did in 1987–88) the UTC
+    // grid drifted by an hour — duplicating/skipping a UTC day. The adapter now
+    // adds in UTC, so the sequence is stable regardless of process.env.TZ.
+    it('addDays steps one clean UTC day across 1987-05-10 (Korea DST start)', () => {
+      let cur = '1987-05-08T00:00:00.000Z';
+      const seq: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        seq.push(cur);
+        cur = adapter.addDays(cur, 1);
+      }
+      expect(seq).toEqual([
+        '1987-05-08T00:00:00.000Z',
+        '1987-05-09T00:00:00.000Z',
+        '1987-05-10T00:00:00.000Z',
+        '1987-05-11T00:00:00.000Z',
+        '1987-05-12T00:00:00.000Z',
+      ]);
+    });
+
+    it('addMonths clamps and stays at UTC midnight; addYears clamps off a leap day', () => {
+      expect(adapter.addMonths('2026-01-31T00:00:00.000Z', 1)).toBe('2026-02-28T00:00:00.000Z');
+      expect(adapter.addYears('2024-02-29T00:00:00.000Z', 1)).toBe('2025-02-28T00:00:00.000Z');
+    });
+  });
 });

--- a/packages/adapter-date-fns/src/index.ts
+++ b/packages/adapter-date-fns/src/index.ts
@@ -1,8 +1,5 @@
 import {
   parseISO,
-  addDays as dfAddDays,
-  addMonths as dfAddMonths,
-  addYears as dfAddYears,
   isBefore as dfIsBefore,
   isAfter as dfIsAfter,
   isValid as dfIsValid,
@@ -62,6 +59,38 @@ function utcEndOfWeek(d: Date, weekStartsOn: 0 | 1): Date {
 }
 
 /**
+ * Add days in UTC. A UTC day is exactly 86_400_000 ms (no DST), so this keeps a
+ * UTC-midnight instant at UTC midnight n days later — unlike date-fns' `addDays`,
+ * which mutates the LOCAL date field and drifts by an hour when the runtime's
+ * timezone crosses a DST transition in the iterated range (the calendar grid
+ * iterates day-by-day, so that drift duplicated/skipped a UTC day for users in a
+ * DST zone — e.g. Asia/Seoul, which observed DST in 1987–88).
+ */
+function utcAddDays(d: Date, n: number): Date {
+  return new Date(d.getTime() + n * 86_400_000);
+}
+
+/** Add months in UTC, clamping the day to the target month's length (Jan 31 +1mo → Feb 28). */
+function utcAddMonths(d: Date, n: number): Date {
+  const total = d.getUTCMonth() + n;
+  const year = d.getUTCFullYear() + Math.floor(total / 12);
+  const month = ((total % 12) + 12) % 12;
+  const daysInTarget = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const day = Math.min(d.getUTCDate(), daysInTarget);
+  return new Date(
+    Date.UTC(
+      year,
+      month,
+      day,
+      d.getUTCHours(),
+      d.getUTCMinutes(),
+      d.getUTCSeconds(),
+      d.getUTCMilliseconds(),
+    ),
+  );
+}
+
+/**
  * DateAdapter implementation backed by date-fns.
  * All operations run in UTC to avoid timezone interference.
  *
@@ -106,15 +135,15 @@ export const DateFnsAdapter: DateAdapter = {
   },
 
   addDays(iso: string, n: number): string {
-    return toISO(dfAddDays(toDate(iso), n));
+    return toISO(utcAddDays(toDate(iso), n));
   },
 
   addMonths(iso: string, n: number): string {
-    return toISO(dfAddMonths(toDate(iso), n));
+    return toISO(utcAddMonths(toDate(iso), n));
   },
 
   addYears(iso: string, n: number): string {
-    return toISO(dfAddYears(toDate(iso), n));
+    return toISO(utcAddMonths(toDate(iso), n * 12));
   },
 
   isBefore(a: string, b: string): boolean {

--- a/packages/core/src/__tests__/timezone.property.test.ts
+++ b/packages/core/src/__tests__/timezone.property.test.ts
@@ -172,3 +172,20 @@ describe('Feb 29 round-trip where the civil date differs from the UTC date (T-R2
     expect(formatInTimezone(at0930, 'yyyy-MM-dd HH:mm', 'Asia/Seoul')).toBe('2024-02-29 09:30');
   });
 });
+
+describe('startOfDayInTimezone on a DST-transition day (regression)', () => {
+  // Counterexample the "reads back as 00:00:00" property surfaced: Australia/Sydney
+  // springs forward on 2034-10-01 (02:00 AEST -> 03:00 AEDT). Civil midnight Oct 1 is
+  // still AEST (+10) = 2034-09-30T14:00:00Z, but the old single-probe code took the
+  // offset of "Oct 1 00:00 UTC" (post-transition AEDT, +11) and returned 13:00Z,
+  // which read back as 23:00 of Sep 30. It must be civil midnight (00:00:00).
+  it('returns true civil midnight, not one hour early (Australia/Sydney 2034-10-01)', () => {
+    const sod = startOfDayInTimezone('2034-09-30T14:00:00.000Z', 'Australia/Sydney');
+    expect(sod).toBe('2034-09-30T14:00:00.000Z');
+    expect(getTimeInTimezone(sod, 'Australia/Sydney')).toEqual({
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    });
+  });
+});

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -105,16 +105,15 @@ export function getTimezoneOffsetMinutes(iso: ISODateString, timeZone: string): 
  * startOfDayInTimezone('2026-03-09T12:00:00.000Z', 'America/New_York'); // '2026-03-09T04:00:00.000Z' (EDT)
  */
 export function startOfDayInTimezone(iso: ISODateString, timeZone: string): ISODateString {
-  const utc = new Date(iso);
-  const p = partsInTimezone(utc, timeZone);
-  // Civil midnight as a UTC epoch (what it would be if the wall clock reading lived in UTC).
-  const civilMidnightUtc = Date.UTC(p.year, p.month - 1, p.day, 0, 0, 0);
-  // Must compute the offset at civil midnight itself — the offset at the input `iso` can
-  // differ (DST transition occurs between midnight and the input), which would shift the
-  // result by one hour on transition days.
-  const midnightProbe = new Date(civilMidnightUtc).toISOString();
-  const offsetMinutes = getTimezoneOffsetMinutes(midnightProbe, timeZone);
-  return new Date(civilMidnightUtc - offsetMinutes * 60_000).toISOString();
+  // Civil midnight of the input's civil day. Delegates to setTimeInTimezone so it
+  // reuses the two-pass DST disambiguation: a single offset probe taken at
+  // "civil-midnight-as-UTC" can land on the wrong side of a DST transition and be
+  // off by one hour. Example (the bug this replaced): Australia/Sydney on a
+  // spring-forward Oct 1 — 00:00 local is still AEST (+10), but 00:00 UTC reads as
+  // post-transition AEDT (+11), so the naive probe produced 23:00 of the prior day.
+  // For midnight-DST zones where 00:00 itself doesn't exist, setTimeInTimezone's
+  // gap policy snaps forward to the first valid instant.
+  return setTimeInTimezone(iso, { hours: 0, minutes: 0, seconds: 0 }, timeZone);
 }
 
 /**


### PR DESCRIPTION
새 fast-check 속성테스트(#140 timezone, #143 calendar)가 잡은 **2개의 실제 user-facing DST 버그**. 반례가 러너 TZ + random seed에 의존해 CI에서 간헐적으로 적색이었음(이번 #149 CI Node 22에서 발현).

## 1. core `startOfDayInTimezone` — DST 전환일 1시간 오류
single offset probe를 "civil-midnight-as-UTC"에서 떠서 전환의 반대편에 착지 가능. 예: Australia/Sydney 2034-10-01 spring-forward — 00:00 local은 여전히 AEST(+10)=`2034-09-30T14:00Z`인데 00:00 UTC는 post-transition AEDT(+11)로 읽혀 13:00Z(전날 23:00)를 반환. → `setTimeInTimezone`의 2-pass disambiguation에 위임. `todayInTimezone`·`civilMidnightFromUtcDay`도 교정됨.

## 2. adapter-date-fns `addDays/addMonths/addYears` — 로컬 시간 드리프트
date-fns가 **로컬 date 필드**를 mutate → 러너 TZ가 iterated 범위에서 DST를 가지면(Asia/Seoul은 1987-88 시행) day-by-day grid 반복이 1시간 드리프트해 **UTC 날짜 중복/누락**(DST 브라우저 TZ 사용자에게 깨진 캘린더). → **UTC 산술**로 변경(UTC day=정확히 86_400_000ms, month/year clamping 유지). `@kalyx/adapter-dayjs`는 dayjs UTC 모드라 무관.

## 검증
**TZ=Asia/Seoul(실패 조건)** 에서: 전체 패키지 스위트 585 pass, 속성 스위트 반복 안정, Sydney-2034·Korea-1987 결정적 회귀 테스트. 번들 불변(15.78/15.88). 1.1.0 wave 흡수(core patch→minor, adapter-date-fns 1.0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)