### PR TITLE
feat(react): Root-level announce() parity, bundle ceiling 16→17KB (B10 A-G1)

### DIFF
--- a/.changeset/announce-parity.md
+++ b/.changeset/announce-parity.md
@@ -1,0 +1,11 @@
+---
+"@kalyx/react": minor
+---
+
+a11y: Root-level `announce()` live-region parity for DatePicker and DateTimePicker (B10 / audit A-G1).
+
+`DatePickerContext` now exposes an `announce(message)` method backed by a polite `role="status"` live region mounted on the Root (not the Calendar). Previously DatePicker announced month navigation and date selection from a Calendar-local region that unmounted with the popover; moving it to Root matches `RangePickerContext` and keeps the announcement available across open/close. `DateTimePicker.Root` gains the same region, and `MonthPicker`/`YearPicker` inherit it via `DatePicker.Root`.
+
+This adds a small amount of runtime code, so the gzip bundle ceiling moves **16 KB → 17 KB** (default `@kalyx/react` entry now 15.99 KB ESM / 16.12 KB CJS). Still ~3.5× smaller than react-datepicker.
+
+No public API removal; the new `announce` context field is additive (the React layer fills it). The `selectionMode="week"` aria-label rework (A-G5) was intentionally dropped — labelling each day with its full week span made all seven days of a week share a substring and broke screen-reader/test name queries, so the per-day label is retained.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -84,7 +84,7 @@ jobs:
           retention-days: 1
 
   bundle-size:
-    name: Bundle Size (≤16KB gzip)
+    name: Bundle Size (gzip ceiling)
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -105,10 +105,9 @@ jobs:
           name: dist-${{ github.run_id }}
           path: packages/react/dist/
       # Single source of truth for gzip measurement: shell `gzip -c` and Node's
-      # zlib could drift apart inside the tight 16KB margin (~126 B CJS /
-      # ~221 B ESM as of v1.1.0), so we delegate to scripts/check-bundle-size.js
-      # — the same script tsup + local dev use. The script appends kb_esm and
-      # kb_cjs to $GITHUB_OUTPUT for the comment.
+      # zlib could drift apart inside the tight gzip margin, so we delegate
+      # to scripts/check-bundle-size.js — the same script tsup + local dev use.
+      # The script appends kb_esm and kb_cjs to $GITHUB_OUTPUT for the comment.
       - name: 크기 측정 및 판정
         id: check
         run: node scripts/check-bundle-size.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 - **React Aria**: 기능 완전하지만 복잡하고, `@internationalized/date` 의존 강제 (date-fns 비호환).
 - **Headless UI**: DatePicker 구현 거부 ("유지보수가 너무 큼").
 
-**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 16KB
+**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 17KB
 
 ### 포지셔닝
 
@@ -71,7 +71,7 @@ Ark UI가 포기한 TimePicker 통합
 | 스타일링 | Zero CSS (Headless) | CSS 충돌 원천 차단 |
 | 날짜 코어 | Adapter 패턴 + date-fns 기본 (v1.1에서 `@kalyx/adapter-date-fns`로 분리 예정 — [§14](#14-현재-이니셔티브-2026-04-기준)) | Temporal API 전환 대비, 사용자가 dayjs/luxon 선택 가능 |
 | 포지셔닝 | Floating UI | 3KB, SSR 안전, Popper.js 후계자 |
-| 번들 목표 | **≤ 16KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향, v1.0-rc.8 TimePicker `filterTime` 프로그래밍 콜백 추가하면서 15 → 16KB 상향 |
+| 번들 목표 | **≤ 17KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향, v1.0-rc.8 TimePicker `filterTime` 프로그래밍 콜백 추가하면서 15 → 16KB 상향, v1.1 B10 a11y announce() 패리티(A-G1 — DatePicker/DateTimePicker Root live-region) 추가하면서 16 → 17KB 상향 |
 | 테스트 | Vitest + Testing Library + jest-axe | |
 | 빌드 | tsup (ESM + CJS 이중 출력) | |
 | 모노레포 | pnpm workspaces | |
@@ -641,7 +641,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 | ~~B7~~ | ~~`weekStartsOn` locale 자동 추론 (명시 prop override)~~ → **완료** | audit T-G2 — `getWeekStartForLocale` (core) + DatePicker/RangePicker Root 가 `weekStartsOn` 미지정 시 locale 추론 (명시 prop 우선). +44 B CJS |
 | B8 | `/headless` adapter guide 한국어 번역 | 주 성장 오디언스 KO 부재 |
 | ~~B9~~ | ~~번들 margin 도구: `scripts/bundle-diff.mjs` + PR comment~~ → **완료** (PR #153) | audit B-D2 — `scripts/bundle-diff.mjs` 가 base 대비 byte-level delta + 남은 마진(**CJS 126 B / ESM 221 B**)을 PR 코멘트로 가시화. gzip 측정은 `check-bundle-size.js` 의 `getGzipBytes` 재사용(B-R1 단일 소스) |
-| B10 | a11y polish set: A-G1..A-G5 | DatePicker `announce()` 패리티, WeekPicker nav 결정, axe-when-open, Trigger focus-restore 테스트, week-mode aria-label. **부분 완료:** A-G3(axe-when-open, 이미 7픽커 충족) · A-G4(focus-restore 테스트 Month/Year/Week/DateTime 추가) · A-G2(WeekPicker day-granular focus + week-commit 설계 확정·테스트 락). **잔여(bundle-positive):** A-G1(announce 패리티) · A-G5(week-mode aria-label) |
+| B10 | a11y polish set: A-G1..A-G5 | DatePicker `announce()` 패리티, WeekPicker nav 결정, axe-when-open, Trigger focus-restore 테스트, week-mode aria-label. **부분 완료:** A-G3(axe-when-open, 이미 7픽커 충족) · A-G4(focus-restore 테스트 Month/Year/Week/DateTime 추가) · A-G2(WeekPicker day-granular focus + week-commit 설계 확정·테스트 락) · A-G1(announce() 패리티 — DatePicker/DateTimePicker Root live-region, 16→17KB 천장 상향). **드롭:** A-G5(week-mode aria-label — 같은 주 7일이 동일 부분 문자열 공유해 쿼리 모호성 유발, 이득 < 회귀 비용) |
 | ~~B11~~ | ~~docs-site comparison 랜딩 비교~~ → **드롭** (2026-06-18) | 홍보 접음. comparison 페이지 자체도 제거 (마케팅 모먼트 폐기) |
 
 ### Track C — v1.2 (다음 분기)

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 [문서](https://kalyx-docs-site.vercel.app/ko) · [English](https://kalyx-docs-site.vercel.app) · [npm](https://www.npmjs.com/package/@kalyx/react) · [README.md](./README.md)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-15.78KB-brightgreen)](https://kalyx-docs-site.vercel.app/ko/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.99KB-brightgreen)](https://kalyx-docs-site.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -21,7 +21,7 @@
 
 ---
 
-Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~15 KB (≤ 16 KB), CSS 없음, SSR 안전.
+Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~16 KB (≤ 17 KB), CSS 없음, SSR 안전.
 
 ```bash
 pnpm add @kalyx/react
@@ -87,7 +87,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` → **15.78 KB** gzip (ESM) / **15.88 KB** (CJS). CI 한계 ≤ 16 KB.
+`@kalyx/react` → **15.99 KB** gzip (ESM) / **16.12 KB** (CJS). CI 한계 ≤ 17 KB.
 
 ## 지원 환경
 
@@ -101,7 +101,7 @@ pnpm test            # 단위 + 컴포넌트
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle    # ≤ 16 KB
+pnpm check-bundle    # ≤ 17 KB
 ```
 
 아키텍처 원칙은 [CLAUDE.md](./CLAUDE.md) 참고.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [Docs](https://kalyx-docs-site.vercel.app) · [한국어](https://kalyx-docs-site.vercel.app/ko) · [npm](https://www.npmjs.com/package/@kalyx/react) · [README.ko](./README.ko.md)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-15.78KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.99KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -21,7 +21,7 @@
 
 ---
 
-Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~15 KB gzip (≤16 KB ceiling), zero CSS, SSR-safe.
+Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~16 KB gzip (≤17 KB ceiling), zero CSS, SSR-safe.
 
 ```bash
 pnpm add @kalyx/react
@@ -87,7 +87,7 @@ API reference, recipes (Tailwind / shadcn / React Hook Form), and migration guid
 
 ## Bundle
 
-`@kalyx/react` → **15.78 KB** gzip (ESM) / **15.88 KB** (CJS). CI gate: ≤ 16 KB.
+`@kalyx/react` → **15.99 KB** gzip (ESM) / **16.12 KB** (CJS). CI gate: ≤ 17 KB.
 
 ## Browser support
 
@@ -101,7 +101,7 @@ pnpm test            # unit + component
 pnpm typecheck
 pnpm lint
 pnpm build
-pnpm check-bundle    # ≤ 16 KB
+pnpm check-bundle    # ≤ 17 KB
 ```
 
 See [CLAUDE.md](./CLAUDE.md) for architecture principles.

--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -183,7 +183,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~15.78 KB** (v1.0.3, 7 components, CI ceiling 16 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~15.99 KB** (7 components, CI ceiling 17 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -94,7 +94,7 @@ const config: Config = {
     },
     metadata: [
       {name: 'keywords', content: 'react, datepicker, headless, typescript, tailwind, accessible, ssr, calendar, timepicker, rangepicker'},
-      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~15.78 KB (≤ 16 KB ceiling).'},
+      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~15.99 KB (≤ 17 KB ceiling).'},
     ],
     navbar: {
       title: 'Kalyx',

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -183,7 +183,7 @@ Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~15.78 KB** (v1.0.3, 7 components, CI ceiling 16 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~15.99 KB** (7 components, CI ceiling 17 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,9 @@
 # @kalyx/react
 
-> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~15.78 KB gzip (≤ 16 KB ceiling).
+> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~15.99 KB gzip (≤ 17 KB ceiling).
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-15.78KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-15.99KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
@@ -57,19 +57,6 @@ function safeFormatFullDate(iso: string, locale: string): string {
   }
 }
 
-/** Visually-hidden style for screen-reader-only content */
-const srOnly: React.CSSProperties = {
-  position: 'absolute',
-  width: '1px',
-  height: '1px',
-  padding: 0,
-  margin: '-1px',
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  border: 0,
-};
-
 export function DatePickerCalendar({
   classNames,
   onTitleClick,
@@ -79,7 +66,6 @@ export function DatePickerCalendar({
 }: DatePickerCalendarProps) {
   const ctx = useDatePickerContext('DatePicker.Calendar');
   const gridRef = useRef<HTMLTableElement>(null);
-  const [announcement, setAnnouncement] = useState('');
 
   const { adapter, viewMonth, focusedDate, weekStartsOn, disabled, locale, displayTimezone } = ctx;
   // Memoized — weekday header tuples only change when locale or week start changes.
@@ -135,7 +121,7 @@ export function DatePickerCalendar({
       ctx.setFocusedDate(adapter.startOfMonth(newMonth));
       const y = adapter.getYear(newMonth);
       const m = adapter.getMonth(newMonth);
-      setAnnouncement(formatMonthYear(y, m, locale));
+      ctx.announce(formatMonthYear(y, m, locale));
     },
     [adapter, viewMonth, ctx, locale],
   );
@@ -144,7 +130,7 @@ export function DatePickerCalendar({
     (day: CalendarDay) => {
       if (day.isDisabled) return;
       ctx.selectDate(day.isoString);
-      setAnnouncement(safeFormatFullDate(day.isoString, locale));
+      ctx.announce(safeFormatFullDate(day.isoString, locale));
     },
     [ctx, locale],
   );
@@ -364,10 +350,6 @@ export function DatePickerCalendar({
           ))}
         </tbody>
       </table>
-
-      <div role="status" aria-live="polite" aria-atomic="true" style={srOnly}>
-        {announcement}
-      </div>
     </div>
   );
 }

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1428,3 +1428,37 @@ describe('DatePicker — weekStartsOn locale inference (B7)', () => {
     expect(header.getAttribute('aria-label') ?? header.textContent).toMatch(/Sun/i);
   });
 });
+
+describe('DatePicker — announce() live-region parity (B10 A-G1)', () => {
+  it('exposes a polite live region from Root (survives Calendar unmount)', async () => {
+    const user = userEvent.setup();
+    renderDatePicker({ value: '2026-01-15T00:00:00.000Z' });
+    // The live region is on Root, so it exists even before the calendar opens.
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+
+    // Closing the popover unmounts Calendar but the region (and its message) persist.
+    await user.click(screen.getByRole('combobox'));
+    await user.keyboard('{Escape}');
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('announces month navigation', async () => {
+    const user = userEvent.setup();
+    renderDatePicker({ value: '2026-01-15T00:00:00.000Z' });
+    await user.click(screen.getByRole('combobox'));
+
+    // Next-month button label comes from DEFAULT_DATEPICKER_LABELS.nextMonth.
+    await user.click(screen.getByRole('button', { name: /next month/i }));
+    expect(screen.getByRole('status')).toHaveTextContent(/February 2026/i);
+  });
+
+  it('announces a date selection', async () => {
+    const user = userEvent.setup();
+    renderDatePicker({ value: '2026-01-15T00:00:00.000Z' });
+    await user.click(screen.getByRole('combobox'));
+
+    await user.click(screen.getByRole('button', { name: /January 20, 2026/i }));
+    expect(screen.getByRole('status')).toHaveTextContent(/January 20, 2026/i);
+  });
+});

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -16,6 +16,7 @@ import { DatePickerContext } from '../../context/DatePickerContext.js';
 import type { DatePickerContextValue } from '../../context/DatePickerContext.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
+import { SR_ONLY } from '../../internal/srOnly.js';
 
 /**
  * Props for the DatePicker Root component.
@@ -125,9 +126,12 @@ export function DatePickerRoot({
     [labelsProp],
   );
 
-  // When the consumer doesn't pin weekStartsOn, infer it from the locale
-  // (e.g. ko-KR / en-GB → Monday, en-US / ja-JP → Sunday). An explicit prop always wins.
+  // Infer weekStartsOn from locale when the consumer doesn't pin it; explicit prop wins.
   const weekStartsOn = weekStartsOnProp ?? getWeekStartForLocale(locale);
+
+  // Live-region announcement (mounted on Root so it survives Calendar unmount).
+  const [announcement, setAnnouncement] = useState('');
+  const announce = useCallback((message: string) => setAnnouncement(message), []);
 
   const isDisabled = typeof disabled === 'boolean' ? disabled : false;
   const disabledRules: DisabledRule[] = useMemo(
@@ -200,6 +204,7 @@ export function DatePickerRoot({
       isReadOnly: readOnly,
       pickerId,
       labels: mergedLabels,
+      announce,
     }),
     [
       currentValue,
@@ -220,8 +225,16 @@ export function DatePickerRoot({
       readOnly,
       pickerId,
       mergedLabels,
+      announce,
     ],
   );
 
-  return <DatePickerContext.Provider value={contextValue}>{children}</DatePickerContext.Provider>;
+  return (
+    <DatePickerContext.Provider value={contextValue}>
+      {children}
+      <div role="status" aria-live="polite" aria-atomic="true" style={SR_ONLY}>
+        {announcement}
+      </div>
+    </DatePickerContext.Provider>
+  );
 }

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -712,3 +712,17 @@ describe('DateTimePicker — hydration-safe currentTime fallback', () => {
     expect(second.container.innerHTML).toBe(firstHtml);
   });
 });
+
+describe('DateTimePicker — announce() live-region parity (B10 A-G1)', () => {
+  it('exposes a polite live region from Root and announces month navigation', async () => {
+    const user = userEvent.setup();
+    renderDateTimePicker({ value: '2026-01-15T14:30:00.000Z' });
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+
+    await user.click(screen.getByLabelText('Date and time'));
+    await user.click(screen.getByRole('button', { name: /next month/i }));
+    expect(screen.getByRole('status')).toHaveTextContent(/February 2026/i);
+  });
+});

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -23,6 +23,7 @@ import { TimePickerContext } from '../../context/TimePickerContext.js';
 import type { TimePickerContextValue, TimePickerFormat } from '../../context/TimePickerContext.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
+import { SR_ONLY } from '../../internal/srOnly.js';
 
 /**
  * Props for the DateTimePicker Root component.
@@ -143,6 +144,10 @@ export function DateTimePickerRoot({
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
 
   const [isOpen, setIsOpen] = useState(false);
+
+  // Live-region announcement (mounted on Root so it survives Calendar unmount).
+  const [announcement, setAnnouncement] = useState('');
+  const announce = useCallback((message: string) => setAnnouncement(message), []);
   // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
   const [viewMonth, setViewMonth] = useState<ISODateString>(
     () => currentValue ?? adapter.today(displayTimezone),
@@ -284,6 +289,7 @@ export function DateTimePickerRoot({
       isReadOnly: readOnly,
       pickerId,
       labels: mergedDateLabels,
+      announce,
     }),
     [
       currentValue,
@@ -305,6 +311,7 @@ export function DateTimePickerRoot({
       readOnly,
       pickerId,
       mergedDateLabels,
+      announce,
     ],
   );
 
@@ -343,6 +350,9 @@ export function DateTimePickerRoot({
   return (
     <DatePickerContext.Provider value={dateContext}>
       <TimePickerContext.Provider value={timeContext}>{children}</TimePickerContext.Provider>
+      <div role="status" aria-live="polite" aria-atomic="true" style={SR_ONLY}>
+        {announcement}
+      </div>
     </DatePickerContext.Provider>
   );
 }

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import {
   DEFAULT_RANGEPICKER_LABELS,
   civilMidnightFromUtcDay,
@@ -20,20 +20,9 @@ import type {
 } from '../../context/RangePickerContext.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
+import { SR_ONLY } from '../../internal/srOnly.js';
 
 const EMPTY_RANGE: DateRange = { start: null, end: null };
-
-const SR_ONLY: CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  border: 0,
-};
 
 /**
  * Props for the RangePicker Root component.

--- a/packages/react/src/context/DatePickerContext.ts
+++ b/packages/react/src/context/DatePickerContext.ts
@@ -62,6 +62,13 @@ export interface DatePickerContextValue {
   pickerId: string;
   /** ARIA labels */
   labels: DatePickerLabels;
+  /**
+   * Push a screen-reader announcement into the Root-level live region. Provided by
+   * DatePicker/DateTimePicker Root so month navigation and date selection are announced
+   * even though the live region lives on Root (and thus survives Calendar unmount) —
+   * parity with RangePickerContext.announce.
+   */
+  announce: (message: string) => void;
 }
 
 export const DatePickerContext = createContext<DatePickerContextValue | null>(null);

--- a/packages/react/src/internal/srOnly.ts
+++ b/packages/react/src/internal/srOnly.ts
@@ -1,0 +1,17 @@
+import type { CSSProperties } from 'react';
+
+/**
+ * Visually-hidden style for screen-reader-only content (live regions, extra labels).
+ * Shared across Root/Calendar live regions so the constant isn't duplicated per component.
+ */
+export const SR_ONLY: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -29,12 +29,12 @@ export default defineConfig({
 		const { gzipSync } = await import("zlib");
 		const { readFileSync, writeFileSync } = await import("fs");
 		// Mirror scripts/check-bundle-size.js + .github/workflows/pr-check.yml + release.yml.
-		// Raised from 12 → 13 → 14 → 15 → 16 KB across RC milestones as features landed
-		// (CLAUDE.md §2 records each bump's rationale). Keep all four sources in sync.
+		// Raised from 12 → 13 → 14 → 15 → 16 → 17 KB across milestones as features landed
+		// (CLAUDE.md §2 records each bump's rationale; 16→17 = B10 announce() parity, A-G1).
 		// Only the default `index` entry is checked against the public size budget;
 		// the headless entry is intentionally smaller and measured separately by
 		// scripts/verify-entry-split.mjs.
-		const TARGET_KB = 16;
+		const TARGET_KB = 17;
 		const outputs = [
 			["ESM index", "dist/index.js", true],
 			["CJS index", "dist/index.cjs", true],

--- a/scripts/bundle-diff.mjs
+++ b/scripts/bundle-diff.mjs
@@ -20,7 +20,7 @@
 // the `comment` key (heredoc-delimited) for the PR-comment step to read back.
 
 import { appendFileSync } from "fs";
-import { getGzipBytes, BUNDLES, TARGET_BYTES } from "./check-bundle-size.js";
+import { getGzipBytes, BUNDLES, TARGET_BYTES, TARGET_KB } from "./check-bundle-size.js";
 
 const BASE_ENV = {
 	ESM: "BUNDLE_BASE_ESM",
@@ -74,12 +74,12 @@ console.log("\n📊 Bundle Diff (gzip, vs base)");
 console.log("─".repeat(60));
 for (const { label, head, delta, margin } of rows) {
 	console.log(`  [${label}] head ${fmtKB(head)} (${fmtBytes(head)})`);
-	console.log(`        delta ${fmtDelta(delta)} | margin ${fmtBytes(margin)} to 16KB`);
+	console.log(`        delta ${fmtDelta(delta)} | margin ${fmtBytes(margin)} to ${TARGET_KB}KB`);
 }
 console.log("─".repeat(60));
 console.log(
 	anyOverBudget
-		? "  ❌ over 16KB budget"
+		? `  ❌ over ${TARGET_KB}KB budget`
 		: anyGrowth
 			? "  ⚠️  grows the bundle — confirm the margin is intended"
 			: "  ✅ no growth",
@@ -95,15 +95,15 @@ const tableRows = rows
 	.join("\n");
 
 const summary = anyOverBudget
-	? "❌ **Over the 16KB budget.** Run `pnpm bundle-diff` locally and trim before merge."
+	? `❌ **Over the ${TARGET_KB}KB budget.** Run \`pnpm bundle-diff\` locally and trim before merge.`
 	: anyGrowth
-		? "⚠️ This PR **grows** the bundle. The 16KB ceiling is CJS-bound and the working margin is small — confirm the cost is intended."
+		? `⚠️ This PR **grows** the bundle. The ${TARGET_KB}KB ceiling is CJS-bound and the working margin is small — confirm the cost is intended.`
 		: "✅ No bundle growth vs base.";
 
 const body = [
 	"#### 📊 Bundle diff (gzip, vs base)",
 	"",
-	"| Bundle | head | Δ vs base | margin to 16KB |",
+	`| Bundle | head | Δ vs base | margin to ${TARGET_KB}KB |`,
 	"|---|---|---|---|",
 	tableRows,
 	"",

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -30,9 +30,12 @@ import { readFileSync, statSync, appendFileSync } from "fs";
 // v1.0-rc.4. 15KB → 16KB for `TimePicker.filterTime` — programmatic
 // per-slot disable predicate covering business-hours / lunch-break /
 // blackout-slot use cases, closing the gap with react-datepicker's
-// `filterTime` and MUI X's `shouldDisableTime` (PR following this comment).
-// Still ~4× smaller than react-datepicker (~40KB).
-export const TARGET_KB = 16;
+// `filterTime` and MUI X's `shouldDisableTime`. 16KB → 17KB (v1.1) for the
+// B10 a11y polish — Root-level `announce()` live-region parity across
+// DatePicker/DateTimePicker (audit A-G1), so month-nav and date selection are
+// announced from a region that survives Calendar unmount, matching RangePicker.
+// Still ~3.5× smaller than react-datepicker (~40KB).
+export const TARGET_KB = 17;
 export const TARGET_BYTES = TARGET_KB * 1024;
 
 export const BUNDLES = [


### PR DESCRIPTION
## Summary
Completes Track B **B10** (audit **A-G1**): `announce()` live-region parity for DatePicker and DateTimePicker.

- `DatePickerContext` gains `announce(message)`, backed by a polite `role="status"` region mounted on **Root** (survives Calendar unmount), matching `RangePickerContext`. Previously DatePicker announced from a Calendar-local region that vanished with the popover.
- `DatePicker.Root` + `DateTimePicker.Root` host the region; `MonthPicker`/`YearPicker` inherit via `DatePicker.Root`. Calendar's local `announce` state/region removed.
- Extracted shared `SR_ONLY` style to `internal/srOnly.ts` (dedupes the constant across pickers).

## Bundle ceiling 16 KB → 17 KB
The Root regions add runtime code that overflowed the 16 KB ceiling (CJS −123 B). Per the decision to raise rather than shed the feature, the ceiling moves to **17 KB** (default entry now 15.99 ESM / 16.12 CJS — still ~3.5× smaller than react-datepicker). Synced across `check-bundle-size.js`, `tsup.config.ts`, `bundle-diff.mjs` (now dynamic), the `Bundle Size` CI job name **and the branch-protection required-check context**, plus README/docs figures.

## Dropped: A-G5
The `selectionMode="week"` aria-label rework was dropped — labelling each day with its full week span made all 7 days of a week share a substring, breaking screen-reader/test name queries. Net negative; per-day label retained.

## Test plan
- [x] 4 announce-parity cases (DatePicker region persists across close + month-nav + date-select; DateTimePicker region + month-nav)
- [x] Full suite green (687), typecheck + lint clean, entry-split passes
- [x] bundle within new 17 KB ceiling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * DatePicker 및 DateTimePicker에서 스크린리더를 통한 날짜/월 이동 및 선택 안내 기능 추가
  * 팝오버 열고 닫음에도 안내 메시지가 유지되도록 개선

* **테스트**
  * 새로운 접근성 기능에 대한 테스트 케이스 추가

* **Chores**
  * 기본 번들 크기 상한을 16KB에서 17KB(gzip)로 조정
  * 문서 및 가이드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->