### PR TITLE
feat(core,react): infer weekStartsOn from locale when not set (B7)

### DIFF
--- a/.changeset/weekstartson-locale-inference.md
+++ b/.changeset/weekstartson-locale-inference.md
@@ -1,0 +1,10 @@
+---
+"@kalyx/core": minor
+"@kalyx/react": minor
+---
+
+Infer `weekStartsOn` from the active `locale` when the prop is not set (B7).
+
+`@kalyx/core` now exports `getWeekStartForLocale(locale)`, which reads `Intl.Locale(locale).weekInfo.firstDay` and maps it to the `WeekStartsOn` surface (`0 | 1`) — Sunday-first locales (e.g. `en-US`, `ja-JP`, `ko-KR`) resolve to `0`, Monday-first locales (e.g. `en-GB`, `de-DE`, `fr-FR`) to `1`. It caches per-locale and falls back to `0` on engines without `weekInfo` or for unparseable tags.
+
+`DatePicker` and `RangePicker` (and the `MonthPicker`/`YearPicker` wrappers built on `DatePicker.Root`) now default `weekStartsOn` to the locale's first day instead of always Sunday. An explicit `weekStartsOn` prop still wins, so existing pinned usage is unchanged. Consumers that relied on the implicit Sunday default while passing a Monday-first `locale` will now see Monday-first weeks — pass `weekStartsOn={0}` to restore the old behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -638,7 +638,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 | B4 | `useMonthPicker` / `useYearPicker` / `useWeekPicker` / `useDateTimePicker` hooks (`/headless` 전용) | audit API-G1. 기본 entry 번들 압력 회피 |
 | B5 | `DateTimePicker.Presets` (`/headless`에서 RangePicker.Presets 패턴 재사용) | audit API-G2 |
 | ~~B6~~ | ~~`@kalyx/adapter-temporal@0.x`~~ → **드롭** (2026-06-18) | 정확성 0 검증: 어댑터 인터페이스는 ISO-string in/out이라 Temporal 역량 운반 불가, core Intl로 재위임. 홍보 접어 optics 청중도 없음. Temporal **전략**은 core 레벨 Track D demand-gate로 보존 |
-| B7 | `weekStartsOn` locale 자동 추론 (명시 prop override) | audit T-G2 |
+| ~~B7~~ | ~~`weekStartsOn` locale 자동 추론 (명시 prop override)~~ → **완료** | audit T-G2 — `getWeekStartForLocale` (core) + DatePicker/RangePicker Root 가 `weekStartsOn` 미지정 시 locale 추론 (명시 prop 우선). +44 B CJS |
 | B8 | `/headless` adapter guide 한국어 번역 | 주 성장 오디언스 KO 부재 |
 | ~~B9~~ | ~~번들 margin 도구: `scripts/bundle-diff.mjs` + PR comment~~ → **완료** (PR #153) | audit B-D2 — `scripts/bundle-diff.mjs` 가 base 대비 byte-level delta + 남은 마진(**CJS 126 B / ESM 221 B**)을 PR 코멘트로 가시화. gzip 측정은 `check-bundle-size.js` 의 `getGzipBytes` 재사용(B-R1 단일 소스) |
 | B10 | a11y polish set: A-G1..A-G5 | DatePicker `announce()` 패리티, WeekPicker nav 결정, axe-when-open, Trigger focus-restore 테스트, week-mode aria-label |

--- a/packages/core/src/__tests__/locale.test.ts
+++ b/packages/core/src/__tests__/locale.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getMonthName, formatMonthYear, getWeekdayNames, formatFullDate } from '../utils/locale.js';
+import {
+  getMonthName,
+  formatMonthYear,
+  getWeekdayNames,
+  formatFullDate,
+  getWeekStartForLocale,
+} from '../utils/locale.js';
 
 describe('getMonthName', () => {
   it('returns English month names (en-US)', () => {
@@ -76,5 +82,40 @@ describe('formatFullDate', () => {
     expect(result).toContain('1월');
     expect(result).toContain('15');
     expect(result).toContain('목요일');
+  });
+});
+
+describe('getWeekStartForLocale', () => {
+  it('returns 1 (Monday) for Monday-first locales', () => {
+    expect(getWeekStartForLocale('en-GB')).toBe(1);
+    expect(getWeekStartForLocale('de-DE')).toBe(1);
+    expect(getWeekStartForLocale('fr-FR')).toBe(1);
+  });
+
+  it('returns 0 (Sunday) for Sunday-first locales', () => {
+    expect(getWeekStartForLocale('en-US')).toBe(0);
+    expect(getWeekStartForLocale('ja-JP')).toBe(0);
+    expect(getWeekStartForLocale('ko-KR')).toBe(0);
+  });
+
+  it('always returns a valid WeekStartsOn (0 or 1)', () => {
+    for (const loc of ['en-US', 'ko-KR', 'en-GB', 'de-DE', 'fr-FR', 'ar-EG', 'he-IL', 'zh-CN']) {
+      expect([0, 1]).toContain(getWeekStartForLocale(loc));
+    }
+  });
+
+  it('falls back to 0 for an unparseable locale tag', () => {
+    expect(getWeekStartForLocale('not-a-real-locale-!!!')).toBe(0);
+  });
+
+  it('defaults to en-US (Sunday) when no locale is given', () => {
+    expect(getWeekStartForLocale()).toBe(0);
+  });
+
+  it('caches repeated lookups (returns the same value)', () => {
+    const a = getWeekStartForLocale('en-GB');
+    const b = getWeekStartForLocale('en-GB');
+    expect(a).toBe(b);
+    expect(a).toBe(1);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,13 @@ export {
   isSameTime,
 } from './utils/time.js';
 export type { TimeValue } from './utils/time.js';
-export { getMonthName, formatMonthYear, getWeekdayNames, formatFullDate } from './utils/locale.js';
+export {
+  getMonthName,
+  formatMonthYear,
+  getWeekdayNames,
+  formatFullDate,
+  getWeekStartForLocale,
+} from './utils/locale.js';
 export type { WeekdayInfo } from './utils/locale.js';
 export {
   formatInTimezone,

--- a/packages/core/src/utils/locale.ts
+++ b/packages/core/src/utils/locale.ts
@@ -95,3 +95,39 @@ export function formatFullDate(iso: string, locale = 'en-US'): string {
     timeZone: 'UTC',
   }).format(date);
 }
+
+const weekStartCache = new Map<string, WeekStartsOn>();
+
+/**
+ * Infers the locale's first day of the week as a {@link WeekStartsOn} (0 = Sunday, 1 = Monday).
+ *
+ * Reads `Intl.Locale(locale).weekInfo.firstDay` (1 = Monday … 7 = Sunday). Since the public
+ * `WeekStartsOn` surface is `0 | 1`, Sunday-first locales (firstDay 7, e.g. en-US, ja-JP) map to
+ * `0` and every other locale maps to `1` (e.g. ko-KR, en-GB, de-DE). Falls back to `0` when the
+ * runtime lacks `weekInfo` (older engines) or the locale tag is unparseable.
+ *
+ * @param locale BCP 47 locale string (e.g. "en-US", "ko-KR")
+ */
+export function getWeekStartForLocale(locale = 'en-US'): WeekStartsOn {
+  const cached = weekStartCache.get(locale);
+  if (cached !== undefined) return cached;
+
+  let result: WeekStartsOn = 0;
+  try {
+    // `weekInfo` is a getter on some engines and a property (`getWeekInfo()`) on others.
+    const loc = new Intl.Locale(locale) as Intl.Locale & {
+      weekInfo?: { firstDay?: number };
+      getWeekInfo?: () => { firstDay?: number };
+    };
+    const info = loc.getWeekInfo?.() ?? loc.weekInfo;
+    if (info?.firstDay != null) {
+      // firstDay: 1 = Monday … 7 = Sunday. Map Sunday → 0, everything else → 1.
+      result = info.firstDay === 7 ? 0 : 1;
+    }
+  } catch {
+    // Unparseable locale or no Intl.Locale — keep the Sunday-first default.
+  }
+
+  weekStartCache.set(locale, result);
+  return result;
+}

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1389,3 +1389,42 @@ describe('DatePicker.Popover — style merging', () => {
     expect(['', 'visible']).toContain(dialog.style.visibility);
   });
 });
+
+describe('DatePicker — weekStartsOn locale inference (B7)', () => {
+  async function firstColumnHeader(locale: string, weekStartsOn?: 0 | 1) {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        value="2026-01-15T00:00:00.000Z"
+        onChange={vi.fn()}
+        locale={locale}
+        weekStartsOn={weekStartsOn}
+      >
+        <DatePicker.Input aria-label="date" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    return screen.getAllByRole('columnheader')[0];
+  }
+
+  it('starts the week on Monday for en-GB (Monday-first locale)', async () => {
+    const header = await firstColumnHeader('en-GB');
+    // en-GB weekInfo.firstDay = 1 (Monday). First column header is Monday.
+    expect(header.getAttribute('aria-label') ?? header.textContent).toMatch(/Mon/i);
+  });
+
+  it('starts the week on Sunday for en-US (Sunday-first locale)', async () => {
+    const header = await firstColumnHeader('en-US');
+    // en-US weekInfo.firstDay = 7 (Sunday). First column header is Sunday.
+    expect(header.getAttribute('aria-label') ?? header.textContent).toMatch(/Sun/i);
+  });
+
+  it('an explicit weekStartsOn prop overrides locale inference', async () => {
+    // en-GB would infer Monday, but the explicit prop pins Sunday-first.
+    const header = await firstColumnHeader('en-GB', 0);
+    expect(header.getAttribute('aria-label') ?? header.textContent).toMatch(/Sun/i);
+  });
+});

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { DEFAULT_DATEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
+import {
+  DEFAULT_DATEPICKER_LABELS,
+  civilMidnightFromUtcDay,
+  getWeekStartForLocale,
+} from '@kalyx/core';
 import type {
   DateAdapter,
   DatePickerLabels,
@@ -79,7 +83,7 @@ export function DatePickerRoot({
   onCalendarNavigate,
   disabled = false,
   readOnly = false,
-  weekStartsOn = 0,
+  weekStartsOn: weekStartsOnProp,
   displayFormat = 'yyyy-MM-dd',
   locale = 'en-US',
   displayTimezone,
@@ -120,6 +124,10 @@ export function DatePickerRoot({
     () => ({ ...DEFAULT_DATEPICKER_LABELS, ...labelsProp }),
     [labelsProp],
   );
+
+  // When the consumer doesn't pin weekStartsOn, infer it from the locale
+  // (e.g. ko-KR / en-GB → Monday, en-US / ja-JP → Sunday). An explicit prop always wins.
+  const weekStartsOn = weekStartsOnProp ?? getWeekStartForLocale(locale);
 
   const isDisabled = typeof disabled === 'boolean' ? disabled : false;
   const disabledRules: DisabledRule[] = useMemo(

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
-import { DEFAULT_RANGEPICKER_LABELS, civilMidnightFromUtcDay } from '@kalyx/core';
+import {
+  DEFAULT_RANGEPICKER_LABELS,
+  civilMidnightFromUtcDay,
+  getWeekStartForLocale,
+} from '@kalyx/core';
 import type {
   DateAdapter,
   DateRange,
@@ -91,7 +95,7 @@ export function RangePickerRoot({
   onCalendarNavigate,
   disabled = false,
   readOnly = false,
-  weekStartsOn = 0,
+  weekStartsOn: weekStartsOnProp,
   displayFormat = 'yyyy-MM-dd',
   locale = 'en-US',
   displayTimezone,
@@ -139,6 +143,9 @@ export function RangePickerRoot({
     () => ({ ...DEFAULT_RANGEPICKER_LABELS, ...labelsProp }),
     [labelsProp],
   );
+
+  // Infer weekStartsOn from locale when not pinned by the consumer (explicit prop wins).
+  const weekStartsOn = weekStartsOnProp ?? getWeekStartForLocale(locale);
 
   const isDisabled = typeof disabled === 'boolean' ? disabled : false;
   const disabledRules: DisabledRule[] = useMemo(


### PR DESCRIPTION
## Summary
Implements Track B **B7** (audit T-G2): default `weekStartsOn` to the active locale's first day instead of always Sunday.

- **`@kalyx/core`**: new `getWeekStartForLocale(locale)` reads `Intl.Locale(locale).weekInfo.firstDay` and maps it to `WeekStartsOn` (`0 | 1`). Sunday-first locales (`en-US`, `ja-JP`, `ko-KR`) → `0`; Monday-first (`en-GB`, `de-DE`, `fr-FR`) → `1`. Per-locale cache, graceful fallback to `0` on engines without `weekInfo` or unparseable tags.
- **`@kalyx/react`**: `DatePicker.Root` and `RangePicker.Root` default `weekStartsOn` to the inferred value. **Explicit `weekStartsOn` prop still wins.** `MonthPicker`/`YearPicker` inherit via `DatePicker.Root`.

## Behavior change
Consumers relying on the implicit Sunday default while passing a Monday-first `locale` will now get Monday-first weeks. Pass `weekStartsOn={0}` to restore. (Documented in the changeset; `minor`.)

## Bundle
+44 B CJS (margin 126 → 82 B), within the 16KB ceiling. The bundle-diff comment on this PR will confirm.

## Test plan
- [x] 6 new core cases (Monday/Sunday locales, override-safe range, unparseable fallback, default, cache)
- [x] 3 new DatePicker cases (first column header = Mon for en-GB, Sun for en-US, explicit prop overrides)
- [x] Full suite green (670 tests)
- [x] typecheck clean