### PR TITLE
fix(release): use scripts/check-bundle-size.js for the bundle gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,11 @@ jobs:
         run: pnpm test:run
 
       - name: 번들 크기 확인
-        run: |
-          BYTES=$(gzip -c packages/react/dist/index.js | wc -c)
-          KB=$(echo "scale=2; $BYTES / 1024" | bc)
-          MAX=16
-          echo "📦 릴리즈 번들 크기: ${KB}KB (목표: ≤${MAX}KB)"
-          if (( $(echo "$KB > $MAX" | bc -l) )); then
-            echo "❌ 번들 크기 ${MAX}KB 초과 — 릴리즈 중단"
-            exit 1
-          fi
+        # Single source of truth for the gzip ceiling + measurement:
+        # scripts/check-bundle-size.js (TARGET_KB) — the same gate pr-check.yml
+        # and tsup use. Avoids the stale inline 16KB limit that blocked 1.2.0
+        # after the ceiling was raised to 17KB (B10 A-G1).
+        run: node scripts/check-bundle-size.js
 
       - name: Changesets 릴리즈
         id: changesets


### PR DESCRIPTION
## Problem

The `Release` workflow has been **failing on every push to `main`** (runs for #158 and #159 both failed), so the Changesets release PR (#155 — `@kalyx/core@1.2.0` / `@kalyx/react@1.2.0`) can't publish.

Root cause: `release.yml` had a **stale inline 16KB gzip gate** (`MAX=16`) that measured the ESM bundle via `gzip -c` at **16.02KB** and aborted — even though the project ceiling was raised to **17KB** in B10 (A-G1 announce parity), tracked only in `scripts/check-bundle-size.js` (`TARGET_KB = 17`).

## Fix

Replace the inline check with the canonical `node scripts/check-bundle-size.js` — the same gate `pr-check.yml` and tsup already use. Benefits:

- **Single-sourced ceiling** — future ceiling changes won't desync the release gate again.
- **Unified gzip measurement** (B-R1) — `gzip -c` vs Node `zlib` drifted apart inside the tight margin; the script is the one source.

Verified locally (built dist): `✅ PASS` — ESM 15.99KB / CJS 16.12KB ≤ 17KB.

Unblocks the 1.2.0 release (#155).