### PR TITLE
docs: competitive-research-driven docs-site improvements (D1–D12)

### DIFF
--- a/apps/docs-site/docs/components/datepicker.md
+++ b/apps/docs-site/docs/components/datepicker.md
@@ -14,6 +14,27 @@ Single-date selection with an input, trigger, popover, and calendar grid.
 import { DatePicker } from '@kalyx/react';
 ```
 
+## Anatomy
+
+Compose the parts you need. Every part below is optional except `DatePicker` (Root) — drop in only what your UI requires.
+
+```tsx
+<DatePicker>            {/* Root — holds state, provides context */}
+  <DatePicker.Input /> {/* combobox <input>, parses typed dates */}
+  <DatePicker.Trigger /> {/* button that toggles the popover */}
+  <DatePicker.Popover> {/* Floating-UI portal, role="dialog" */}
+    <DatePicker.Presets> {/* role="group" of quick-select buttons */}
+      <DatePicker.Preset /> {/* one quick-select toggle button */}
+    </DatePicker.Presets>
+    <DatePicker.Calendar /> {/* month grid, role="grid" */}
+    <DatePicker.MonthGrid /> {/* 3×4 month jump grid (optional view) */}
+    <DatePicker.YearGrid /> {/* paginated year grid (optional view) */}
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+`Calendar`, `MonthGrid`, and `YearGrid` are alternative views of the same popover — swap between them with `onTitleClick` (see [Month / Year navigation](#month--year-navigation)).
+
 ## Basic usage
 
 ```tsx
@@ -35,6 +56,8 @@ function Example() {
 ```
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function BasicDatePicker() {
@@ -241,6 +264,19 @@ type DatePickerCalendarClassNames = {
 };
 ```
 
+### `data-*` attributes
+
+Each day button emits state attributes you can style by (e.g. `data-[selected]:` in Tailwind, or `[data-selected]` in CSS). They appear only when active. See [Styling](../concepts/styling.md) for the full contract.
+
+| Attribute | Active when |
+| --- | --- |
+| `data-selected` | Day is the selected date. |
+| `data-today` | Day is today. |
+| `data-focused` | Day holds keyboard focus. |
+| `data-outside-month` | Day belongs to an adjacent month. |
+
+Disabled days use the native `disabled` + `aria-disabled` attributes (style with `:disabled` or the `dayDisabled` slot).
+
 ## `<DatePicker.MonthGrid>` (optional)
 
 A 3×4 grid of months — drop in to let users jump directly to a month.
@@ -264,6 +300,8 @@ type DatePickerMonthGridClassNames = {
 };
 ```
 
+Each month button emits `data-selected` (selected month), `data-current` (current month), and `data-focused` (keyboard focus). See [Styling](../concepts/styling.md).
+
 ## `<DatePicker.YearGrid>` (optional)
 
 A paginated grid of years (12 per page).
@@ -285,6 +323,8 @@ type DatePickerYearGridClassNames = {
   yearCurrent?: string;
 };
 ```
+
+Each year button emits `data-selected`, `data-current`, and `data-focused` — same contract as `MonthGrid`.
 
 ## `<DatePicker.Presets>` / `<DatePicker.Preset>` (optional)
 

--- a/apps/docs-site/docs/components/datetimepicker.md
+++ b/apps/docs-site/docs/components/datetimepicker.md
@@ -14,6 +14,24 @@ Combined date + time, one popover, one ISO string.
 import { DateTimePicker } from '@kalyx/react';
 ```
 
+## Anatomy
+
+```tsx
+<DateTimePicker>            {/* Root — one ISO string for date + time */}
+  <DateTimePicker.Input /> {/* combobox <input>, parses date + time */}
+  <DateTimePicker.Popover> {/* Floating-UI portal, role="dialog" */}
+    <DateTimePicker.Calendar /> {/* month grid (reuses DatePicker.Calendar) */}
+    <DateTimePicker.MonthGrid /> {/* optional month jump view */}
+    <DateTimePicker.YearGrid /> {/* optional year jump view */}
+    <DateTimePicker.HourList /> {/* hour listbox (reuses TimePicker.HourList) */}
+    <DateTimePicker.MinuteList /> {/* minute listbox */}
+    <DateTimePicker.AmPmToggle /> {/* AM/PM switch (12-hour mode only) */}
+  </DateTimePicker.Popover>
+</DateTimePicker>
+```
+
+The Calendar/MonthGrid/YearGrid parts are re-exported from `DatePicker`, and HourList/MinuteList/AmPmToggle from `TimePicker` — they read the shared `DateTimePicker` context, so a single value drives both halves. `DateTimePicker.Presets` / `.Preset` are available from the [`@kalyx/react/headless`](../guides/adapters.md) entry.
+
 ## Basic usage
 
 ```tsx
@@ -38,6 +56,8 @@ function Example() {
 Selecting a day **does not close the popover** — time can be adjusted after. Use your own close button or outside-click to confirm.
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function BasicDateTime() {
@@ -125,6 +145,8 @@ DateTimePicker re-exports sub-components from both DatePicker and TimePicker und
 | `.AmPmToggle` | Same as TimePicker.AmPmToggle (12h mode only). |
 
 All `classNames` types are re-exported — see [DatePicker](./datepicker.md) and [TimePicker](./timepicker.md).
+
+Sub-components emit the same `data-*` state attributes as their source picker (`data-selected` / `data-today` / `data-focused` on calendar days, `data-selected` on time options). See [Styling](../concepts/styling.md).
 
 ## Patterns
 

--- a/apps/docs-site/docs/components/monthpicker.md
+++ b/apps/docs-site/docs/components/monthpicker.md
@@ -14,6 +14,20 @@ Month selector. The value is the first day of the selected month in UTC-ISO form
 import { MonthPicker } from '@kalyx/react';
 ```
 
+## Anatomy
+
+```tsx
+<MonthPicker>            {/* Root — value = first day of month, UTC */}
+  <MonthPicker.Input /> {/* combobox <input>, parses "YYYY-MM" */}
+  <MonthPicker.Trigger /> {/* button that toggles the popover */}
+  <MonthPicker.Popover> {/* Floating-UI portal, role="dialog" */}
+    <MonthPicker.Grid /> {/* 3×4 grid of months, role="grid" */}
+  </MonthPicker.Popover>
+</MonthPicker>
+```
+
+`Input` and `Trigger` are re-exported from `DatePicker` and read the `MonthPicker` context.
+
 ## Basic usage
 
 ```tsx
@@ -36,6 +50,8 @@ function Example() {
 The default `displayFormat` is `"yyyy-MM"`. Override it if you prefer a different representation (e.g., `"MMMM yyyy"` for `"April 2026"`).
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function BasicMonthPicker() {
@@ -217,6 +233,8 @@ For simple forms where you don't need React state:
   }}
 />
 ```
+
+Each month cell emits `data-selected`, `data-current`, and `data-focused` (active-only). See [Styling](../concepts/styling.md).
 
 ## Related
 

--- a/apps/docs-site/docs/components/rangepicker.md
+++ b/apps/docs-site/docs/components/rangepicker.md
@@ -14,6 +14,21 @@ Two-date selection — a start and an end — with optional presets.
 import { RangePicker } from '@kalyx/react';
 ```
 
+## Anatomy
+
+```tsx
+<RangePicker>            {/* Root — holds the { start, end } range */}
+  <RangePicker.Input part="start" /> {/* start-date combobox input */}
+  <RangePicker.Input part="end" />   {/* end-date combobox input */}
+  <RangePicker.Popover> {/* Floating-UI portal, role="dialog" */}
+    <RangePicker.Presets> {/* role="group" of quick-range buttons */}
+      <RangePicker.Preset /> {/* one quick-range toggle button */}
+    </RangePicker.Presets>
+    <RangePicker.Calendar /> {/* range-aware month grid */}
+  </RangePicker.Popover>
+</RangePicker>
+```
+
 ## Basic usage
 
 ```tsx
@@ -37,6 +52,8 @@ function Example() {
 **Selection flow:** first click sets `start`; second click sets `end`. If the second click is earlier than the first, the two swap automatically.
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function BasicRange() {
@@ -145,6 +162,19 @@ type RangePickerCalendarClassNames = {
   weekdayHeader?: string;
 };
 ```
+
+### `data-*` attributes
+
+Day buttons emit range-aware state attributes (active-only). See [Styling](../concepts/styling.md).
+
+| Attribute | Active when |
+| --- | --- |
+| `data-range-start` | Day is the range start. |
+| `data-range-end` | Day is the range end. |
+| `data-in-range` | Day is strictly between start and end. |
+| `data-today` | Day is today. |
+| `data-focused` | Day holds keyboard focus. |
+| `data-outside-month` | Day belongs to an adjacent month. |
 
 ## `<RangePicker.Presets>`
 

--- a/apps/docs-site/docs/components/timepicker.md
+++ b/apps/docs-site/docs/components/timepicker.md
@@ -14,6 +14,19 @@ Hour + minute (+ optional seconds) selection. 12- or 24-hour mode.
 import { TimePicker } from '@kalyx/react';
 ```
 
+## Anatomy
+
+```tsx
+<TimePicker>            {/* Root — holds the time value (ISO string) */}
+  <TimePicker.Input /> {/* combobox <input>, parses "HH:mm" */}
+  <TimePicker.HourList /> {/* role="listbox" of selectable hours */}
+  <TimePicker.MinuteList /> {/* role="listbox" of selectable minutes */}
+  <TimePicker.AmPmToggle /> {/* AM/PM switch (12-hour mode only) */}
+</TimePicker>
+```
+
+`AmPmToggle` is only meaningful when the Root runs in `format="12h"`. `HourList` / `MinuteList` can be rendered inline or inside your own popover.
+
 ## Basic usage
 
 ```tsx
@@ -35,6 +48,8 @@ function Example() {
 The value is still an ISO 8601 UTC string — the date part acts as a placeholder. Use `getTime(iso)` from `@kalyx/core` if you need just the hours/minutes.
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function Basic24h() {
@@ -112,6 +127,8 @@ Hour set:
 
 - `format="24h"` → `0–23`
 - `format="12h"` → `1–12` (AM/PM managed by `<AmPmToggle>`)
+
+Each option emits `data-selected` when it is the current hour. `MinuteList` and `AmPmToggle` options emit the same `data-selected` flag. See [Styling](../concepts/styling.md).
 
 ## `<TimePicker.MinuteList>`
 

--- a/apps/docs-site/docs/components/weekpicker.md
+++ b/apps/docs-site/docs/components/weekpicker.md
@@ -14,6 +14,20 @@ Week selector. A single click commits the entire week containing the clicked day
 import { WeekPicker, type DateRange } from '@kalyx/react';
 ```
 
+## Anatomy
+
+```tsx
+<WeekPicker>            {/* Root — value = { start, end } of the week */}
+  <WeekPicker.Input part="start" /> {/* week-start combobox input */}
+  <WeekPicker.Input part="end" />   {/* week-end combobox input */}
+  <WeekPicker.Popover> {/* Floating-UI portal, role="dialog" */}
+    <WeekPicker.Calendar /> {/* week-highlighting month grid */}
+  </WeekPicker.Popover>
+</WeekPicker>
+```
+
+`Input` and `Popover` are re-exported from `RangePicker`; a single click in `WeekPicker.Calendar` commits the whole week containing the clicked day (per `weekStartsOn`).
+
 ## Basic usage
 
 ```tsx
@@ -36,6 +50,8 @@ function Example() {
 ```
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function BasicWeekPicker() {
@@ -206,6 +222,8 @@ Same shape as `RangePicker.Calendar` classNames, with an extra `dayInWeek` modif
   }}
 />
 ```
+
+`WeekPicker.Calendar` wraps `RangePicker.Calendar`, so day cells emit the same `data-range-start` / `data-range-end` / `data-in-range` / `data-today` / `data-focused` / `data-outside-month` attributes — the whole committed week spans start→end. See [Styling](../concepts/styling.md).
 
 ## Related
 

--- a/apps/docs-site/docs/components/yearpicker.md
+++ b/apps/docs-site/docs/components/yearpicker.md
@@ -14,6 +14,20 @@ Year selector. The value is January 1 of the selected year in UTC-ISO form — f
 import { YearPicker } from '@kalyx/react';
 ```
 
+## Anatomy
+
+```tsx
+<YearPicker>            {/* Root — value = Jan 1 of the year, UTC */}
+  <YearPicker.Input /> {/* combobox <input>, parses "YYYY" */}
+  <YearPicker.Trigger /> {/* button that toggles the popover */}
+  <YearPicker.Popover> {/* Floating-UI portal, role="dialog" */}
+    <YearPicker.Grid /> {/* paginated grid of years, role="grid" */}
+  </YearPicker.Popover>
+</YearPicker>
+```
+
+`Input` and `Trigger` are re-exported from `DatePicker` and read the `YearPicker` context.
+
 ## Basic usage
 
 ```tsx
@@ -36,6 +50,8 @@ function Example() {
 The default `displayFormat` is `"yyyy"`.
 
 ### Try it live
+
+> The live editor runs with `React` and all Kalyx components in scope, so `import` lines are omitted. Copy them in when porting to your project — see the full imports in the non-live blocks above.
 
 ```jsx live
 function BasicYearPicker() {
@@ -202,6 +218,8 @@ function DisabledYearPicker() {
   }}
 />
 ```
+
+Each year cell emits `data-selected`, `data-current`, and `data-focused` (active-only). See [Styling](../concepts/styling.md).
 
 ## Related
 

--- a/apps/docs-site/docs/concepts/accessibility.md
+++ b/apps/docs-site/docs/concepts/accessibility.md
@@ -8,6 +8,17 @@ sidebar_position: 5
 
 Every Kalyx component ships with WAI-ARIA roles, full keyboard support, and passes automated axe checks in our test suite. You don't *add* accessibility — you'd have to *remove* it.
 
+## Standards & conformance
+
+Kalyx implements the relevant [W3C WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/) patterns:
+
+- **Date Picker Dialog** — [APG pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/) for the calendar popover (`role="dialog"` + a `role="grid"` calendar).
+- **Combobox** — [APG pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) for the text inputs that open a popover.
+- **Listbox** — [APG pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/) for the TimePicker hour / minute lists.
+- **Radio Group** — [APG pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/) for the AM/PM toggle.
+
+**Conformance target:** structure, roles, names, and keyboard operation aim for **WCAG 2.1 Level AA**. Because Kalyx ships zero colors, the color-contrast success criteria (1.4.3, 1.4.11) depend on *your* CSS — see [Color contrast](#color-contrast) below.
+
 ## ARIA roles at a glance
 
 | Element | Role / attributes |
@@ -43,6 +54,23 @@ Focused dates have `tabIndex=0`; all other days have `tabIndex=-1` — a single 
 | `↑` / `↓` | Move focus between options |
 | `Home` / `End` | First / last option |
 | `Enter` / `Space` | Select option |
+
+## Keyboard — MonthGrid / YearGrid
+
+The month-jump and year-jump grids (`DatePicker.MonthGrid`, `DatePicker.YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid`) share one roving-focus model:
+
+| Key | Action |
+| --- | --- |
+| `←` / `→` | Move focus one cell |
+| `↑` / `↓` | Move focus one row (3 cells) |
+| `Home` / `End` | Start / end of the current row |
+| `PageUp` / `PageDown` | Previous / next frame (year for months, decade for years) |
+| `Enter` / `Space` | Select focused month / year |
+| `Escape` | Close popover, restore focus |
+
+## Keyboard — RangePicker / WeekPicker calendar
+
+Same grid keys as `DatePicker.Calendar` above. For RangePicker, the first `Enter` / click sets `start`, the second sets `end` (auto-swapping if reversed). For WeekPicker, a single `Enter` / click commits the entire week containing the focused day.
 
 ## Keyboard — Trigger and Input
 

--- a/apps/docs-site/docs/concepts/internationalization.md
+++ b/apps/docs-site/docs/concepts/internationalization.md
@@ -149,6 +149,46 @@ Weekday headers and month names use `Intl.DateTimeFormat` under the hood. Pass t
 
 Both are independent — you can use `locale="ko-KR"` with English labels, or vice versa.
 
+## Right-to-left (RTL)
+
+Kalyx renders semantic HTML and reads no layout direction of its own, so RTL "just works" — set `dir="rtl"` on any ancestor (or `<html dir="rtl">`) and the calendar grid, inputs, and popover mirror with the document. Use a matching `locale` (e.g. `ar-EG`) for Arabic weekday / month names.
+
+Toggle the direction below to see the same picker mirror:
+
+```jsx live
+function RtlToggle() {
+  const [date, setDate] = React.useState(null);
+  const [dir, setDir] = React.useState('rtl');
+  return (
+    <div>
+      <button
+        className="kx-live-trigger"
+        style={{ marginBottom: 12 }}
+        onClick={() => setDir((d) => (d === 'rtl' ? 'ltr' : 'rtl'))}>
+        dir = {dir} (toggle)
+      </button>
+      <div dir={dir}>
+        <DatePicker value={date} onChange={setDate} locale={dir === 'rtl' ? 'ar-EG' : 'en-US'}>
+          <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
+          <DatePicker.Popover className="kx-live-popover">
+            <DatePicker.Calendar
+              classNames={{
+                header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav',
+                grid: 'kx-live-grid', gridCell: 'kx-live-cell', weekdayHeader: 'kx-live-weekday',
+                day: 'live-day', daySelected: 'live-day-selected', dayToday: 'live-day-today',
+                dayOutsideMonth: 'kx-live-outside',
+              }}
+            />
+          </DatePicker.Popover>
+        </DatePicker>
+      </div>
+    </div>
+  );
+}
+```
+
+The navigation chevrons keep their visual "previous / next" meaning because the whole grid mirrors with `dir` — you don't need to swap them yourself. Provide localized `labels` (see [above](#label-keys-reference)) so screen-reader announcements match the language.
+
 ## Next
 
 - [Accessibility →](./accessibility.md)

--- a/apps/docs-site/docs/concepts/styling.md
+++ b/apps/docs-site/docs/concepts/styling.md
@@ -1,0 +1,99 @@
+---
+id: styling
+title: Styling
+sidebar_position: 2
+---
+
+# Styling
+
+Kalyx ships **zero CSS**. Every part renders semantic, unstyled HTML and exposes two styling contracts:
+
+1. **`classNames` prop** — a typed map of slot names → class strings, on each sub-component.
+2. **`data-*` state attributes** — emitted on interactive elements so you can style by state in CSS / Tailwind without re-rendering.
+
+Either works alone; combine them when you want a stable class plus state-based variants.
+
+## 1. The `classNames` prop
+
+Every sub-component accepts a `classNames` object keyed by internal slot. Pass only the slots you care about.
+
+```tsx
+<DatePicker.Calendar
+  classNames={{
+    grid: 'grid grid-cols-7 gap-1',
+    day: 'rounded p-2 hover:bg-gray-100',
+    daySelected: 'bg-blue-600 text-white',
+    dayToday: 'ring-1 ring-blue-400',
+    dayDisabled: 'opacity-40 cursor-not-allowed',
+    dayOutsideMonth: 'text-gray-300',
+  }}
+/>
+```
+
+Slot keys are documented per sub-component on each [component page](../components/datepicker.md). The state slots (`daySelected`, `dayToday`, …) are applied **in addition to** the base slot (`day`) when that state is active — so a selected day gets both `day` and `daySelected` classes.
+
+## 2. `data-*` state attributes
+
+For Tailwind (`data-[selected]:…`) or plain CSS attribute selectors, every stateful element also carries `data-*` attributes. They are **present only when the state is active** (omitted otherwise — never `data-selected="false"`), so `[data-selected]` is a reliable selector.
+
+```css
+/* plain CSS */
+.day[data-selected] { background: #2563eb; color: white; }
+.day[data-today]    { outline: 1px solid #60a5fa; }
+.day[data-in-range] { background: #dbeafe; }
+```
+
+```tsx
+/* Tailwind v3.1+ data variants — no classNames needed */
+<DatePicker.Calendar
+  classNames={{
+    day: 'rounded p-2 data-[selected]:bg-blue-600 data-[selected]:text-white data-[today]:ring-1',
+  }}
+/>
+```
+
+### Attribute reference
+
+These are the attributes Kalyx emits. `disabled` days use the native `disabled` attribute **and** `aria-disabled` (not a `data-*` flag), so style them with `:disabled` or the `dayDisabled` slot.
+
+#### Calendar day cells
+
+| Attribute | Emitted by | Active when |
+| --- | --- | --- |
+| `data-focused` | `DatePicker` / `RangePicker` / `WeekPicker` / `DateTimePicker` `.Calendar` | Day holds keyboard focus (roving tabindex). |
+| `data-selected` | `DatePicker` / `DateTimePicker` `.Calendar` | Day is the selected date. |
+| `data-today` | all `.Calendar` | Day is today (in `displayTimezone` if set). |
+| `data-outside-month` | all `.Calendar` | Day pads the 6-week view from an adjacent month. |
+| `data-range-start` | `RangePicker` / `WeekPicker` `.Calendar` | Day is the range's start. |
+| `data-range-end` | `RangePicker` / `WeekPicker` `.Calendar` | Day is the range's end. |
+| `data-in-range` | `RangePicker` / `WeekPicker` `.Calendar` | Day is strictly between start and end. |
+| `data-week-number` | all `.Calendar` (on the row `<th>`) | Present when week numbers are shown. |
+
+#### Month / year cells
+
+| Attribute | Emitted by | Active when |
+| --- | --- | --- |
+| `data-selected` | `DatePicker.MonthGrid` / `.YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid` | Cell is the selected month / year. |
+| `data-current` | same as above | Cell is the current month / year (today). |
+| `data-focused` | same as above | Cell holds keyboard focus. |
+
+#### Time cells
+
+| Attribute | Emitted by | Active when |
+| --- | --- | --- |
+| `data-selected` | `TimePicker.HourList` / `.MinuteList` / `.AmPmToggle` (and `DateTimePicker` equivalents) | The hour / minute / meridiem is the current value. |
+
+#### Presets & inputs
+
+| Attribute | Emitted by | Active when |
+| --- | --- | --- |
+| `data-active` | `DatePicker` / `RangePicker` / `DateTimePicker` `.Preset` | The preset's resolved date matches the current value. |
+| `data-part` | `RangePicker` / `WeekPicker` `.Input` | Always — value is `"start"` or `"end"`, to target each input. |
+
+## Which should I use?
+
+- **Static look** → `classNames` base slots (`day`, `grid`, …).
+- **State variants in Tailwind** → `data-[selected]:` / `data-[today]:` utilities inside a single slot class.
+- **Plain CSS / design tokens** → `data-*` attribute selectors in your stylesheet.
+
+See the [Tailwind recipe](../recipes/tailwind.md) and [shadcn recipe](../recipes/shadcn.md) for end-to-end examples.

--- a/apps/docs-site/docs/getting-started/installation.md
+++ b/apps/docs-site/docs/getting-started/installation.md
@@ -19,15 +19,8 @@ Kalyx is distributed as two packages. Most apps install only `@kalyx/react` — 
 
 ## Install
 
-```bash
-# pnpm (recommended)
-pnpm add @kalyx/react
-
-# npm
+```bash npm2yarn
 npm install @kalyx/react
-
-# yarn
-yarn add @kalyx/react
 ```
 
 `@kalyx/react` depends on:

--- a/apps/docs-site/docs/getting-started/quick-start.mdx
+++ b/apps/docs-site/docs/getting-started/quick-start.mdx
@@ -12,6 +12,10 @@ Build a working DatePicker in five minutes.
 
 Edit the code below — changes update the preview instantly. Kalyx is headless, so what you see is raw HTML plus the `classNames` you provide.
 
+:::note Live editor imports
+The live editors on this site run with `React` and every Kalyx component / hook already in scope, so the examples omit `import` lines. When you copy a live snippet into your own project, add the imports — e.g. `import { useState } from 'react';` and `import { DatePicker } from '@kalyx/react';`. The non-live `tsx` blocks below always show the full imports.
+:::
+
 ```jsx live
 function LiveExample() {
   const [date, setDate] = React.useState(null);
@@ -48,13 +52,13 @@ function LiveExample() {
 
 ## 1. Install
 
-```bash
-pnpm add @kalyx/react
+```bash npm2yarn
+npm install @kalyx/react
 ```
 
 ## 2. Controlled DatePicker
 
-```tsx
+```tsx title="BirthdayPicker.tsx"
 import { useState } from 'react';
 import { DatePicker, type ISODateString } from '@kalyx/react';
 
@@ -62,6 +66,7 @@ export function BirthdayPicker() {
   const [date, setDate] = useState<ISODateString | null>(null);
 
   return (
+    // highlight-next-line
     <DatePicker value={date} onChange={setDate}>
       <DatePicker.Input placeholder="YYYY-MM-DD" />
       <DatePicker.Trigger />
@@ -122,7 +127,7 @@ See [ISO Strings →](../concepts/iso-string) for why.
 
 ## 5. Try a range
 
-```tsx
+```tsx title="VacationRange.tsx"
 import { useState } from 'react';
 import { RangePicker, type DateRange } from '@kalyx/react';
 

--- a/apps/docs-site/docs/guides/adapters.md
+++ b/apps/docs-site/docs/guides/adapters.md
@@ -16,8 +16,8 @@ because Kalyx is here.
 
 ## Default (date-fns)
 
-```bash
-pnpm add @kalyx/react
+```bash npm2yarn
+npm install @kalyx/react
 ```
 
 ```tsx

--- a/apps/docs-site/docs/hooks/use-date-time-picker.md
+++ b/apps/docs-site/docs/hooks/use-date-time-picker.md
@@ -1,0 +1,100 @@
+---
+id: use-date-time-picker
+title: useDateTimePicker
+sidebar_position: 7
+---
+
+# useDateTimePicker
+
+The headless hook behind `<DateTimePicker>`. One ISO string drives both the calendar and the time-of-day; `selectDate` preserves the time and `setTime` preserves the date.
+
+:::info `/headless` entry
+Exported from **`@kalyx/react/headless`** (adapter-agnostic). See [Date adapters & the `/headless` entry](../guides/adapters.md).
+:::
+
+```tsx
+import { useDateTimePicker } from '@kalyx/react/headless';
+```
+
+## Signature
+
+```ts
+function useDateTimePicker(options?: UseDateTimePickerOptions): UseDateTimePickerReturn;
+```
+
+### Options
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `ISODateString \| null` | — | Controlled datetime (date + time, UTC). |
+| `defaultValue` | `ISODateString` | — | Uncontrolled initial datetime. |
+| `onChange` | `(value: ISODateString \| null) => void` | — | Fires when the datetime changes. |
+| `disabled` | `DisabledRule[]` | `[]` | Disable rules (applied to days). |
+| `weekStartsOn` | `0 \| 1` | `0` | Day the week starts on. |
+| `adapter` | `DateAdapter` | — | Date adapter (required on `/headless`). |
+| `displayTimezone` | `string` | — | IANA zone. `currentTime` is reported in this zone. See [Timezone](../concepts/timezone.md). |
+
+### Return
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `value` | `ISODateString \| null` | Current datetime. |
+| `isOpen` | `boolean` | Popover state. |
+| `open` / `close` / `toggle` | `() => void` | Popover controls. |
+| `selectDate` | `(iso: ISODateString \| null) => void` | Set the date, preserving the time (does **not** close the popover). |
+| `setTime` | `(partial: Partial<TimeValue>) => void` | Change the time, preserving the date. |
+| `currentTime` | `TimeValue` | Time portion of the value (in `displayTimezone` when set). |
+| `viewMonth` | `ISODateString` | First-day-of-visible-month. |
+| `setViewMonth` | `(iso: ISODateString) => void` | Jump to a month. |
+| `calendar` | `CalendarGrid` | 6×7 grid of `CalendarDay`s. |
+| `focusedDate` | `ISODateString` | Keyboard-focused day. |
+| `setFocusedDate` | `(iso: ISODateString) => void` | Move focus. |
+| `previousMonth` / `nextMonth` | `() => void` | Month navigation shorthands. |
+| `pickerId` | `string` | Stable ID for ARIA wiring. |
+| `adapter` | `DateAdapter` | The resolved adapter. |
+
+### `TimeValue`
+
+```ts
+type TimeValue = {
+  hours: number;   // 0–23
+  minutes: number; // 0–59
+  seconds: number; // 0–59
+};
+```
+
+## Example
+
+```tsx
+import { useDateTimePicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniDateTime() {
+  const { value, currentTime, calendar, selectDate, setTime } =
+    useDateTimePicker({ adapter: DateFnsAdapter, displayTimezone: 'Asia/Seoul' });
+
+  return (
+    <div>
+      <div className="grid grid-cols-7">
+        {calendar.flat().map((day) => (
+          <button key={day.isoString} onClick={() => selectDate(day.isoString)}>
+            {day.dayNumber}
+          </button>
+        ))}
+      </div>
+      <input
+        type="number"
+        value={currentTime.hours}
+        onChange={(e) => setTime({ hours: Number(e.target.value) })}
+      />
+      <code>{value ?? 'null'}</code>
+    </div>
+  );
+}
+```
+
+## Related
+
+- [DateTimePicker component →](../components/datetimepicker.md)
+- [useDatePicker →](./use-date-picker.md) / [useTimePicker →](./use-time-picker.md)
+- [Date adapters →](../guides/adapters.md)

--- a/apps/docs-site/docs/hooks/use-month-picker.md
+++ b/apps/docs-site/docs/hooks/use-month-picker.md
@@ -1,0 +1,101 @@
+---
+id: use-month-picker
+title: useMonthPicker
+sidebar_position: 4
+---
+
+# useMonthPicker
+
+The headless hook behind `<MonthPicker>`. Exposes the 12-month grid and navigation; you render the DOM and wire focus / keyboard.
+
+:::info `/headless` entry
+The Month / Year / Week / DateTime hooks are exported from the **`@kalyx/react/headless`** entry, which is adapter-agnostic (no bundled date-fns). See [Date adapters & the `/headless` entry](../guides/adapters.md).
+:::
+
+```tsx
+import { useMonthPicker } from '@kalyx/react/headless';
+```
+
+## Signature
+
+```ts
+function useMonthPicker(options?: UseMonthPickerOptions): UseMonthPickerReturn;
+```
+
+### Options
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `ISODateString \| null` | — | Controlled month (stored as month-start ISO). |
+| `defaultValue` | `ISODateString` | — | Uncontrolled initial month. |
+| `onChange` | `(value: ISODateString \| null) => void` | — | Fires when the month changes. |
+| `disabled` | `DisabledRule[]` | `[]` | A month is disabled only when fully excluded. |
+| `adapter` | `DateAdapter` | — | Date adapter (required on `/headless`). |
+| `displayTimezone` | `string` | — | IANA zone for civil-day comparison. See [Timezone](../concepts/timezone.md). |
+| `locale` | `string` | `'en-US'` | BCP 47 locale for month names. |
+
+### Return
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `value` | `ISODateString \| null` | Current selected month. |
+| `isOpen` | `boolean` | Popover state. |
+| `open` / `close` / `toggle` | `() => void` | Popover controls. |
+| `selectMonth` | `(iso: ISODateString) => void` | Commit a month (pass a cell's `isoString`). |
+| `viewYear` | `number` | Year currently shown in the grid. |
+| `previousYear` / `nextYear` | `() => void` | Move the grid one year. |
+| `months` | `MonthCell[]` | The 12 month cells for `viewYear`. |
+| `pickerId` | `string` | Stable `useId`-based ID for ARIA wiring. |
+| `adapter` | `DateAdapter` | The resolved adapter. |
+
+### `MonthCell`
+
+```ts
+type MonthCell = {
+  isoString: ISODateString; // month-start ISO (UTC)
+  monthIndex: number;       // 0 = January
+  label: string;            // localized month name
+  isSelected: boolean;
+  isCurrent: boolean;       // current month (today)
+  isDisabled: boolean;
+};
+```
+
+## Example
+
+```tsx
+import { useMonthPicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniMonthGrid() {
+  const { months, viewYear, previousYear, nextYear, selectMonth } =
+    useMonthPicker({ adapter: DateFnsAdapter, onChange: (v) => console.log(v) });
+
+  return (
+    <div>
+      <header>
+        <button onClick={previousYear} aria-label="Previous year">◀</button>
+        <span>{viewYear}</span>
+        <button onClick={nextYear} aria-label="Next year">▶</button>
+      </header>
+      <div className="grid grid-cols-3">
+        {months.map((m) => (
+          <button
+            key={m.isoString}
+            aria-selected={m.isSelected}
+            disabled={m.isDisabled}
+            onClick={() => selectMonth(m.isoString)}>
+            {m.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## Related
+
+- [MonthPicker component →](../components/monthpicker.md)
+- [useYearPicker →](./use-year-picker.md)
+- [Date adapters →](../guides/adapters.md)

--- a/apps/docs-site/docs/hooks/use-week-picker.md
+++ b/apps/docs-site/docs/hooks/use-week-picker.md
@@ -1,0 +1,91 @@
+---
+id: use-week-picker
+title: useWeekPicker
+sidebar_position: 6
+---
+
+# useWeekPicker
+
+The headless hook behind `<WeekPicker>`. A single `selectWeek` commits the whole week containing the clicked day; the grid highlights the selected week as a range.
+
+:::info `/headless` entry
+Exported from **`@kalyx/react/headless`** (adapter-agnostic). See [Date adapters & the `/headless` entry](../guides/adapters.md).
+:::
+
+```tsx
+import { useWeekPicker } from '@kalyx/react/headless';
+```
+
+## Signature
+
+```ts
+function useWeekPicker(options?: UseWeekPickerOptions): UseWeekPickerReturn;
+```
+
+### Options
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `DateRange` | — | Controlled week as a `{ start, end }` range. |
+| `defaultValue` | `DateRange` | — | Uncontrolled initial week. |
+| `onChange` | `(week: DateRange) => void` | — | Fires when the selected week changes. |
+| `disabled` | `DisabledRule[]` | `[]` | Disable rules. |
+| `weekStartsOn` | `0 \| 1` | `0` | Day the week starts on. |
+| `adapter` | `DateAdapter` | — | Date adapter (required on `/headless`). |
+| `displayTimezone` | `string` | — | IANA zone for civil-day comparison. |
+
+### Return
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `value` | `DateRange` | Selected week as `{ start, end }`. |
+| `isOpen` | `boolean` | Popover state. |
+| `open` / `close` / `toggle` | `() => void` | Popover controls. |
+| `selectWeek` | `(iso: ISODateString) => void` | Commit the whole week containing the clicked day. |
+| `viewMonth` | `ISODateString` | First-day-of-visible-month. |
+| `setViewMonth` | `(iso: ISODateString) => void` | Jump to a month. |
+| `calendar` | `CalendarGrid` | 6×7 grid with the selected week highlighted as a range. |
+| `previousMonth` / `nextMonth` | `() => void` | Month navigation shorthands. |
+| `pickerId` | `string` | Stable ID for ARIA wiring. |
+| `adapter` | `DateAdapter` | The resolved adapter. |
+
+Each `CalendarDay` in `calendar` carries `isRangeStart` / `isRangeEnd` / `isInRange` reflecting the committed week (see [useDatePicker → CalendarDay](./use-date-picker.md#calendarday)).
+
+## Example
+
+```tsx
+import { useWeekPicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniWeekGrid() {
+  const { calendar, viewMonth, previousMonth, nextMonth, selectWeek } =
+    useWeekPicker({ adapter: DateFnsAdapter, weekStartsOn: 1 });
+
+  return (
+    <div>
+      <header>
+        <button onClick={previousMonth} aria-label="Previous">◀</button>
+        <span>{viewMonth.slice(0, 7)}</span>
+        <button onClick={nextMonth} aria-label="Next">▶</button>
+      </header>
+      <div className="grid grid-cols-7">
+        {calendar.flat().map((day) => (
+          <button
+            key={day.isoString}
+            disabled={day.isDisabled}
+            onClick={() => selectWeek(day.isoString)}
+            className={day.isInRange || day.isRangeStart || day.isRangeEnd ? 'bg-indigo-100' : ''}>
+            {day.dayNumber}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## Related
+
+- [WeekPicker component →](../components/weekpicker.md)
+- [useRangePicker →](./use-range-picker.md)
+- [Date adapters →](../guides/adapters.md)

--- a/apps/docs-site/docs/hooks/use-year-picker.md
+++ b/apps/docs-site/docs/hooks/use-year-picker.md
@@ -1,0 +1,99 @@
+---
+id: use-year-picker
+title: useYearPicker
+sidebar_position: 5
+---
+
+# useYearPicker
+
+The headless hook behind `<YearPicker>`. Exposes a 12-year decade block and navigation.
+
+:::info `/headless` entry
+Exported from **`@kalyx/react/headless`** (adapter-agnostic). See [Date adapters & the `/headless` entry](../guides/adapters.md).
+:::
+
+```tsx
+import { useYearPicker } from '@kalyx/react/headless';
+```
+
+## Signature
+
+```ts
+function useYearPicker(options?: UseYearPickerOptions): UseYearPickerReturn;
+```
+
+### Options
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `ISODateString \| null` | — | Controlled year (stored as Jan 1 ISO). |
+| `defaultValue` | `ISODateString` | — | Uncontrolled initial year. |
+| `onChange` | `(value: ISODateString \| null) => void` | — | Fires when the year changes. |
+| `disabled` | `DisabledRule[]` | `[]` | A year is disabled only when fully excluded. |
+| `adapter` | `DateAdapter` | — | Date adapter (required on `/headless`). |
+| `displayTimezone` | `string` | — | IANA zone for civil-day comparison. |
+
+### Return
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `value` | `ISODateString \| null` | Current selected year. |
+| `isOpen` | `boolean` | Popover state. |
+| `open` / `close` / `toggle` | `() => void` | Popover controls. |
+| `selectYear` | `(iso: ISODateString) => void` | Commit a year (pass a cell's `isoString`). |
+| `decadeStart` | `number` | First year of the displayed 12-year block. |
+| `previousDecade` / `nextDecade` | `() => void` | Move the grid one decade block. |
+| `years` | `YearCell[]` | The 12 year cells for the current block. |
+| `pickerId` | `string` | Stable ID for ARIA wiring. |
+| `adapter` | `DateAdapter` | The resolved adapter. |
+
+### `YearCell`
+
+```ts
+type YearCell = {
+  isoString: ISODateString; // Jan 1, UTC midnight
+  year: number;
+  isSelected: boolean;
+  isCurrent: boolean;       // current year (today)
+  isDisabled: boolean;
+};
+```
+
+## Example
+
+```tsx
+import { useYearPicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniYearGrid() {
+  const { years, decadeStart, previousDecade, nextDecade, selectYear } =
+    useYearPicker({ adapter: DateFnsAdapter });
+
+  return (
+    <div>
+      <header>
+        <button onClick={previousDecade} aria-label="Previous decade">◀</button>
+        <span>{decadeStart}–{decadeStart + 11}</span>
+        <button onClick={nextDecade} aria-label="Next decade">▶</button>
+      </header>
+      <div className="grid grid-cols-3">
+        {years.map((y) => (
+          <button
+            key={y.isoString}
+            aria-selected={y.isSelected}
+            disabled={y.isDisabled}
+            onClick={() => selectYear(y.isoString)}>
+            {y.year}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## Related
+
+- [YearPicker component →](../components/yearpicker.md)
+- [useMonthPicker →](./use-month-picker.md)
+- [Date adapters →](../guides/adapters.md)

--- a/apps/docs-site/docs/recipes/testing.md
+++ b/apps/docs-site/docs/recipes/testing.md
@@ -12,8 +12,8 @@ How to test Kalyx components in your application using Vitest (or Jest) + Testin
 
 Install the testing dependencies:
 
-```bash
-pnpm add -D vitest @testing-library/react @testing-library/user-event @testing-library/jest-dom jest-axe jsdom
+```bash npm2yarn
+npm install -D vitest @testing-library/react @testing-library/user-event @testing-library/jest-dom jest-axe jsdom
 ```
 
 Configure Vitest with jsdom:

--- a/apps/docs-site/docs/recipes/use-cases.md
+++ b/apps/docs-site/docs/recipes/use-cases.md
@@ -1,0 +1,239 @@
+---
+id: use-cases
+title: Use-case recipes
+sidebar_position: 0
+---
+
+# Use-case recipes
+
+Copy-pasteable solutions to the date-picking problems people actually have. Each recipe is a complete, working component — try it live, then copy the source below it.
+
+These use Tailwind-style class names for brevity, but the only thing that matters is the **composition** and the **props**. Swap in your own classes or the [`classNames` styling contract](../concepts/styling.md).
+
+---
+
+## Date of birth
+
+A birthday picker needs to jump across decades fast — nobody wants to click "previous month" 300 times. Wire `Calendar → MonthGrid → YearGrid` so the title is a drill-up control, and disable future dates.
+
+```jsx live
+function DateOfBirth() {
+  const [dob, setDob] = React.useState(null);
+  const [view, setView] = React.useState('days');
+  const today = new Date().toISOString();
+  const headerCls = { header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav' };
+  return (
+    <DatePicker
+      value={dob}
+      onChange={(v) => { setDob(v); setView('days'); }}
+      disabled={[{ after: today }]}
+    >
+      <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
+      <DatePicker.Popover className="kx-live-popover">
+        {view === 'days' && (
+          <DatePicker.Calendar
+            onTitleClick={() => setView('months')}
+            classNames={{
+              ...headerCls, grid: 'kx-live-grid', gridCell: 'kx-live-cell',
+              weekdayHeader: 'kx-live-weekday', day: 'live-day',
+              daySelected: 'live-day-selected', dayToday: 'live-day-today',
+              dayDisabled: 'kx-live-disabled', dayOutsideMonth: 'kx-live-outside',
+            }}
+          />
+        )}
+        {view === 'months' && (
+          <DatePicker.MonthGrid
+            onSelect={() => setView('days')}
+            onTitleClick={() => setView('years')}
+            classNames={{ ...headerCls, grid: 'kx-live-month-grid', month: 'kx-live-my-cell', monthSelected: 'kx-live-my-selected', monthCurrent: 'kx-live-my-current' }}
+          />
+        )}
+        {view === 'years' && (
+          <DatePicker.YearGrid
+            onSelect={() => setView('months')}
+            classNames={{ ...headerCls, grid: 'kx-live-year-grid', year: 'kx-live-my-cell', yearSelected: 'kx-live-my-selected', yearCurrent: 'kx-live-my-current' }}
+          />
+        )}
+      </DatePicker.Popover>
+      <div className="kx-live-value">Born: <code>{dob?.slice(0, 10) ?? 'null'}</code> — tap the title to jump by month / year.</div>
+    </DatePicker>
+  );
+}
+```
+
+```tsx title="DateOfBirth.tsx"
+import { useState } from 'react';
+import { DatePicker, type ISODateString } from '@kalyx/react';
+
+export function DateOfBirth() {
+  const [dob, setDob] = useState<ISODateString | null>(null);
+  const [view, setView] = useState<'days' | 'months' | 'years'>('days');
+  const today = new Date().toISOString();
+
+  return (
+    <DatePicker
+      value={dob}
+      onChange={(v) => { setDob(v); setView('days'); }}
+      disabled={[{ after: today }]} // no future birthdays
+    >
+      <DatePicker.Input placeholder="YYYY-MM-DD" />
+      <DatePicker.Popover>
+        {view === 'days' && (
+          <DatePicker.Calendar onTitleClick={() => setView('months')} />
+        )}
+        {view === 'months' && (
+          <DatePicker.MonthGrid
+            onSelect={() => setView('days')}
+            onTitleClick={() => setView('years')}
+          />
+        )}
+        {view === 'years' && (
+          <DatePicker.YearGrid onSelect={() => setView('months')} />
+        )}
+      </DatePicker.Popover>
+    </DatePicker>
+  );
+}
+```
+
+**Why this works:** the title becomes a drill-up control (`onTitleClick`), and each grid's `onSelect` drills back down. `disabled={[{ after: today }]}` blocks future dates without a `maxDate` prop. See [DatePicker → Month / Year navigation](../components/datepicker.md#month--year-navigation).
+
+---
+
+## Booking range with presets
+
+A reservation flow wants a start/end range *and* one-tap common ranges. Combine `RangePicker.Presets` with the range calendar; presets commit and close.
+
+```jsx live
+function BookingRange() {
+  const [range, setRange] = React.useState({ start: null, end: null });
+  const iso = (d) => { const x = new Date(); x.setUTCHours(0,0,0,0); x.setUTCDate(x.getUTCDate() + d); return x.toISOString(); };
+  return (
+    <RangePicker value={range} onChange={setRange}>
+      <div className="kx-live-row">
+        <RangePicker.Input part="start" className="kx-live-input" placeholder="Check-in" />
+        <span aria-hidden>→</span>
+        <RangePicker.Input part="end" className="kx-live-input" placeholder="Check-out" />
+      </div>
+      <RangePicker.Popover className="kx-live-popover">
+        <RangePicker.Presets className="kx-live-presets">
+          <RangePicker.Preset className="kx-live-preset" range={{ start: iso(0), end: iso(2) }}>Weekend</RangePicker.Preset>
+          <RangePicker.Preset className="kx-live-preset" range={{ start: iso(0), end: iso(6) }}>1 week</RangePicker.Preset>
+          <RangePicker.Preset className="kx-live-preset" range={{ start: iso(0), end: iso(13) }}>2 weeks</RangePicker.Preset>
+        </RangePicker.Presets>
+        <RangePicker.Calendar
+          classNames={{
+            header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav',
+            grid: 'kx-live-grid', gridCell: 'kx-live-cell', weekdayHeader: 'kx-live-weekday',
+            day: 'kx-live-day-range', dayRangeStart: 'kx-live-range-start',
+            dayRangeEnd: 'kx-live-range-end', dayInRange: 'kx-live-inrange',
+            dayToday: 'live-day-today', dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+      </RangePicker.Popover>
+      <div className="kx-live-value">
+        <code>{range.start?.slice(0, 10) ?? 'null'}</code> → <code>{range.end?.slice(0, 10) ?? 'null'}</code>
+      </div>
+    </RangePicker>
+  );
+}
+```
+
+```tsx title="BookingRange.tsx"
+import { useState } from 'react';
+import { RangePicker, type DateRange } from '@kalyx/react';
+
+const day = (offset: number) => {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString();
+};
+
+export function BookingRange() {
+  const [range, setRange] = useState<DateRange>({ start: null, end: null });
+  return (
+    <RangePicker value={range} onChange={setRange}>
+      <RangePicker.Input part="start" placeholder="Check-in" />
+      <RangePicker.Input part="end" placeholder="Check-out" />
+      <RangePicker.Popover>
+        <RangePicker.Presets>
+          <RangePicker.Preset range={{ start: day(0), end: day(2) }}>Weekend</RangePicker.Preset>
+          <RangePicker.Preset range={{ start: day(0), end: day(6) }}>1 week</RangePicker.Preset>
+          <RangePicker.Preset range={{ start: day(0), end: day(13) }}>2 weeks</RangePicker.Preset>
+        </RangePicker.Presets>
+        <RangePicker.Calendar />
+      </RangePicker.Popover>
+    </RangePicker>
+  );
+}
+```
+
+**Why this works:** each `RangePicker.Preset` takes a `range={{ start, end }}` of ISO-UTC strings, commits both ends, and closes the popover. Active presets get `data-active` so you can highlight the current selection. See [RangePicker → Presets](../components/rangepicker.md).
+
+---
+
+## DateTime with a fixed timezone
+
+Scheduling UIs must store an unambiguous instant while *showing* a specific civil time. Set `displayTimezone` — the Input and Calendar render in that zone, but `onChange` still emits a UTC instant.
+
+```jsx live
+function MeetingTime() {
+  const [dt, setDt] = React.useState(null);
+  return (
+    <DateTimePicker value={dt} onChange={setDt} format="24h" step={30} displayTimezone="Asia/Seoul">
+      <DateTimePicker.Input className="kx-live-input" placeholder="Pick a meeting time (KST)" />
+      <DateTimePicker.Popover className="kx-live-popover kx-live-popover--split">
+        <DateTimePicker.Calendar
+          classNames={{
+            header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav',
+            grid: 'kx-live-grid', gridCell: 'kx-live-cell', weekdayHeader: 'kx-live-weekday',
+            day: 'live-day', daySelected: 'live-day-selected', dayToday: 'live-day-today',
+            dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+        <div className="kx-live-stack">
+          <DateTimePicker.HourList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+          <DateTimePicker.MinuteList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+        </div>
+      </DateTimePicker.Popover>
+      <div className="kx-live-value">UTC stored: <code>{dt ?? 'null'}</code></div>
+    </DateTimePicker>
+  );
+}
+```
+
+```tsx title="MeetingTime.tsx"
+import { useState } from 'react';
+import { DateTimePicker, type ISODateString } from '@kalyx/react';
+
+export function MeetingTime() {
+  const [dt, setDt] = useState<ISODateString | null>(null);
+  return (
+    <DateTimePicker
+      value={dt}
+      onChange={setDt}      // always a UTC ISO string
+      format="24h"
+      step={30}
+      displayTimezone="Asia/Seoul" // shown as KST, stored as UTC
+    >
+      <DateTimePicker.Input placeholder="Pick a meeting time (KST)" />
+      <DateTimePicker.Popover>
+        <DateTimePicker.Calendar />
+        <DateTimePicker.HourList />
+        <DateTimePicker.MinuteList />
+      </DateTimePicker.Popover>
+    </DateTimePicker>
+  );
+}
+```
+
+**Why this works:** `displayTimezone` separates *display* from *storage*. The user picks 14:00 KST; `onChange` receives the matching UTC instant (`05:00Z`). No off-by-one bugs. See [Timezone](../concepts/timezone.md) and [DateTimePicker](../components/datetimepicker.md).
+
+---
+
+## More
+
+- [DatePicker patterns](../components/datepicker.md#patterns) — form submission, min/max via `disabled`.
+- [React Hook Form](./react-hook-form.md) — controlled integration with validation.
+- [Tailwind](./tailwind.md) / [shadcn](./shadcn.md) — full styling walkthroughs.

--- a/apps/docs-site/docs/troubleshooting.md
+++ b/apps/docs-site/docs/troubleshooting.md
@@ -99,19 +99,43 @@ This can happen if an element calls `event.stopPropagation()` before the click r
 
 ### Selected date is off by one day
 
-This is the most common timezone confusion. When you store a UTC ISO string like `"2026-04-15T00:00:00.000Z"` and display it in a timezone like `Asia/Seoul` (UTC+9), the displayed date is April 15 — but if the value was `"2026-04-15T15:00:00.000Z"`, that's April 16 in Seoul.
+This is the **single most-reported datepicker bug** ([react-datepicker #1018](https://github.com/Hacker0x01/react-datepicker/issues/1018) is a decade-old example). It almost always comes from one of two causes.
 
-**Fix:** Use `displayTimezone` to ensure correct display, and always let `onChange` handle the value — it emits civil midnight in the display timezone:
+**Cause 1 — you passed a native `Date` instead of an ISO string.** A `Date` is interpreted in the *runtime's* local zone, which differs between the user's browser and your server:
+
+```ts
+// ❌ off-by-one waiting to happen
+const picked = new Date(2026, 3, 15); // local midnight → "2026-04-14T15:00:00.000Z" in UTC+9
+save(picked.toISOString());           // server reads April 14
+```
+
+Kalyx never takes a `Date` — its value contract is an ISO-8601 UTC string, so this class of bug is structurally removed. Always read the value from `onChange`:
+
+```tsx
+// ✅ value is already a correct UTC ISO string
+<DatePicker value={value} onChange={setValue}>...</DatePicker>
+```
+
+**Cause 2 — you display a UTC instant in a different civil zone.** `"2026-04-15T00:00:00.000Z"` is April 15 in UTC but still April 15 in Seoul; `"2026-04-15T15:00:00.000Z"` is April 16 in Seoul. If you want the calendar to commit and highlight by *civil* day in a specific zone, set `displayTimezone`:
 
 ```tsx
 <DatePicker
   value={value}
   onChange={setValue}
-  displayTimezone="Asia/Seoul"
+  displayTimezone="Asia/Seoul"   // commit + highlight by Seoul civil day
 >
   ...
 </DatePicker>
+// click "April 15" → onChange emits the UTC instant equal to Seoul April 15 00:00
 ```
+
+**Diagnosis checklist:**
+
+1. Are you ever constructing `new Date(...)` and passing `.toISOString()` into `value`? → stop; let `onChange` own the value.
+2. Is the *stored* string correct but the *displayed* day wrong? → set `displayTimezone` to the zone you want to display in.
+3. Is the *stored* string itself wrong? → check the code that wrote it (often a server default of `00:00` local instead of UTC).
+
+See the [Timezone concept page](./concepts/timezone.md) for the full model.
 
 ### DST transition causes unexpected behavior
 

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -1,4 +1,6 @@
 import {themes as prismThemes} from 'prism-react-renderer';
+import npm2yarn from '@docusaurus/remark-plugin-npm2yarn';
+import llmsTxtPlugin from './src/plugins/llms-txt';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
@@ -56,6 +58,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           routeBasePath: 'docs',
+          remarkPlugins: [[npm2yarn, {sync: true, converters: ['yarn', 'pnpm', 'bun']}]],
           include: [
             'intro.{md,mdx}',
             'migration.{md,mdx}',
@@ -86,6 +89,8 @@ const config: Config = {
       } satisfies Preset.Options,
     ],
   ],
+
+  plugins: [llmsTxtPlugin],
 
   themeConfig: {
     image: 'img/og-hero.png',
@@ -160,6 +165,7 @@ const config: Config = {
             {label: '@kalyx/react on npm', href: 'https://www.npmjs.com/package/@kalyx/react'},
             {label: '@kalyx/core on npm', href: 'https://www.npmjs.com/package/@kalyx/core'},
             {label: 'Changelog', href: 'https://github.com/jiji-hoon96/kalyx/blob/main/packages/react/CHANGELOG.md'},
+            {label: 'llms.txt', href: 'pathname:///llms.txt'},
           ],
         },
       ],

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/accessibility.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/accessibility.md
@@ -8,6 +8,17 @@ sidebar_position: 5
 
 모든 Kalyx 컴포넌트는 WAI-ARIA 역할, 풀 키보드 지원을 갖추고 테스트에서 axe 자동 검사를 통과합니다. 접근성을 *추가*하는 게 아니라 *제거*하려 애써야 사라집니다.
 
+## 표준 & 준수
+
+Kalyx는 관련 [W3C WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/) 패턴을 구현합니다:
+
+- **Date Picker Dialog** — 캘린더 popover([APG 패턴](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/), `role="dialog"` + `role="grid"` 캘린더).
+- **Combobox** — popover를 여는 텍스트 입력([APG 패턴](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)).
+- **Listbox** — TimePicker 시/분 리스트([APG 패턴](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)).
+- **Radio Group** — AM/PM 토글([APG 패턴](https://www.w3.org/WAI/ARIA/apg/patterns/radio/)).
+
+**준수 목표:** 구조·역할·이름·키보드 조작은 **WCAG 2.1 레벨 AA**를 목표로 합니다. Kalyx는 색상을 전혀 제공하지 않으므로 색상 대비 기준(1.4.3, 1.4.11)은 *여러분의* CSS에 달려 있습니다 — 아래 [색상 대비](#색상-대비) 참고.
+
 ## ARIA 역할 한눈에
 
 | 요소 | 역할 / 속성 |
@@ -43,6 +54,23 @@ sidebar_position: 5
 | `↑` / `↓` | 옵션 간 이동 |
 | `Home` / `End` | 첫 / 마지막 옵션 |
 | `Enter` / `Space` | 옵션 선택 |
+
+## 키보드 — MonthGrid / YearGrid
+
+월 점프·연도 점프 그리드(`DatePicker.MonthGrid`, `DatePicker.YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid`)는 하나의 roving-focus 모델을 공유합니다:
+
+| 키 | 동작 |
+| --- | --- |
+| `←` / `→` | 셀 한 칸 이동 |
+| `↑` / `↓` | 한 행(3칸) 이동 |
+| `Home` / `End` | 현재 행의 시작 / 끝 |
+| `PageUp` / `PageDown` | 이전 / 다음 프레임 (월 그리드는 연도, 연도 그리드는 10년) |
+| `Enter` / `Space` | 포커스된 월 / 연도 선택 |
+| `Escape` | popover 닫고 포커스 복원 |
+
+## 키보드 — RangePicker / WeekPicker 캘린더
+
+위 `DatePicker.Calendar`와 동일한 그리드 키를 사용합니다. RangePicker는 첫 `Enter`/클릭이 `start`, 두 번째가 `end`를 설정합니다(역순이면 자동 스왑). WeekPicker는 단일 `Enter`/클릭으로 포커스된 날이 속한 주 전체를 커밋합니다.
 
 ## 키보드 — Trigger / Input
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -149,6 +149,46 @@ export const ja: DatePickerLabels = {
 
 둘은 독립적입니다 — `locale="ko-KR"`과 영어 라벨을 함께 쓸 수도 있고, 그 반대도 가능합니다.
 
+## 오른쪽-왼쪽 (RTL)
+
+Kalyx는 의미론적 HTML을 렌더링하며 자체적으로 레이아웃 방향을 읽지 않으므로 RTL이 "그냥 동작"합니다 — 상위 요소(또는 `<html dir="rtl">`)에 `dir="rtl"`을 주면 캘린더 그리드·입력·popover가 문서와 함께 미러링됩니다. 아랍어 요일/월 이름을 위해 맞는 `locale`(예: `ar-EG`)을 사용하세요.
+
+아래에서 방향을 토글해 같은 picker가 미러링되는 것을 확인하세요:
+
+```jsx live
+function RtlToggle() {
+  const [date, setDate] = React.useState(null);
+  const [dir, setDir] = React.useState('rtl');
+  return (
+    <div>
+      <button
+        className="kx-live-trigger"
+        style={{ marginBottom: 12 }}
+        onClick={() => setDir((d) => (d === 'rtl' ? 'ltr' : 'rtl'))}>
+        dir = {dir} (토글)
+      </button>
+      <div dir={dir}>
+        <DatePicker value={date} onChange={setDate} locale={dir === 'rtl' ? 'ar-EG' : 'en-US'}>
+          <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
+          <DatePicker.Popover className="kx-live-popover">
+            <DatePicker.Calendar
+              classNames={{
+                header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav',
+                grid: 'kx-live-grid', gridCell: 'kx-live-cell', weekdayHeader: 'kx-live-weekday',
+                day: 'live-day', daySelected: 'live-day-selected', dayToday: 'live-day-today',
+                dayOutsideMonth: 'kx-live-outside',
+              }}
+            />
+          </DatePicker.Popover>
+        </DatePicker>
+      </div>
+    </div>
+  );
+}
+```
+
+내비게이션 화살표는 그리드 전체가 `dir`과 함께 미러링되므로 "이전 / 다음"의 시각적 의미를 그대로 유지합니다 — 직접 바꿀 필요가 없습니다. 스크린 리더 안내가 언어와 맞도록 지역화된 `labels`(위 라벨 키 레퍼런스 참고)를 제공하세요.
+
 ## 다음
 
 - [접근성 →](./accessibility.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/styling.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/styling.md
@@ -1,0 +1,99 @@
+---
+id: styling
+title: 스타일링
+sidebar_position: 2
+---
+
+# 스타일링
+
+Kalyx는 **CSS를 전혀 포함하지 않습니다**. 모든 파트는 의미론적이고 스타일이 없는 HTML을 렌더링하며, 두 가지 스타일링 계약을 노출합니다:
+
+1. **`classNames` prop** — 각 서브 컴포넌트에 있는, 슬롯 이름 → 클래스 문자열의 타입드 맵.
+2. **`data-*` 상태 어트리뷰트** — 인터랙티브 요소에 방출되어, 리렌더 없이 CSS / Tailwind로 상태별 스타일을 줄 수 있습니다.
+
+둘 중 하나만 써도 되고, 안정적인 클래스 + 상태 기반 변형을 원하면 함께 쓰세요.
+
+## 1. `classNames` prop
+
+모든 서브 컴포넌트는 내부 슬롯별로 키가 지정된 `classNames` 객체를 받습니다. 필요한 슬롯만 전달하세요.
+
+```tsx
+<DatePicker.Calendar
+  classNames={{
+    grid: 'grid grid-cols-7 gap-1',
+    day: 'rounded p-2 hover:bg-gray-100',
+    daySelected: 'bg-blue-600 text-white',
+    dayToday: 'ring-1 ring-blue-400',
+    dayDisabled: 'opacity-40 cursor-not-allowed',
+    dayOutsideMonth: 'text-gray-300',
+  }}
+/>
+```
+
+슬롯 키는 각 컴포넌트 페이지에 서브 컴포넌트별로 문서화되어 있습니다. 상태 슬롯(`daySelected`, `dayToday` 등)은 해당 상태가 활성일 때 기본 슬롯(`day`)에 **추가로** 적용됩니다 — 즉 선택된 날짜는 `day`와 `daySelected` 클래스를 모두 갖습니다.
+
+## 2. `data-*` 상태 어트리뷰트
+
+Tailwind(`data-[selected]:…`)나 일반 CSS 어트리뷰트 셀렉터를 쓰려면, 모든 상태 요소가 `data-*` 어트리뷰트도 함께 갖습니다. 이 어트리뷰트는 **상태가 활성일 때만 존재**하며(비활성이면 생략 — `data-selected="false"`는 절대 없음), 따라서 `[data-selected]`는 신뢰할 수 있는 셀렉터입니다.
+
+```css
+/* 일반 CSS */
+.day[data-selected] { background: #2563eb; color: white; }
+.day[data-today]    { outline: 1px solid #60a5fa; }
+.day[data-in-range] { background: #dbeafe; }
+```
+
+```tsx
+/* Tailwind v3.1+ data 변형 — classNames 불필요 */
+<DatePicker.Calendar
+  classNames={{
+    day: 'rounded p-2 data-[selected]:bg-blue-600 data-[selected]:text-white data-[today]:ring-1',
+  }}
+/>
+```
+
+### 어트리뷰트 레퍼런스
+
+Kalyx가 방출하는 어트리뷰트 목록입니다. `disabled` 날짜는 네이티브 `disabled` 어트리뷰트 **와** `aria-disabled`를 사용하므로(`data-*` 플래그 아님), `:disabled` 또는 `dayDisabled` 슬롯으로 스타일하세요.
+
+#### 캘린더 날짜 셀
+
+| 어트리뷰트 | 방출 주체 | 활성 조건 |
+| --- | --- | --- |
+| `data-focused` | `DatePicker` / `RangePicker` / `WeekPicker` / `DateTimePicker` `.Calendar` | 날짜가 키보드 포커스를 가짐(roving tabindex). |
+| `data-selected` | `DatePicker` / `DateTimePicker` `.Calendar` | 날짜가 선택된 날짜임. |
+| `data-today` | 모든 `.Calendar` | 날짜가 오늘(설정 시 `displayTimezone` 기준). |
+| `data-outside-month` | 모든 `.Calendar` | 6주 뷰를 채우는 인접 월의 날짜. |
+| `data-range-start` | `RangePicker` / `WeekPicker` `.Calendar` | 범위의 시작일. |
+| `data-range-end` | `RangePicker` / `WeekPicker` `.Calendar` | 범위의 종료일. |
+| `data-in-range` | `RangePicker` / `WeekPicker` `.Calendar` | 시작과 종료 사이(배타적)의 날짜. |
+| `data-week-number` | 모든 `.Calendar`(행 `<th>`에) | 주차 표시가 켜져 있을 때 존재. |
+
+#### 월 / 연도 셀
+
+| 어트리뷰트 | 방출 주체 | 활성 조건 |
+| --- | --- | --- |
+| `data-selected` | `DatePicker.MonthGrid` / `.YearGrid`, `MonthPicker.Grid`, `YearPicker.Grid` | 셀이 선택된 월 / 연도. |
+| `data-current` | 위와 동일 | 셀이 현재 월 / 연도(오늘). |
+| `data-focused` | 위와 동일 | 셀이 키보드 포커스를 가짐. |
+
+#### 시간 셀
+
+| 어트리뷰트 | 방출 주체 | 활성 조건 |
+| --- | --- | --- |
+| `data-selected` | `TimePicker.HourList` / `.MinuteList` / `.AmPmToggle`(및 `DateTimePicker` 대응) | 시 / 분 / 오전·오후가 현재 값. |
+
+#### 프리셋 & 입력
+
+| 어트리뷰트 | 방출 주체 | 활성 조건 |
+| --- | --- | --- |
+| `data-active` | `DatePicker` / `RangePicker` / `DateTimePicker` `.Preset` | 프리셋이 해석한 날짜가 현재 값과 일치. |
+| `data-part` | `RangePicker` / `WeekPicker` `.Input` | 항상 — 값은 `"start"` 또는 `"end"`로, 각 입력을 타겟팅. |
+
+## 무엇을 써야 하나요?
+
+- **정적인 외형** → `classNames` 기본 슬롯(`day`, `grid` 등).
+- **Tailwind에서 상태 변형** → 한 슬롯 클래스 안에 `data-[selected]:` / `data-[today]:` 유틸리티.
+- **일반 CSS / 디자인 토큰** → 스타일시트의 `data-*` 어트리뷰트 셀렉터.
+
+전체 예제는 [Tailwind 레시피](../recipes/tailwind.md)와 [shadcn 레시피](../recipes/shadcn.md)를 참고하세요.

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -19,15 +19,8 @@ Kalyx는 두 개의 패키지로 배포됩니다. 대부분의 앱은 `@kalyx/re
 
 ## 설치 명령
 
-```bash
-# pnpm (권장)
-pnpm add @kalyx/react
-
-# npm
+```bash npm2yarn
 npm install @kalyx/react
-
-# yarn
-yarn add @kalyx/react
 ```
 
 `@kalyx/react`는 다음에 의존합니다.

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/quick-start.mdx
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/getting-started/quick-start.mdx
@@ -10,8 +10,8 @@ sidebar_position: 2
 
 ## 1. 설치
 
-```bash
-pnpm add @kalyx/react
+```bash npm2yarn
+npm install @kalyx/react
 ```
 
 ## 2. 제어형 DatePicker

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/guides/adapters.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/guides/adapters.md
@@ -16,8 +16,8 @@ because Kalyx is here.
 
 ## Default (date-fns)
 
-```bash
-pnpm add @kalyx/react
+```bash npm2yarn
+npm install @kalyx/react
 ```
 
 ```tsx

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-date-time-picker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-date-time-picker.md
@@ -1,0 +1,100 @@
+---
+id: use-date-time-picker
+title: useDateTimePicker
+sidebar_position: 7
+---
+
+# useDateTimePicker
+
+`<DateTimePicker>` 뒤의 헤드리스 훅. 하나의 ISO 문자열이 캘린더와 시각을 모두 구동합니다 — `selectDate` 는 시각을 보존하고 `setTime` 은 날짜를 보존합니다.
+
+:::info `/headless` 엔트리
+**`@kalyx/react/headless`**(어댑터 비의존)에서 export됩니다. [날짜 어댑터 & `/headless` 엔트리](../guides/adapters.md) 참고.
+:::
+
+```tsx
+import { useDateTimePicker } from '@kalyx/react/headless';
+```
+
+## 시그니처
+
+```ts
+function useDateTimePicker(options?: UseDateTimePickerOptions): UseDateTimePickerReturn;
+```
+
+### 옵션
+
+| 필드 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `value` | `ISODateString \| null` | — | controlled datetime (날짜 + 시간, UTC). |
+| `defaultValue` | `ISODateString` | — | uncontrolled 초기 datetime. |
+| `onChange` | `(value: ISODateString \| null) => void` | — | datetime이 바뀔 때 호출. |
+| `disabled` | `DisabledRule[]` | `[]` | 비활성 규칙 (날짜에 적용). |
+| `weekStartsOn` | `0 \| 1` | `0` | 주 시작 요일. |
+| `adapter` | `DateAdapter` | — | 날짜 어댑터 (`/headless`에서 필수). |
+| `displayTimezone` | `string` | — | IANA 존. `currentTime` 이 이 존으로 보고됨. [타임존](../concepts/timezone.md) 참고. |
+
+### 반환
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `value` | `ISODateString \| null` | 현재 datetime. |
+| `isOpen` | `boolean` | popover 상태. |
+| `open` / `close` / `toggle` | `() => void` | popover 제어. |
+| `selectDate` | `(iso: ISODateString \| null) => void` | 시각을 보존하며 날짜 설정(popover를 **닫지 않음**). |
+| `setTime` | `(partial: Partial<TimeValue>) => void` | 날짜를 보존하며 시각 변경. |
+| `currentTime` | `TimeValue` | 값의 시각 부분(설정 시 `displayTimezone` 기준). |
+| `viewMonth` | `ISODateString` | 표시 중인 달의 1일. |
+| `setViewMonth` | `(iso: ISODateString) => void` | 특정 달로 점프. |
+| `calendar` | `CalendarGrid` | 6×7 `CalendarDay` 그리드. |
+| `focusedDate` | `ISODateString` | 키보드 포커스된 날. |
+| `setFocusedDate` | `(iso: ISODateString) => void` | 포커스 이동. |
+| `previousMonth` / `nextMonth` | `() => void` | 달 내비게이션 단축. |
+| `pickerId` | `string` | ARIA 연결용 안정 ID. |
+| `adapter` | `DateAdapter` | 해석된 어댑터. |
+
+### `TimeValue`
+
+```ts
+type TimeValue = {
+  hours: number;   // 0–23
+  minutes: number; // 0–59
+  seconds: number; // 0–59
+};
+```
+
+## 예제
+
+```tsx
+import { useDateTimePicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniDateTime() {
+  const { value, currentTime, calendar, selectDate, setTime } =
+    useDateTimePicker({ adapter: DateFnsAdapter, displayTimezone: 'Asia/Seoul' });
+
+  return (
+    <div>
+      <div className="grid grid-cols-7">
+        {calendar.flat().map((day) => (
+          <button key={day.isoString} onClick={() => selectDate(day.isoString)}>
+            {day.dayNumber}
+          </button>
+        ))}
+      </div>
+      <input
+        type="number"
+        value={currentTime.hours}
+        onChange={(e) => setTime({ hours: Number(e.target.value) })}
+      />
+      <code>{value ?? 'null'}</code>
+    </div>
+  );
+}
+```
+
+## 관련
+
+- [DateTimePicker 컴포넌트 →](../components/datetimepicker.md)
+- [useDatePicker →](./use-date-picker.md) / [useTimePicker →](./use-time-picker.md)
+- [날짜 어댑터 →](../guides/adapters.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-month-picker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-month-picker.md
@@ -1,0 +1,101 @@
+---
+id: use-month-picker
+title: useMonthPicker
+sidebar_position: 4
+---
+
+# useMonthPicker
+
+`<MonthPicker>` 뒤의 헤드리스 훅. 12개월 그리드와 내비게이션을 노출합니다 — DOM 렌더링과 포커스/키보드 연결은 여러분의 몫입니다.
+
+:::info `/headless` 엔트리
+Month / Year / Week / DateTime 훅은 어댑터 비의존(date-fns 미번들)인 **`@kalyx/react/headless`** 엔트리에서 export됩니다. [날짜 어댑터 & `/headless` 엔트리](../guides/adapters.md) 참고.
+:::
+
+```tsx
+import { useMonthPicker } from '@kalyx/react/headless';
+```
+
+## 시그니처
+
+```ts
+function useMonthPicker(options?: UseMonthPickerOptions): UseMonthPickerReturn;
+```
+
+### 옵션
+
+| 필드 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `value` | `ISODateString \| null` | — | controlled 월 (월 시작 ISO로 저장). |
+| `defaultValue` | `ISODateString` | — | uncontrolled 초기 월. |
+| `onChange` | `(value: ISODateString \| null) => void` | — | 월이 바뀔 때 호출. |
+| `disabled` | `DisabledRule[]` | `[]` | 월은 완전히 배제될 때만 비활성. |
+| `adapter` | `DateAdapter` | — | 날짜 어댑터 (`/headless`에서 필수). |
+| `displayTimezone` | `string` | — | civil-day 비교용 IANA 존. [타임존](../concepts/timezone.md) 참고. |
+| `locale` | `string` | `'en-US'` | 월 이름용 BCP 47 locale. |
+
+### 반환
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `value` | `ISODateString \| null` | 현재 선택된 월. |
+| `isOpen` | `boolean` | popover 상태. |
+| `open` / `close` / `toggle` | `() => void` | popover 제어. |
+| `selectMonth` | `(iso: ISODateString) => void` | 월 커밋 (셀의 `isoString` 전달). |
+| `viewYear` | `number` | 그리드에 표시 중인 연도. |
+| `previousYear` / `nextYear` | `() => void` | 그리드를 1년 이동. |
+| `months` | `MonthCell[]` | `viewYear`의 12개월 셀. |
+| `pickerId` | `string` | ARIA 연결용 `useId` 기반 안정 ID. |
+| `adapter` | `DateAdapter` | 해석된 어댑터. |
+
+### `MonthCell`
+
+```ts
+type MonthCell = {
+  isoString: ISODateString; // 월 시작 ISO (UTC)
+  monthIndex: number;       // 0 = 1월
+  label: string;            // 지역화된 월 이름
+  isSelected: boolean;
+  isCurrent: boolean;       // 현재 월 (오늘)
+  isDisabled: boolean;
+};
+```
+
+## 예제
+
+```tsx
+import { useMonthPicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniMonthGrid() {
+  const { months, viewYear, previousYear, nextYear, selectMonth } =
+    useMonthPicker({ adapter: DateFnsAdapter, onChange: (v) => console.log(v) });
+
+  return (
+    <div>
+      <header>
+        <button onClick={previousYear} aria-label="Previous year">◀</button>
+        <span>{viewYear}</span>
+        <button onClick={nextYear} aria-label="Next year">▶</button>
+      </header>
+      <div className="grid grid-cols-3">
+        {months.map((m) => (
+          <button
+            key={m.isoString}
+            aria-selected={m.isSelected}
+            disabled={m.isDisabled}
+            onClick={() => selectMonth(m.isoString)}>
+            {m.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## 관련
+
+- [MonthPicker 컴포넌트 →](../components/monthpicker.md)
+- [useYearPicker →](./use-year-picker.md)
+- [날짜 어댑터 →](../guides/adapters.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-week-picker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-week-picker.md
@@ -1,0 +1,91 @@
+---
+id: use-week-picker
+title: useWeekPicker
+sidebar_position: 6
+---
+
+# useWeekPicker
+
+`<WeekPicker>` 뒤의 헤드리스 훅. 단일 `selectWeek` 가 클릭된 날이 속한 주 전체를 커밋하고, 그리드는 선택된 주를 범위로 강조합니다.
+
+:::info `/headless` 엔트리
+**`@kalyx/react/headless`**(어댑터 비의존)에서 export됩니다. [날짜 어댑터 & `/headless` 엔트리](../guides/adapters.md) 참고.
+:::
+
+```tsx
+import { useWeekPicker } from '@kalyx/react/headless';
+```
+
+## 시그니처
+
+```ts
+function useWeekPicker(options?: UseWeekPickerOptions): UseWeekPickerReturn;
+```
+
+### 옵션
+
+| 필드 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `value` | `DateRange` | — | controlled 주, `{ start, end }` 범위. |
+| `defaultValue` | `DateRange` | — | uncontrolled 초기 주. |
+| `onChange` | `(week: DateRange) => void` | — | 선택된 주가 바뀔 때 호출. |
+| `disabled` | `DisabledRule[]` | `[]` | 비활성 규칙. |
+| `weekStartsOn` | `0 \| 1` | `0` | 주 시작 요일. |
+| `adapter` | `DateAdapter` | — | 날짜 어댑터 (`/headless`에서 필수). |
+| `displayTimezone` | `string` | — | civil-day 비교용 IANA 존. |
+
+### 반환
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `value` | `DateRange` | 선택된 주 `{ start, end }`. |
+| `isOpen` | `boolean` | popover 상태. |
+| `open` / `close` / `toggle` | `() => void` | popover 제어. |
+| `selectWeek` | `(iso: ISODateString) => void` | 클릭된 날이 속한 주 전체 커밋. |
+| `viewMonth` | `ISODateString` | 표시 중인 달의 1일. |
+| `setViewMonth` | `(iso: ISODateString) => void` | 특정 달로 점프. |
+| `calendar` | `CalendarGrid` | 선택된 주를 범위로 강조한 6×7 그리드. |
+| `previousMonth` / `nextMonth` | `() => void` | 달 내비게이션 단축. |
+| `pickerId` | `string` | ARIA 연결용 안정 ID. |
+| `adapter` | `DateAdapter` | 해석된 어댑터. |
+
+`calendar` 의 각 `CalendarDay` 는 커밋된 주를 반영하는 `isRangeStart` / `isRangeEnd` / `isInRange` 를 가집니다([useDatePicker → CalendarDay](./use-date-picker.md#calendarday) 참고).
+
+## 예제
+
+```tsx
+import { useWeekPicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniWeekGrid() {
+  const { calendar, viewMonth, previousMonth, nextMonth, selectWeek } =
+    useWeekPicker({ adapter: DateFnsAdapter, weekStartsOn: 1 });
+
+  return (
+    <div>
+      <header>
+        <button onClick={previousMonth} aria-label="Previous">◀</button>
+        <span>{viewMonth.slice(0, 7)}</span>
+        <button onClick={nextMonth} aria-label="Next">▶</button>
+      </header>
+      <div className="grid grid-cols-7">
+        {calendar.flat().map((day) => (
+          <button
+            key={day.isoString}
+            disabled={day.isDisabled}
+            onClick={() => selectWeek(day.isoString)}
+            className={day.isInRange || day.isRangeStart || day.isRangeEnd ? 'bg-indigo-100' : ''}>
+            {day.dayNumber}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## 관련
+
+- [WeekPicker 컴포넌트 →](../components/weekpicker.md)
+- [useRangePicker →](./use-range-picker.md)
+- [날짜 어댑터 →](../guides/adapters.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-year-picker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/hooks/use-year-picker.md
@@ -1,0 +1,99 @@
+---
+id: use-year-picker
+title: useYearPicker
+sidebar_position: 5
+---
+
+# useYearPicker
+
+`<YearPicker>` 뒤의 헤드리스 훅. 12년 단위 10년 블록과 내비게이션을 노출합니다.
+
+:::info `/headless` 엔트리
+**`@kalyx/react/headless`**(어댑터 비의존)에서 export됩니다. [날짜 어댑터 & `/headless` 엔트리](../guides/adapters.md) 참고.
+:::
+
+```tsx
+import { useYearPicker } from '@kalyx/react/headless';
+```
+
+## 시그니처
+
+```ts
+function useYearPicker(options?: UseYearPickerOptions): UseYearPickerReturn;
+```
+
+### 옵션
+
+| 필드 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `value` | `ISODateString \| null` | — | controlled 연도 (1월 1일 ISO로 저장). |
+| `defaultValue` | `ISODateString` | — | uncontrolled 초기 연도. |
+| `onChange` | `(value: ISODateString \| null) => void` | — | 연도가 바뀔 때 호출. |
+| `disabled` | `DisabledRule[]` | `[]` | 연도는 완전히 배제될 때만 비활성. |
+| `adapter` | `DateAdapter` | — | 날짜 어댑터 (`/headless`에서 필수). |
+| `displayTimezone` | `string` | — | civil-day 비교용 IANA 존. |
+
+### 반환
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `value` | `ISODateString \| null` | 현재 선택된 연도. |
+| `isOpen` | `boolean` | popover 상태. |
+| `open` / `close` / `toggle` | `() => void` | popover 제어. |
+| `selectYear` | `(iso: ISODateString) => void` | 연도 커밋 (셀의 `isoString` 전달). |
+| `decadeStart` | `number` | 표시 중인 12년 블록의 첫 해. |
+| `previousDecade` / `nextDecade` | `() => void` | 그리드를 한 10년 블록 이동. |
+| `years` | `YearCell[]` | 현재 블록의 12년 셀. |
+| `pickerId` | `string` | ARIA 연결용 안정 ID. |
+| `adapter` | `DateAdapter` | 해석된 어댑터. |
+
+### `YearCell`
+
+```ts
+type YearCell = {
+  isoString: ISODateString; // 1월 1일, UTC 자정
+  year: number;
+  isSelected: boolean;
+  isCurrent: boolean;       // 현재 연도 (오늘)
+  isDisabled: boolean;
+};
+```
+
+## 예제
+
+```tsx
+import { useYearPicker } from '@kalyx/react/headless';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+
+export function MiniYearGrid() {
+  const { years, decadeStart, previousDecade, nextDecade, selectYear } =
+    useYearPicker({ adapter: DateFnsAdapter });
+
+  return (
+    <div>
+      <header>
+        <button onClick={previousDecade} aria-label="Previous decade">◀</button>
+        <span>{decadeStart}–{decadeStart + 11}</span>
+        <button onClick={nextDecade} aria-label="Next decade">▶</button>
+      </header>
+      <div className="grid grid-cols-3">
+        {years.map((y) => (
+          <button
+            key={y.isoString}
+            aria-selected={y.isSelected}
+            disabled={y.isDisabled}
+            onClick={() => selectYear(y.isoString)}>
+            {y.year}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## 관련
+
+- [YearPicker 컴포넌트 →](../components/yearpicker.md)
+- [useMonthPicker →](./use-month-picker.md)
+- [날짜 어댑터 →](../guides/adapters.md)

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/recipes/testing.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/recipes/testing.md
@@ -12,8 +12,8 @@ How to test Kalyx components in your application using Vitest (or Jest) + Testin
 
 Install the testing dependencies:
 
-```bash
-pnpm add -D vitest @testing-library/react @testing-library/user-event @testing-library/jest-dom jest-axe jsdom
+```bash npm2yarn
+npm install -D vitest @testing-library/react @testing-library/user-event @testing-library/jest-dom jest-axe jsdom
 ```
 
 Configure Vitest with jsdom:

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/recipes/use-cases.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/recipes/use-cases.md
@@ -1,0 +1,239 @@
+---
+id: use-cases
+title: 유스케이스 레시피
+sidebar_position: 0
+---
+
+# 유스케이스 레시피
+
+실제로 자주 마주치는 날짜 선택 문제에 대한 복붙 가능한 해법입니다. 각 레시피는 완성된 동작 컴포넌트입니다 — 라이브로 시험해 본 뒤 아래 소스를 복사하세요.
+
+간결함을 위해 Tailwind 스타일 클래스를 쓰지만, 중요한 건 **조합(composition)** 과 **props** 입니다. 클래스는 여러분 것으로 바꾸거나 [`classNames` 스타일링 계약](../concepts/styling.md)을 사용하세요.
+
+---
+
+## 생년월일
+
+생일 선택기는 수십 년을 빠르게 건너뛸 수 있어야 합니다 — "이전 달"을 300번 누르고 싶은 사람은 없습니다. `Calendar → MonthGrid → YearGrid` 를 연결해 타이틀을 드릴업 컨트롤로 만들고, 미래 날짜를 비활성화하세요.
+
+```jsx live
+function DateOfBirth() {
+  const [dob, setDob] = React.useState(null);
+  const [view, setView] = React.useState('days');
+  const today = new Date().toISOString();
+  const headerCls = { header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav' };
+  return (
+    <DatePicker
+      value={dob}
+      onChange={(v) => { setDob(v); setView('days'); }}
+      disabled={[{ after: today }]}
+    >
+      <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
+      <DatePicker.Popover className="kx-live-popover">
+        {view === 'days' && (
+          <DatePicker.Calendar
+            onTitleClick={() => setView('months')}
+            classNames={{
+              ...headerCls, grid: 'kx-live-grid', gridCell: 'kx-live-cell',
+              weekdayHeader: 'kx-live-weekday', day: 'live-day',
+              daySelected: 'live-day-selected', dayToday: 'live-day-today',
+              dayDisabled: 'kx-live-disabled', dayOutsideMonth: 'kx-live-outside',
+            }}
+          />
+        )}
+        {view === 'months' && (
+          <DatePicker.MonthGrid
+            onSelect={() => setView('days')}
+            onTitleClick={() => setView('years')}
+            classNames={{ ...headerCls, grid: 'kx-live-month-grid', month: 'kx-live-my-cell', monthSelected: 'kx-live-my-selected', monthCurrent: 'kx-live-my-current' }}
+          />
+        )}
+        {view === 'years' && (
+          <DatePicker.YearGrid
+            onSelect={() => setView('months')}
+            classNames={{ ...headerCls, grid: 'kx-live-year-grid', year: 'kx-live-my-cell', yearSelected: 'kx-live-my-selected', yearCurrent: 'kx-live-my-current' }}
+          />
+        )}
+      </DatePicker.Popover>
+      <div className="kx-live-value">생년월일: <code>{dob?.slice(0, 10) ?? 'null'}</code> — 타이틀을 눌러 월 / 연도로 점프하세요.</div>
+    </DatePicker>
+  );
+}
+```
+
+```tsx title="DateOfBirth.tsx"
+import { useState } from 'react';
+import { DatePicker, type ISODateString } from '@kalyx/react';
+
+export function DateOfBirth() {
+  const [dob, setDob] = useState<ISODateString | null>(null);
+  const [view, setView] = useState<'days' | 'months' | 'years'>('days');
+  const today = new Date().toISOString();
+
+  return (
+    <DatePicker
+      value={dob}
+      onChange={(v) => { setDob(v); setView('days'); }}
+      disabled={[{ after: today }]} // 미래 생일 금지
+    >
+      <DatePicker.Input placeholder="YYYY-MM-DD" />
+      <DatePicker.Popover>
+        {view === 'days' && (
+          <DatePicker.Calendar onTitleClick={() => setView('months')} />
+        )}
+        {view === 'months' && (
+          <DatePicker.MonthGrid
+            onSelect={() => setView('days')}
+            onTitleClick={() => setView('years')}
+          />
+        )}
+        {view === 'years' && (
+          <DatePicker.YearGrid onSelect={() => setView('months')} />
+        )}
+      </DatePicker.Popover>
+    </DatePicker>
+  );
+}
+```
+
+**동작 원리:** 타이틀이 드릴업 컨트롤(`onTitleClick`)이 되고, 각 그리드의 `onSelect`가 다시 아래로 내려갑니다. `disabled={[{ after: today }]}` 는 `maxDate` prop 없이 미래 날짜를 막습니다. [DatePicker](../components/datepicker.md) 의 월 / 연도 내비게이션 섹션 참고.
+
+---
+
+## 프리셋이 있는 예약 범위
+
+예약 플로우는 시작/종료 범위 *와* 원탭 공통 범위를 원합니다. `RangePicker.Presets` 를 범위 캘린더와 조합하세요. 프리셋은 커밋 후 닫힙니다.
+
+```jsx live
+function BookingRange() {
+  const [range, setRange] = React.useState({ start: null, end: null });
+  const iso = (d) => { const x = new Date(); x.setUTCHours(0,0,0,0); x.setUTCDate(x.getUTCDate() + d); return x.toISOString(); };
+  return (
+    <RangePicker value={range} onChange={setRange}>
+      <div className="kx-live-row">
+        <RangePicker.Input part="start" className="kx-live-input" placeholder="체크인" />
+        <span aria-hidden>→</span>
+        <RangePicker.Input part="end" className="kx-live-input" placeholder="체크아웃" />
+      </div>
+      <RangePicker.Popover className="kx-live-popover">
+        <RangePicker.Presets className="kx-live-presets">
+          <RangePicker.Preset className="kx-live-preset" range={{ start: iso(0), end: iso(2) }}>주말</RangePicker.Preset>
+          <RangePicker.Preset className="kx-live-preset" range={{ start: iso(0), end: iso(6) }}>1주</RangePicker.Preset>
+          <RangePicker.Preset className="kx-live-preset" range={{ start: iso(0), end: iso(13) }}>2주</RangePicker.Preset>
+        </RangePicker.Presets>
+        <RangePicker.Calendar
+          classNames={{
+            header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav',
+            grid: 'kx-live-grid', gridCell: 'kx-live-cell', weekdayHeader: 'kx-live-weekday',
+            day: 'kx-live-day-range', dayRangeStart: 'kx-live-range-start',
+            dayRangeEnd: 'kx-live-range-end', dayInRange: 'kx-live-inrange',
+            dayToday: 'live-day-today', dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+      </RangePicker.Popover>
+      <div className="kx-live-value">
+        <code>{range.start?.slice(0, 10) ?? 'null'}</code> → <code>{range.end?.slice(0, 10) ?? 'null'}</code>
+      </div>
+    </RangePicker>
+  );
+}
+```
+
+```tsx title="BookingRange.tsx"
+import { useState } from 'react';
+import { RangePicker, type DateRange } from '@kalyx/react';
+
+const day = (offset: number) => {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString();
+};
+
+export function BookingRange() {
+  const [range, setRange] = useState<DateRange>({ start: null, end: null });
+  return (
+    <RangePicker value={range} onChange={setRange}>
+      <RangePicker.Input part="start" placeholder="체크인" />
+      <RangePicker.Input part="end" placeholder="체크아웃" />
+      <RangePicker.Popover>
+        <RangePicker.Presets>
+          <RangePicker.Preset range={{ start: day(0), end: day(2) }}>주말</RangePicker.Preset>
+          <RangePicker.Preset range={{ start: day(0), end: day(6) }}>1주</RangePicker.Preset>
+          <RangePicker.Preset range={{ start: day(0), end: day(13) }}>2주</RangePicker.Preset>
+        </RangePicker.Presets>
+        <RangePicker.Calendar />
+      </RangePicker.Popover>
+    </RangePicker>
+  );
+}
+```
+
+**동작 원리:** 각 `RangePicker.Preset` 은 ISO-UTC 문자열의 `range={{ start, end }}` 를 받아 양 끝을 커밋하고 popover를 닫습니다. 활성 프리셋은 `data-active` 를 받아 현재 선택을 강조할 수 있습니다. [RangePicker → Presets](../components/rangepicker.md) 참고.
+
+---
+
+## 고정 타임존의 DateTime
+
+스케줄링 UI는 명확한 순간(instant)을 저장하면서도 특정 현지 시각을 *보여줘야* 합니다. `displayTimezone` 을 설정하면 Input과 Calendar는 그 존으로 렌더링되지만 `onChange` 는 여전히 UTC 순간을 방출합니다.
+
+```jsx live
+function MeetingTime() {
+  const [dt, setDt] = React.useState(null);
+  return (
+    <DateTimePicker value={dt} onChange={setDt} format="24h" step={30} displayTimezone="Asia/Seoul">
+      <DateTimePicker.Input className="kx-live-input" placeholder="회의 시간 선택 (KST)" />
+      <DateTimePicker.Popover className="kx-live-popover kx-live-popover--split">
+        <DateTimePicker.Calendar
+          classNames={{
+            header: 'kx-live-header', title: 'kx-live-title', navButton: 'kx-live-nav',
+            grid: 'kx-live-grid', gridCell: 'kx-live-cell', weekdayHeader: 'kx-live-weekday',
+            day: 'live-day', daySelected: 'live-day-selected', dayToday: 'live-day-today',
+            dayOutsideMonth: 'kx-live-outside',
+          }}
+        />
+        <div className="kx-live-stack">
+          <DateTimePicker.HourList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+          <DateTimePicker.MinuteList classNames={{ root: 'kx-live-list', option: 'kx-live-option', optionSelected: 'kx-live-option-selected' }} />
+        </div>
+      </DateTimePicker.Popover>
+      <div className="kx-live-value">저장된 UTC: <code>{dt ?? 'null'}</code></div>
+    </DateTimePicker>
+  );
+}
+```
+
+```tsx title="MeetingTime.tsx"
+import { useState } from 'react';
+import { DateTimePicker, type ISODateString } from '@kalyx/react';
+
+export function MeetingTime() {
+  const [dt, setDt] = useState<ISODateString | null>(null);
+  return (
+    <DateTimePicker
+      value={dt}
+      onChange={setDt}      // 항상 UTC ISO 문자열
+      format="24h"
+      step={30}
+      displayTimezone="Asia/Seoul" // KST로 표시, UTC로 저장
+    >
+      <DateTimePicker.Input placeholder="회의 시간 선택 (KST)" />
+      <DateTimePicker.Popover>
+        <DateTimePicker.Calendar />
+        <DateTimePicker.HourList />
+        <DateTimePicker.MinuteList />
+      </DateTimePicker.Popover>
+    </DateTimePicker>
+  );
+}
+```
+
+**동작 원리:** `displayTimezone` 은 *표시* 와 *저장* 을 분리합니다. 사용자가 14:00 KST를 고르면 `onChange` 는 대응하는 UTC 순간(`05:00Z`)을 받습니다. off-by-one 버그가 없습니다. [타임존](../concepts/timezone.md) 과 [DateTimePicker](../components/datetimepicker.md) 참고.
+
+---
+
+## 더 보기
+
+- [DatePicker 패턴](../components/datepicker.md) — 폼 제출, `disabled` 를 통한 min/max.
+- [React Hook Form](./react-hook-form.md) — 검증과 함께 controlled 통합.
+- [Tailwind](./tailwind.md) / [shadcn](./shadcn.md) — 전체 스타일링 가이드.

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
@@ -97,25 +97,49 @@ This can happen if an element calls `event.stopPropagation()` before the click r
 
 ## Timezone
 
-### Selected date is off by one day
+### 선택한 날짜가 하루 어긋나요
 
-This is the most common timezone confusion. When you store a UTC ISO string like `"2026-04-15T00:00:00.000Z"` and display it in a timezone like `Asia/Seoul` (UTC+9), the displayed date is April 15 — but if the value was `"2026-04-15T15:00:00.000Z"`, that's April 16 in Seoul.
+이것은 **가장 많이 보고되는 datepicker 버그**입니다([react-datepicker #1018](https://github.com/Hacker0x01/react-datepicker/issues/1018)이 10년 된 사례). 거의 항상 두 가지 원인 중 하나입니다.
 
-**Fix:** Use `displayTimezone` to ensure correct display, and always let `onChange` handle the value — it emits civil midnight in the display timezone:
+**원인 1 — ISO 문자열 대신 네이티브 `Date`를 전달함.** `Date`는 *런타임의* 로컬 존으로 해석되며, 사용자 브라우저와 서버에서 다릅니다:
+
+```ts
+// ❌ off-by-one이 기다리고 있음
+const picked = new Date(2026, 3, 15); // 로컬 자정 → UTC+9에서 "2026-04-14T15:00:00.000Z"
+save(picked.toISOString());           // 서버는 4월 14일로 읽음
+```
+
+Kalyx는 `Date`를 받지 않습니다 — 값 계약이 ISO-8601 UTC 문자열이라 이 부류의 버그가 구조적으로 제거됩니다. 항상 `onChange`에서 값을 읽으세요:
+
+```tsx
+// ✅ value는 이미 올바른 UTC ISO 문자열
+<DatePicker value={value} onChange={setValue}>...</DatePicker>
+```
+
+**원인 2 — UTC 순간을 다른 civil 존에서 표시함.** `"2026-04-15T00:00:00.000Z"`는 UTC에서 4월 15일이고 서울에서도 4월 15일이지만, `"2026-04-15T15:00:00.000Z"`는 서울에서 4월 16일입니다. 캘린더가 특정 존의 *civil* 일자 기준으로 커밋·강조하길 원하면 `displayTimezone`을 설정하세요:
 
 ```tsx
 <DatePicker
   value={value}
   onChange={setValue}
-  displayTimezone="Asia/Seoul"
+  displayTimezone="Asia/Seoul"   // 서울 civil 일자 기준으로 커밋 + 강조
 >
   ...
 </DatePicker>
+// "4월 15일" 클릭 → onChange는 서울 4월 15일 00:00과 같은 UTC 순간을 방출
 ```
 
-### DST transition causes unexpected behavior
+**진단 체크리스트:**
 
-During DST transitions (e.g., US "spring forward"), 2:00 AM doesn't exist. Kalyx handles this internally with two-pass offset correction. If you're doing manual timezone math, use `@kalyx/core`'s `startOfDayInTimezone` instead of computing midnight yourself.
+1. `new Date(...)`를 만들어 `.toISOString()`을 `value`에 넣고 있나요? → 멈추고 `onChange`가 값을 소유하게 하세요.
+2. *저장된* 문자열은 맞는데 *표시된* 일자가 틀린가요? → 표시하려는 존으로 `displayTimezone`을 설정하세요.
+3. *저장된* 문자열 자체가 틀린가요? → 그것을 쓴 코드를 확인하세요(흔히 서버가 UTC 대신 로컬 `00:00`을 기본값으로 사용).
+
+전체 모델은 [타임존 개념 페이지](./concepts/timezone.md)를 참고하세요.
+
+### DST 전환 시 예기치 않은 동작
+
+DST 전환(예: 미국 "spring forward") 동안 새벽 2:00는 존재하지 않습니다. Kalyx는 two-pass 오프셋 보정으로 내부 처리합니다. 수동 타임존 계산을 한다면 자정을 직접 계산하지 말고 `@kalyx/core`의 `startOfDayInTimezone`을 쓰세요.
 
 ---
 

--- a/apps/docs-site/package.json
+++ b/apps/docs-site/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/remark-plugin-npm2yarn": "3.10.1",
     "@docusaurus/tsconfig": "3.10.1",
     "@docusaurus/types": "3.10.1",
     "@types/react": "^19.0.0",

--- a/apps/docs-site/sidebars.ts
+++ b/apps/docs-site/sidebars.ts
@@ -17,6 +17,7 @@ const sidebars: SidebarsConfig = {
       label: 'Concepts',
       items: [
         'concepts/composition',
+        'concepts/styling',
         'concepts/iso-string',
         'concepts/timezone',
         'concepts/ssr',
@@ -52,12 +53,17 @@ const sidebars: SidebarsConfig = {
         'hooks/use-date-picker',
         'hooks/use-range-picker',
         'hooks/use-time-picker',
+        'hooks/use-month-picker',
+        'hooks/use-year-picker',
+        'hooks/use-week-picker',
+        'hooks/use-date-time-picker',
       ],
     },
     {
       type: 'category',
       label: 'Recipes',
       items: [
+        'recipes/use-cases',
         'recipes/tailwind',
         'recipes/shadcn',
         'recipes/react-hook-form',

--- a/apps/docs-site/src/components/StackBlitzEmbed/StackBlitzEmbed.module.css
+++ b/apps/docs-site/src/components/StackBlitzEmbed/StackBlitzEmbed.module.css
@@ -11,8 +11,13 @@
   border-radius: 8px;
 }
 
+.links {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
 .openLink {
-  align-self: flex-end;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--ifm-color-primary);

--- a/apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx
+++ b/apps/docs-site/src/components/StackBlitzEmbed/__tests__/StackBlitzEmbed.test.tsx
@@ -24,6 +24,24 @@ describe('<StackBlitzEmbed>', () => {
     expect(link.getAttribute('rel')).toContain('noopener');
   });
 
+  it('renders a "View source" link to the example file on GitHub', () => {
+    render(<StackBlitzEmbed id="datepicker-basic" />);
+    const link = screen.getByRole('link', { name: /view source/i });
+    expect(link.getAttribute('href')).toBe(
+      'https://github.com/jiji-hoon96/kalyx/blob/main/examples/datepicker-basic/src/App.tsx'
+    );
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toContain('noopener');
+  });
+
+  it('points View source at a custom file when provided', () => {
+    render(<StackBlitzEmbed id="datepicker-tailwind" file="src/index.css" />);
+    const link = screen.getByRole('link', { name: /view source/i });
+    expect(link.getAttribute('href')).toBe(
+      'https://github.com/jiji-hoon96/kalyx/blob/main/examples/datepicker-tailwind/src/index.css'
+    );
+  });
+
   it('passes axe', async () => {
     const { container } = render(<StackBlitzEmbed id="datepicker-basic" />);
     // iframes cannot be accessed in jsdom; skip iframe rules to avoid internal axe errors.

--- a/apps/docs-site/src/components/StackBlitzEmbed/index.tsx
+++ b/apps/docs-site/src/components/StackBlitzEmbed/index.tsx
@@ -12,6 +12,7 @@ export type StackBlitzEmbedProps = {
 };
 
 const REPO_PATH = 'jiji-hoon96/kalyx/tree/main/examples';
+const SOURCE_PATH = 'jiji-hoon96/kalyx/blob/main/examples';
 
 export default function StackBlitzEmbed({
   id,
@@ -21,6 +22,7 @@ export default function StackBlitzEmbed({
 }: StackBlitzEmbedProps) {
   const embedSrc = `https://stackblitz.com/github/${REPO_PATH}/${id}?embed=1&file=${file}&hideExplorer=1&theme=${theme}`;
   const fullHref = `https://stackblitz.com/github/${REPO_PATH}/${id}`;
+  const sourceHref = `https://github.com/${SOURCE_PATH}/${id}/${file}`;
 
   return (
     <div className={styles.wrapper}>
@@ -31,13 +33,22 @@ export default function StackBlitzEmbed({
         loading="lazy"
         height={height}
       />
-      <a
-        className={styles.openLink}
-        href={fullHref}
-        target="_blank"
-        rel="noopener noreferrer">
-        Open in StackBlitz ↗
-      </a>
+      <div className={styles.links}>
+        <a
+          className={styles.openLink}
+          href={sourceHref}
+          target="_blank"
+          rel="noopener noreferrer">
+          View source ↗
+        </a>
+        <a
+          className={styles.openLink}
+          href={fullHref}
+          target="_blank"
+          rel="noopener noreferrer">
+          Open in StackBlitz ↗
+        </a>
+      </div>
     </div>
   );
 }

--- a/apps/docs-site/src/plugins/llms-txt.ts
+++ b/apps/docs-site/src/plugins/llms-txt.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type {LoadContext, Plugin} from '@docusaurus/types';
+
+/**
+ * Emits LLM-friendly artifacts after the build:
+ *   - `/<route>.md`  — the raw Markdown source of every English doc page
+ *   - `/llms.txt`    — an index (per the llmstxt.org convention) linking to them
+ *
+ * Pure DX / agent affordance — no marketing surface. English docs only
+ * (the canonical source); the `/ko` locale is a translation layer.
+ */
+export default function llmsTxtPlugin(context: LoadContext): Plugin {
+  const {siteConfig} = context;
+  const siteUrl = siteConfig.url + siteConfig.baseUrl.replace(/\/$/, '');
+  const docsDir = path.join(context.siteDir, 'docs');
+
+  return {
+    name: 'kalyx-llms-txt',
+
+    async postBuild({outDir, routesPaths}) {
+      // Map of doc source files → their built route.
+      const mdFiles: {route: string; abs: string}[] = [];
+
+      async function walk(dir: string): Promise<void> {
+        const entries = await fs.readdir(dir, {withFileTypes: true});
+        for (const entry of entries) {
+          const abs = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            await walk(abs);
+          } else if (/\.mdx?$/.test(entry.name)) {
+            const rel = path.relative(docsDir, abs).replace(/\.mdx?$/, '');
+            // intro.md has slug `/intro`; everything else lives under /docs/.
+            const slug = rel === 'intro' ? 'intro' : rel;
+            const route = `/docs/${slug}`.replace(/\/intro$/, '/intro');
+            mdFiles.push({route, abs});
+          }
+        }
+      }
+      await walk(docsDir);
+
+      const indexLines: string[] = [
+        `# ${siteConfig.title}`,
+        '',
+        `> ${siteConfig.tagline}`,
+        '',
+        'This file follows the llmstxt.org convention. Each link points to the raw Markdown source of a documentation page.',
+        '',
+        '## Docs',
+        '',
+      ];
+
+      for (const {route, abs} of mdFiles.sort((a, b) => a.route.localeCompare(b.route))) {
+        const raw = await fs.readFile(abs, 'utf8');
+        // Strip the front-matter for the title; fall back to the first heading.
+        const titleMatch =
+          raw.match(/^title:\s*(.+)$/m) ?? raw.match(/^#\s+(.+)$/m);
+        const title = titleMatch ? titleMatch[1].trim().replace(/^['"]|['"]$/g, '') : route;
+
+        // Write the raw markdown copy alongside the HTML route.
+        const mdOut = path.join(outDir, `${route}.md`.replace(/^\//, ''));
+        await fs.mkdir(path.dirname(mdOut), {recursive: true});
+        await fs.writeFile(mdOut, raw, 'utf8');
+
+        indexLines.push(`- [${title}](${siteUrl}${route}.md)`);
+      }
+
+      indexLines.push('');
+      await fs.writeFile(path.join(outDir, 'llms.txt'), indexLines.join('\n'), 'utf8');
+    },
+  };
+}

--- a/docs/superpowers/specs/2026-06-25-docs-competitive-research-and-improvement-plan.md
+++ b/docs/superpowers/specs/2026-06-25-docs-competitive-research-and-improvement-plan.md
@@ -1,0 +1,193 @@
+# Kalyx 공식문서 경쟁 리서치 + 개선 플랜
+
+> **작성일:** 2026-06-25
+> **목적:** 7개 경쟁 OSS의 공식문서 UX를 6개 측면에서 조사하고, 그 근거로 kalyx `apps/docs-site` (Docusaurus) 개선 플랜을 우선순위와 함께 확정한다.
+> **범위:** 문서/사이트(IA·데모·코드 예제·API 표현·랜딩·a11y/i18n) UX에 한정. 라이브러리 런타임 코드 변경은 별도 spec.
+> **방향 정합성:** [`2026-06-18-current-state-analysis-and-correctness-first-direction.md`](2026-06-18-current-state-analysis-and-correctness-first-direction.md) 의 "홍보는 접는다(라이브 마케팅 콘텐츠 제거) / 정확성 먼저" 결정과 충돌하지 않도록, 본 플랜은 **마케팅 모먼트가 아니라 "평가자(evaluator)·구현자가 빠르게 이해·복붙·신뢰"** 하는 docs 품질에 집중한다. comparison 랜딩·블로그 announcement 류는 **다시 만들지 않는다.**
+
+---
+
+## 0. 조사 대상 & 방법
+
+| # | 프로젝트 | 포지션 | 문서 스택 |
+|---|---|---|---|
+| 1 | react-day-picker | Headless 직접 경쟁자 | Docusaurus |
+| 2 | Radix UI Primitives | Headless 컴포넌트 문서 표준 | 자체 |
+| 3 | Ark UI | Composition + 멀티프레임워크 | 자체 |
+| 4 | shadcn/ui | "복사해서 쓰는" 문서 UX | 자체(Next) |
+| 5 | react-datepicker | 통합형·기능 밀집(but dated) | SPA |
+| 6 | React Aria / Adobe | a11y·i18n 문서의 gold standard | 자체 |
+| 7 | MUI X Date Pickers | API 레퍼런스·prop 토글 데모 표준 | 자체 |
+
+조사 측면(6): IA/네비게이션 · 인터랙티브 데모/플레이그라운드 · 코드 예제 제시 · API 레퍼런스 표현 · 랜딩/Hero · 접근성·i18n.
+
+---
+
+## 1. 측면별 비교 매트릭스
+
+범례: ●= 강함/모범, ◐= 부분적, ○= 없음/약함.
+
+### 1.1 IA / 네비게이션
+
+| 프로젝트 | 평가 | 핵심 패턴 |
+|---|---|---|
+| react-day-picker | ◐ | Docs/Playground/API 3-탭. **태스크 중심 사이드바**(Selecting Days, Localization, Guides). 버전 드롭다운. |
+| Radix | ● | **Overview / Guides / Components / Utilities** 4분할 — 개념과 컴포넌트 레퍼런스 분리. |
+| Ark UI | ● | **프레임워크 스위처**(React/Solid/Vue/Svelte)가 URL·코드 동시 전환. **"AI for agents"** 사이드바 그룹. 버전 드롭다운. |
+| shadcn/ui | ◐ | cmd+K 검색, 헤더에 **GitHub 스타 수** 노출. provider 스위처(radix/base). |
+| react-datepicker | ○ | 단일 롱스크롤 예제 페이지. 사이드바·검색·버전 없음. SPA라 no-JS 깨짐. |
+| React Aria | ● | **컴포넌트별 일관 스켈레톤**(intro→example→concept→Anatomy→API). |
+| MUI X | ● | **최고 분류**: Components / Main features / Localization / Customization / API reference. Algolia + 버전 셀렉터 + 우측 TOC. |
+
+**kalyx 현재:** category 분할(Getting Started / Concepts / Guides / Components / Hooks / Recipes / API / migration / troubleshooting)은 이미 Radix/MUI에 근접. **약점:** "Main features"류 동작(validation/lifecycle) 카테고리 부재, 버전 셀렉터 부재(단일 버전이라 OK), 검색은 Docusaurus 기본.
+
+### 1.2 인터랙티브 데모 / 플레이그라운드
+
+| 프로젝트 | 평가 | 핵심 패턴 |
+|---|---|---|
+| react-day-picker | ● | **도메인 축을 토글로**: locale × timezone × calendar system × numeral × week-start × RTL → 하단에 코드 생성. |
+| Radix | ◐ | 스타일된 인터랙티브 프리뷰 우선(읽기전용). |
+| Ark UI | ◐ | 유스케이스 카드("booking systems") + Show Code. |
+| shadcn/ui | ◐ | 유스케이스별 프리뷰(DOB/range/time/자연어) + 인라인 RTL+아랍어 토글. |
+| react-datepicker | ◐ | 기능마다 인라인 라이브 프리뷰(밀집). 편집 불가. |
+| React Aria | ● | **Vanilla CSS + Tailwind 쌍둥이 예제**. `<I18nProvider>`로 RTL/locale 인라인. |
+| MUI X | ● | **모든 데모에 "Edit code" 인라인 에디터** + 전용 Customization 플레이그라운드. |
+
+**kalyx 현재:** `live` 코드블록(react-live), 전용 `/playground` (Picker 선택 + classNames 에디터 + locale/timezone 토글 + StackBlitz 내보내기), `HeroDemo` 애니메이션. **이미 상위권.** 약점: 데모가 "유스케이스(DOB/booking/datetime)"가 아니라 "API 데모" 위주. RTL 인라인 토글 데모 없음.
+
+### 1.3 코드 예제 제시
+
+| 프로젝트 | 평가 | 핵심 패턴 |
+|---|---|---|
+| react-day-picker | ◐ | 파일명 헤더 + **"View source"**(GitHub 실제 예제 파일 링크). |
+| Radix | ● | Anatomy 우선 → **멀티파일**(index+styles) → "Custom APIs"의 **Usage+Implementation 페어**. |
+| Ark UI | ◐ | 프레임워크 탭 코드. **Open in ChatGPT/Claude + view-as-markdown + llms.txt**. |
+| shadcn/ui | ● | **per-block 복사 + "Copy Page"(전체 md)** + 파일명 헤더 + pm 인식. |
+| react-datepicker | ◐ | **예제 상단 주석 import + Common Imports Guide**(복붙 후 컴파일 안 되는 문제 해결). |
+| React Aria | ● | **멀티파일 + 파일명 헤더 + 라인 하이라이트 마커**. |
+| MUI X | ● | 라이브 데모 아래 **"Show code" 토글** + 복사 버튼. |
+
+**kalyx 현재:** Docusaurus 기본 복사 버튼. **약점:** pm 탭(npm/pnpm/yarn/bun) 미사용, 라인 하이라이트 거의 없음, 파일명 헤더 부분적, "Copy Page"/llms.txt 없음, 예제 import 누락으로 복붙 마찰 가능.
+
+### 1.4 API 레퍼런스 표현
+
+| 프로젝트 | 평가 | 핵심 패턴 |
+|---|---|---|
+| react-day-picker | ◐ | TypeDoc 자동 + 토픽별 큐레이션 prop 표. |
+| Radix | ● | **part별 Prop/Type/Default 표 + 별도 `data-*` 어트리뷰트 표** + **Anatomy** 트리. |
+| Ark UI | ● | **part당 3계약**: props + **data-attrs** + **CSS 변수** + **헤드리스 훅 Context 표**. |
+| shadcn/ui | ◐ | **ASCII Composition 트리** + "root 컴포넌트 없음" 정직한 설명. |
+| react-datepicker | ○ | 수기 단일 prop 표(드리프트). |
+| React Aria | ● | **Anatomy JSX 트리** + `data-*` 상태 스타일 표 + render props/slots. |
+| MUI X | ● | per-prop 앵커 + **함수 시그니처 인라인 전개** + **Slots 표**(slot→기본 컴포넌트→class). |
+
+**kalyx 현재:** 컴포넌트 페이지에 Prop/Type/Default 표 + classNames 키 표(타입으로). **약점:** (1) **Anatomy 트리 부재** — Composition API가 thesis인데 트리를 먼저 안 보여줌. (2) `data-*` 어트리뷰트 계약을 표로 문서화 안 함(실제 코드에 `data-active` 등 존재). (3) 헤드리스 훅(`useDatePicker` 등) 반환값 Context 표가 산문/부분적. (4) classNames가 타입 코드블록이라 "어떤 상태에 적용되는지" 설명 열이 없음.
+
+### 1.5 랜딩 / Hero
+
+| 프로젝트 | 평가 | 핵심 패턴 |
+|---|---|---|
+| react-day-picker | ◐ | intro=hero, **모든 기능 불릿이 딥링크**(피처리스트=네비). 스폰서 월. |
+| Radix | ◐ | **문제 우선 프레이밍**("기존 구현은 부적절"). |
+| Ark UI | ● | **"Built with Ark UI" 쇼케이스 그리드**(실서비스 디자인시스템). 탭 코드 hero. |
+| shadcn/ui | ● | **도발적 한 줄 포지셔닝** + **브랜드 social proof**(OpenAI/Adobe) + 인라인 FAQ. |
+| react-datepicker | ○ | hero 없음, 바로 예제 그리드. |
+| React Aria | ● | **주석 달린 인터랙티브 hero**(실앱+컴포넌트 화살표 라벨=네비). |
+| MUI X | ● | **value-pillar별 라이브 데모**(i18n=타임존 셀렉터, a11y=키보드 그래픽). |
+
+**kalyx 현재:** Hero + FeatureGrid + SameJsxBlock + PickerGrid + WhyKalyx + GetStarted, HeroDemo 애니메이션. **이미 강함.** 약점: 피처 불릿→딥링크 연결 약함, value-pillar별 "데모로 증명" 부족(특히 timezone/correctness가 thesis인데 hero에서 라이브로 안 보여줌).
+
+### 1.6 접근성 & i18n
+
+| 프로젝트 | 평가 | 핵심 패턴 |
+|---|---|---|
+| react-day-picker | ● | **a11y 전용 가이드** + WAI-ARIA APG 인용 + **키보드 표** + 캘린더시스템별 페이지. |
+| Radix | ● | **2단**: 전역 a11y 개념 + 컴포넌트별 키보드 표 + APG 패턴 링크. |
+| Ark UI | ◐ | i18n을 **타입드 props**(`locale`/`timeZone`/`translations`)로 문서화. |
+| shadcn/ui | ◐ | **전용 /rtl 페이지** + 인라인 RTL 토글. |
+| react-datepicker | ◐ | README 키보드 리스트 + **"date is one day off" 타임존 가이드**(#1 구글링 버그 직접 해결). |
+| React Aria | ● | **gold standard**: APG 인용, SR 테스트, 30+언어/13캘린더/RTL을 **코드로 시연**. |
+| MUI X | ● | **서브컴포넌트별 키보드 표**(Field/Calendar/Range 각각) + WCAG AA 명시 + APG URL. |
+
+**kalyx 현재:** `concepts/accessibility.md`, `concepts/internationalization.md`, `concepts/timezone.md` 존재. **약점:** (1) 컴포넌트 페이지에 **서브컴포넌트별 키보드 표**가 없음(Calendar grid 키만 일부). (2) APG 패턴 URL 명시적 인용 약함. (3) **RTL 인라인 토글 데모** 없음. (4) timezone "하루 어긋남" 같은 **명명된 트러블슈팅 레시피**가 약함 — 정확성이 thesis인데 #1 버그를 소유하지 못함.
+
+---
+
+## 2. 종합: kalyx가 이미 강한 것 / 격차
+
+### 이미 모범 수준 (유지)
+- **인터랙티브 데모**: react-live 인라인 + 전용 Playground + StackBlitz 내보내기 + locale/timezone 토글 → react-day-picker/MUI 급. 7개 중 상위권.
+- **IA 분류**: Radix/MUI 스타일 카테고리 분할 이미 적용.
+- **랜딩**: Hero/FeatureGrid/PickerGrid/HeroDemo 구성 양호.
+
+### 핵심 격차 (개선 타깃) — 우선순위순
+1. **Anatomy 트리 부재** (API 표현). Composition이 thesis인데 가장 강력한 교육 장치가 없음.
+2. **`data-*` / classNames 계약의 표 문서화 부재** (API 표현). 헤드리스의 스타일링 API 자체.
+3. **서브컴포넌트별 키보드 표 + APG 인용 부재** (a11y).
+4. **유스케이스 레시피 + "View source" 부재** (데모/코드). DOB/booking/datetime 같은 복붙 레시피.
+5. **코드 제시 마찰**: pm 탭, 라인 하이라이트, Copy Page/llms.txt, 예제 import 누락.
+6. **timezone "하루 어긋남" 명명 트러블슈팅 + RTL 인라인 토글** (a11y/i18n) — 정확성 thesis 소유.
+7. **헤드리스 훅 Context 반환 표** (API 표현).
+
+---
+
+## 3. 개선 플랜 (근거 + 우선순위)
+
+각 항목: 근거(출처 프로젝트) · 작업 위치 · 예상 비용. 코드(런타임) 변경 없음, docs-site 한정.
+
+### P0 — 가장 높은 레버리지 (thesis 직결, 비용 중간)
+
+| # | 항목 | 근거(출처) | 위치 |
+|---|---|---|---|
+| D1 | **Anatomy 트리 블록**을 7개 컴포넌트 페이지 상단에 추가(Basic usage 위). JSX 트리로 composition 계약 우선 노출. | Radix/React Aria/Ark Anatomy, shadcn ASCII 트리 | `docs/components/*.md` |
+| D2 | **classNames 표 리포맷** + **`data-*` 어트리뷰트 표** per 서브컴포넌트. 현재 타입 코드블록을 `Slot / data-attr / 적용 시점 / 설명` 표로. | Radix data-attr 표, React Aria 상태 표, MUI Slots 표 | `docs/components/*.md`, 신규 `concepts/styling.md` |
+| D3 | **서브컴포넌트별 키보드 인터랙션 표** + WAI-ARIA APG datepicker-dialog/combobox/spinbutton **URL 인용** + WCAG AA 목표 명시. | MUI(per-sub 표·APG URL), Radix(2단), react-day-picker(키보드 표) | `docs/concepts/accessibility.md` + 각 컴포넌트 "Accessibility" 섹션 |
+
+### P1 — 복붙·신뢰 (비용 낮음~중간)
+
+| # | 항목 | 근거(출처) | 위치 |
+|---|---|---|---|
+| D4 | **유스케이스 레시피 페이지** 신설: Date of Birth(month/year jump), Booking range + presets, DateTime + timezone, 자연어 입력(가능 범위). 라이브 프리뷰 + 복붙. | shadcn 유스케이스 카드, Ark "booking systems" | 신규 `docs/recipes/use-cases/*` 또는 recipes 확장 |
+| D5 | **"View source" 링크**: 라이브 예제를 GitHub의 실제(테스트되는) 예제 파일에 연결해 드리프트 방지. | react-day-picker, React Aria | 예제 컴포넌트 + 코드블록 |
+| D6 | **헤드리스 훅 Context 반환 표**: `useDatePicker`/`useRangePicker`/`useTimePicker` + (1.1 추가분) 반환 state/메서드 전수 표. | Ark Context 표, React Aria render props | `docs/hooks/*.md` |
+| D7 | **timezone "하루 어긋남" 명명 트러블슈팅**: 정확성 thesis를 소유. "Why is my date one day off?" 섹션 + ISO/UTC 계약으로 해결됨을 코드로. | react-datepicker #1018 가이드 | `docs/concepts/timezone.md` + `troubleshooting.md` |
+
+### P2 — 마감/마찰 제거 (비용 낮음)
+
+| # | 항목 | 근거(출처) | 위치 |
+|---|---|---|---|
+| D8 | **pm 탭**(npm/pnpm/yarn/bun) — Docusaurus `Tabs` 또는 `@docusaurus/theme` npm2yarn 플러그인. | shadcn/MUI | installation/quick-start + 전역 |
+| D9 | **라인 하이라이트 마커** + 파일명 헤더 일관화. | React Aria, shadcn | 전역 코드블록 |
+| D10 | **예제 상단 import 일관화 + Common Imports 노트**(복붙 후 컴파일 보장). | react-datepicker Common Imports Guide | 예제 전반 |
+| D11 | **"Copy Page (markdown)" + `llms.txt`** — LLM/에이전트 친화. (홍보 아님, DX) | Ark UI, shadcn Copy Page | docs-site 테마/정적 |
+| D12 | **RTL 인라인 토글 데모** 1개(Playground 또는 i18n 페이지). | shadcn /rtl, React Aria | `concepts/internationalization.md`/Playground |
+
+### P3 — 랜딩 폴리시 (선택, 홍보 아님)
+
+| # | 항목 | 근거(출처) | 위치 |
+|---|---|---|---|
+| D13 | 피처 불릿 → 해당 doc **딥링크**(피처리스트=네비). | react-day-picker | `intro.md`, FeatureGrid |
+| D14 | value-pillar(correctness/timezone)별 **라이브 데모로 증명** 1개씩(이미 HeroDemo 자산 재사용). | MUI value-pillar 데모, React Aria 주석 hero | 랜딩 컴포넌트 |
+
+> ⚠️ comparison 랜딩·블로그 announcement·외부 홍보 카피는 **범위 밖**(2026-06-18 결정). D13/D14는 사이트 내부 네비/이해도 개선이지 마케팅 모먼트가 아니다.
+
+---
+
+## 4. 권장 실행 순서
+
+```
+1차(P0): D1 Anatomy → D2 styling/data-attr 표 → D3 a11y 키보드 표+APG
+2차(P1): D4 유스케이스 레시피 → D7 timezone 트러블슈팅 → D5 View source → D6 훅 Context 표
+3차(P2): D8 pm 탭 → D9 라인 하이라이트 → D10 import → D11 Copy Page/llms.txt → D12 RTL 데모
+4차(P3, 선택): D13 딥링크 → D14 pillar 데모
+```
+
+근거: P0 3개가 "헤드리스 + composition + 정확성"이라는 kalyx thesis를 문서에서 가장 직접적으로 증명하는 격차다. P1은 평가자가 복붙·신뢰하게 만드는 전환 레버. P2는 마찰 제거(저비용 일괄). P3은 여력 시.
+
+---
+
+## 5. 비범위 / 주의
+
+- **런타임/번들 변경 없음.** 모든 항목 docs-site 한정. (`data-*` 표 작성 중 실제 컴포넌트에 누락된 data-attr 발견 시 → 별도 1.0.x 이슈로 분리, 본 플랜에서 코드 수정 금지.)
+- **i18n(한국어) docs 번역**은 별도 트랙(§14 B8)과 정합. 본 플랜의 신규 페이지는 영문 기준, KO 번역은 후속.
+- **검증**: 각 PR에서 `pnpm --filter docs-site build` 통과 + 기존 컴포넌트 테스트(PickerGrid/Playground/Hero 등) 유지.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.1
         version: 3.10.1(@swc/core@1.15.41(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/remark-plugin-npm2yarn':
+        specifier: 3.10.1
+        version: 3.10.1
       '@docusaurus/tsconfig':
         specifier: 3.10.1
         version: 3.10.1
@@ -1689,6 +1692,10 @@ packages:
     resolution: {integrity: sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==}
     peerDependencies:
       react: '*'
+
+  '@docusaurus/remark-plugin-npm2yarn@3.10.1':
+    resolution: {integrity: sha512-HNxVv5Y9yx934/WLZBHJC7dYua7DVAHvhMl3hbQuzYGOghClP30Rt3hjZ0tqj/K7KqbSbVN0T4M1rBGk+e3t9A==}
+    engines: {node: '>=20.0'}
 
   '@docusaurus/theme-classic@3.10.1':
     resolution: {integrity: sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==}
@@ -5864,6 +5871,10 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-to-yarn@3.0.1:
+    resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
@@ -10006,6 +10017,16 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
+  '@docusaurus/remark-plugin-npm2yarn@3.10.1':
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      npm-to-yarn: 3.0.1
+      tslib: 2.8.1
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@docusaurus/theme-classic@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.41(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.15)(esbuild@0.28.1)(postcss@8.5.15))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.15.41(@swc/helpers@0.5.15))(@types/react@19.2.17)(esbuild@0.28.1)(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.41(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.15)(esbuild@0.28.1)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@swc/core@1.15.41(@swc/helpers@0.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
@@ -10865,7 +10886,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -14910,6 +14931,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npm-to-yarn@3.0.1: {}
 
   nprogress@0.2.0: {}
 


### PR DESCRIPTION
## What

Researched the official docs of 7 OSS libraries (react-day-picker, Radix, Ark UI, shadcn/ui, react-datepicker, React Aria, MUI X) across 6 dimensions (IA / interactive demos / code examples / API reference / landing / a11y & i18n) and applied the strongest patterns to `apps/docs-site`.

**No runtime/bundle changes — `docs-site` only.** Aligned with the 2026-06-18 "shelve promotion / correctness-first" direction (no marketing surfaces; focus on evaluator/implementer comprehension, copy-paste, and trust).

## Changes (D1–D12)

**P0 — thesis-direct**
- **D1** Anatomy composition tree on all 7 component pages
- **D2** styling contract: new `concepts/styling.md` + per-component `data-*` tables (verified against component source)
- **D3** a11y: WAI-ARIA APG pattern citations + WCAG 2.1 AA target + MonthGrid/YearGrid and Range/Week keyboard tables

**P1 — copy / trust**
- **D4** use-case recipes page (DOB / booking range / timezone DateTime)
- **D5** "View source" links on `StackBlitzEmbed` → real `examples/*` files (+tests)
- **D6** Context return tables for the 4 `/headless` hooks (`useMonthPicker`/`useYearPicker`/`useWeekPicker`/`useDateTimePicker`)
- **D7** named "date is one day off" timezone troubleshooting with diagnosis steps

**P2 — friction**
- **D8** package-manager tabs via `@docusaurus/remark-plugin-npm2yarn`
- **D9** line-highlight + filename headers on key snippets
- **D10** "live editor imports" notes so copied snippets compile
- **D11** `llms.txt` + per-page raw `.md` copies via a `postBuild` plugin
- **D12** inline RTL toggle demo

## Notes

- All new/edited pages authored in **both `en` and `ko`** locales.
- `docs-site` build is **warning-free** (no broken links / anchors); **50/50** docs-site component tests pass.
- Research + plan: `docs/superpowers/specs/2026-06-25-docs-competitive-research-and-improvement-plan.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 날짜/시간 선택기와 관련된 문서가 대폭 보강되었고, 여러 헤드리스 훅 사용 가이드가 새로 추가되었습니다.
  * 문서 예제에서 바로 볼 수 있는 **소스 보기** 링크와 **llms.txt** 지원이 추가되었습니다.

* **문서 개선**
  * 컴포넌트 구조, 스타일링 규칙, 상태별 `data-*` 속성, 접근성 키보드 동작, RTL 지원, 타임존 처리 안내가 더 명확해졌습니다.
  * 설치 및 시작 가이드의 명령어 표기가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->