### PR TITLE
feat(react): DateTimePicker.Presets/.Preset on /headless entry (B5)

### DIFF
--- a/.changeset/datetimepicker-presets.md
+++ b/.changeset/datetimepicker-presets.md
@@ -1,0 +1,17 @@
+---
+"@kalyx/react": minor
+---
+
+Add `DateTimePicker.Presets` / `DateTimePicker.Preset` to the `@kalyx/react/headless` entry (B5).
+
+One-click presets that commit a **full datetime** (date + time) atomically — unlike `DateTimePicker.Calendar`, which preserves the existing time. Pass a complete ISO value:
+
+```tsx
+import { DateTimePicker } from '@kalyx/react/headless';
+
+<DateTimePicker.Presets>
+  <DateTimePicker.Preset value="2026-01-19T09:00:00.000Z">Mon 9 AM</DateTimePicker.Preset>
+</DateTimePicker.Presets>
+```
+
+These ship on the `/headless` entry only. The default `@kalyx/react` bundle is at its 16KB ceiling, so adding the preset components there would break the budget; `/headless` is measured separately. The supporting `selectDateTime` Root method (a small atomic date+time setter, exposed via `DatePickerContext`) is present on both entries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -636,7 +636,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 | B2 | `@kalyx/core/test-helpers` 어댑터 conformance test suite | B1/B3/B6 unblock — adapter 작성자 테스트 부담 제거 |
 | B3 | `@kalyx/adapter-luxon` | B2 후 비용 낮음. enterprise/timezone 사용자 |
 | B4 | `useMonthPicker` / `useYearPicker` / `useWeekPicker` / `useDateTimePicker` hooks (`/headless` 전용) | audit API-G1. 기본 entry 번들 압력 회피 |
-| B5 | `DateTimePicker.Presets` (`/headless`에서 RangePicker.Presets 패턴 재사용) | audit API-G2 |
+| ~~B5~~ | ~~`DateTimePicker.Presets` (`/headless`에서 RangePicker.Presets 패턴 재사용)~~ → **완료** | audit API-G2 — `DateTimePicker.Presets`/`.Preset` 가 datetime 전체(날짜+시간)를 원자적으로 커밋. `/headless` 전용 배치(기본 엔트리 천장 회피), `selectDateTime` Root 메서드는 양쪽 엔트리 공통 (+~40 B CJS) |
 | ~~B6~~ | ~~`@kalyx/adapter-temporal@0.x`~~ → **드롭** (2026-06-18) | 정확성 0 검증: 어댑터 인터페이스는 ISO-string in/out이라 Temporal 역량 운반 불가, core Intl로 재위임. 홍보 접어 optics 청중도 없음. Temporal **전략**은 core 레벨 Track D demand-gate로 보존 |
 | ~~B7~~ | ~~`weekStartsOn` locale 자동 추론 (명시 prop override)~~ → **완료** | audit T-G2 — `getWeekStartForLocale` (core) + DatePicker/RangePicker Root 가 `weekStartsOn` 미지정 시 locale 추론 (명시 prop 우선). +44 B CJS |
 | B8 | `/headless` adapter guide 한국어 번역 | 주 성장 오디언스 KO 부재 |

--- a/packages/react/src/components/DateTimePicker/Presets.test.tsx
+++ b/packages/react/src/components/DateTimePicker/Presets.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+// Presets/Preset live on the `/headless` entry only (keeps the default bundle
+// under the 16KB ceiling), so we import the headless-augmented DateTimePicker.
+import { DateTimePicker } from './headless.js';
+
+const MON_9AM = '2026-01-19T09:00:00.000Z'; // Monday
+const TUE_3PM = '2026-01-20T15:30:00.000Z';
+
+function renderWithPresets(onChange = vi.fn(), value?: string | null) {
+  const result = render(
+    <DateTimePicker value={value} onChange={onChange}>
+      <DateTimePicker.Input />
+      <DateTimePicker.Popover>
+        <DateTimePicker.Calendar />
+        <DateTimePicker.HourList />
+        <DateTimePicker.MinuteList />
+        <DateTimePicker.Presets>
+          <DateTimePicker.Preset value={MON_9AM}>Mon 9 AM</DateTimePicker.Preset>
+          <DateTimePicker.Preset value={TUE_3PM}>Tue 3:30 PM</DateTimePicker.Preset>
+        </DateTimePicker.Presets>
+      </DateTimePicker.Popover>
+    </DateTimePicker>,
+  );
+  return { ...result, onChange };
+}
+
+describe('DateTimePicker.Presets (B5)', () => {
+  it('renders presets inside a labelled group', async () => {
+    const user = userEvent.setup();
+    renderWithPresets();
+    await user.click(screen.getByRole('combobox'));
+    const group = screen.getByRole('group', { name: /presets/i });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mon 9 AM' })).toBeInTheDocument();
+  });
+
+  it('commits the full datetime (date + time) atomically on click', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderWithPresets();
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Mon 9 AM' }));
+    // Both the date (Jan 19) and the time (09:00) land in a single onChange.
+    expect(onChange).toHaveBeenCalledWith(MON_9AM);
+  });
+
+  it('does not preserve a previously selected time (unlike Calendar)', async () => {
+    const user = userEvent.setup();
+    // Start at a value with a 15:30 time — the preset must overwrite the time, not keep it.
+    const { onChange } = renderWithPresets(vi.fn(), TUE_3PM);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Mon 9 AM' }));
+    expect(onChange).toHaveBeenLastCalledWith(MON_9AM);
+  });
+
+  it('marks the active preset with aria-pressed', async () => {
+    const user = userEvent.setup();
+    renderWithPresets(vi.fn(), MON_9AM);
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('button', { name: 'Mon 9 AM' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: 'Tue 3:30 PM' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  it('closes the popover after selecting a preset', async () => {
+    const user = userEvent.setup();
+    renderWithPresets();
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Mon 9 AM' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('does not commit when the picker is disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DateTimePicker value={null} onChange={onChange} disabled>
+        <DateTimePicker.Input />
+        <DateTimePicker.Presets>
+          <DateTimePicker.Preset value={MON_9AM}>Mon 9 AM</DateTimePicker.Preset>
+        </DateTimePicker.Presets>
+      </DateTimePicker>,
+    );
+    const button = screen.getByRole('button', { name: 'Mon 9 AM' });
+    expect(button).toBeDisabled();
+    await user.click(button).catch(() => {});
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('has no axe violations when open', async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithPresets();
+    await user.click(screen.getByRole('combobox'));
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/packages/react/src/components/DateTimePicker/Presets.tsx
+++ b/packages/react/src/components/DateTimePicker/Presets.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useMemo } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
+import type { ISODateString } from '@kalyx/core';
+import { useDatePickerContext } from '../../context/DatePickerContext.js';
+
+export interface DateTimePickerPresetsClassNames {
+  root?: string;
+  preset?: string;
+  presetActive?: string;
+}
+
+export interface DateTimePickerPresetsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'role'> {
+  classNames?: DateTimePickerPresetsClassNames;
+  children?: ReactNode;
+}
+
+/**
+ * DateTimePicker.Presets — container that groups one-click datetime presets.
+ * Place {@link DateTimePickerPreset} buttons inside.
+ *
+ * @example
+ * ```tsx
+ * <DateTimePicker.Presets>
+ *   <DateTimePicker.Preset value="2026-01-15T09:00:00.000Z">Mon 9 AM</DateTimePicker.Preset>
+ * </DateTimePicker.Presets>
+ * ```
+ */
+export function DateTimePickerPresets({
+  classNames,
+  children,
+  ...props
+}: DateTimePickerPresetsProps) {
+  // DatePickerLabels has no presets label (it's a RangePicker concept), so default
+  // a sensible group label here. Consumers can override via the spread `aria-label`.
+  return (
+    <div role="group" aria-label="Date and time presets" className={classNames?.root} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export interface DateTimePickerPresetProps extends Omit<
+  HTMLAttributes<HTMLButtonElement>,
+  'value'
+> {
+  /** Full datetime (ISO 8601 UTC) to commit when clicked — includes both date and time. */
+  value: ISODateString;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * DateTimePicker.Preset — one-click button that commits a full datetime (date + time).
+ *
+ * Unlike `DateTimePicker.Calendar` (which preserves the existing time) this sets both the
+ * date and time portions atomically, so a preset like "tomorrow 9 AM" lands exactly.
+ *
+ * @example
+ * ```tsx
+ * <DateTimePicker.Preset value="2026-01-16T09:00:00.000Z">Tomorrow 9 AM</DateTimePicker.Preset>
+ * ```
+ */
+export function DateTimePickerPreset({
+  value,
+  children,
+  onClick,
+  ...props
+}: DateTimePickerPresetProps) {
+  const ctx = useDatePickerContext('DateTimePicker.Preset');
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (ctx.isDisabled || ctx.isReadOnly) return;
+      // selectDateTime is only present on DateTimePicker.Root; fall back to selectDate
+      // (date-only) if a Preset is somehow mounted under a plain DatePicker.
+      (ctx.selectDateTime ?? ctx.selectDate)(value);
+      ctx.close();
+      onClick?.(e);
+    },
+    [ctx, value, onClick],
+  );
+
+  const isActive = useMemo(
+    () => ctx.value != null && ctx.adapter.isSameDay(ctx.value, value) && ctx.value === value,
+    [ctx.value, ctx.adapter, value],
+  );
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isActive}
+      data-active={isActive || undefined}
+      disabled={ctx.isDisabled}
+      onClick={handleClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -225,6 +225,23 @@ export function DateTimePickerRoot({
     [currentValue, updateValue, displayTimezone, adapter],
   );
 
+  /**
+   * Commit a full datetime (date + time) atomically. Used by DateTimePicker.Presets,
+   * where a preset carries both portions and must not race the time-preserving selectDate.
+   */
+  const selectDateTime = useCallback(
+    (iso: ISODateString | null) => {
+      if (iso === null) {
+        updateValue(null);
+        return;
+      }
+      // A preset ISO is already a UTC instant; when a display timezone is set the
+      // value is interpreted/displayed there, so no civil-midnight remapping is needed.
+      updateValue(iso);
+    },
+    [updateValue],
+  );
+
   const open = useCallback(() => {
     if (isDisabled || readOnly) return;
     setIsOpen(true);
@@ -248,6 +265,7 @@ export function DateTimePickerRoot({
       referenceRef,
       value: currentValue,
       selectDate,
+      selectDateTime,
       isOpen,
       open,
       close,
@@ -270,6 +288,7 @@ export function DateTimePickerRoot({
     [
       currentValue,
       selectDate,
+      selectDateTime,
       isOpen,
       open,
       close,

--- a/packages/react/src/components/DateTimePicker/headless.ts
+++ b/packages/react/src/components/DateTimePicker/headless.ts
@@ -1,0 +1,19 @@
+// DateTimePicker for the `@kalyx/react/headless` entry — identical to the default
+// export plus `.Presets` / `.Preset`. These live on the headless entry alone so the
+// budgeted default `@kalyx/react` bundle stays under the 16KB ceiling (the preset
+// resolver + extra component would push it over). The two entries are built with
+// tsup `splitting: false`, so this object is a distinct instance from the default
+// one and the Object.assign here doesn't mutate the default export.
+import { DateTimePicker as DateTimePickerBase } from './index.js';
+import { DateTimePickerPresets, DateTimePickerPreset } from './Presets.js';
+
+export const DateTimePicker = Object.assign(DateTimePickerBase, {
+  Presets: DateTimePickerPresets,
+  Preset: DateTimePickerPreset,
+});
+
+export type {
+  DateTimePickerPresetsProps,
+  DateTimePickerPresetsClassNames,
+  DateTimePickerPresetProps,
+} from './Presets.js';

--- a/packages/react/src/context/DatePickerContext.ts
+++ b/packages/react/src/context/DatePickerContext.ts
@@ -15,6 +15,13 @@ export interface DatePickerContextValue {
   value: ISODateString | null;
   /** Date selection handler */
   selectDate: (iso: ISODateString | null) => void;
+  /**
+   * Apply a full datetime (date + time) in a single update. Only provided by
+   * DateTimePicker.Root — undefined for plain DatePicker. Used by
+   * DateTimePicker.Presets so a preset like "today 09:00" commits both portions
+   * atomically instead of racing `selectDate` (time-preserving) with `setTime`.
+   */
+  selectDateTime?: (iso: ISODateString | null) => void;
   /** Popover open state */
   isOpen: boolean;
   /** Open the popover */

--- a/packages/react/src/headless.ts
+++ b/packages/react/src/headless.ts
@@ -28,7 +28,7 @@
 export { DatePicker } from './components/DatePicker/index.js';
 export { RangePicker } from './components/RangePicker/index.js';
 export { TimePicker } from './components/TimePicker/index.js';
-export { DateTimePicker } from './components/DateTimePicker/index.js';
+export { DateTimePicker } from './components/DateTimePicker/headless.js';
 export { MonthPicker } from './components/MonthPicker/index.js';
 export { YearPicker } from './components/YearPicker/index.js';
 export { WeekPicker } from './components/WeekPicker/index.js';
@@ -89,6 +89,11 @@ export type {
   DateTimePickerRootProps,
   DateTimePickerInputProps,
 } from './components/DateTimePicker/index.js';
+export type {
+  DateTimePickerPresetsProps,
+  DateTimePickerPresetsClassNames,
+  DateTimePickerPresetProps,
+} from './components/DateTimePicker/headless.js';
 
 export type {
   MonthPickerRootProps,


### PR DESCRIPTION
## Summary
Implements Track B **B5** (audit API-G2): `DateTimePicker.Presets` + `DateTimePicker.Preset` for one-click datetime selection.

Unlike `DateTimePicker.Calendar` (which preserves the existing time), a Preset commits a **full datetime** (date + time) atomically:

```tsx
import { DateTimePicker } from '@kalyx/react/headless';

<DateTimePicker.Presets>
  <DateTimePicker.Preset value="2026-01-19T09:00:00.000Z">Mon 9 AM</DateTimePicker.Preset>
</DateTimePicker.Presets>
```

## Bundle placement decision
The default `@kalyx/react` entry is at the 16KB ceiling — adding the preset components there overflowed (CJS -152 B). So they ship on the **`/headless` entry only** (built with tsup `splitting: false`, measured separately, date-fns-free — `verify-entry-split` passes). The supporting `selectDateTime` Root method (atomic date+time setter via optional `DatePickerContext.selectDateTime`) is on both entries: **+~40 B CJS, margin still 46 B** under the ceiling.

## Test plan
- [x] 7 new cases: atomic date+time commit, time-overwrite (vs Calendar's preserve), `aria-pressed` active state, popover close, disabled no-op, axe-when-open
- [x] Full suite green (677 tests), typecheck clean
- [x] `verify-entry-split.mjs` passes (headless has no date-fns)
- [x] bundle-diff: default entry ESM 15.86 / CJS 15.96 — within 16KB