### PR TITLE
feat: luxon adapter, RTL support, and release changeset guard

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": ["@kalyx/docs", "docs-site"],
+	"ignore": ["@kalyx/docs", "docs-site", "@kalyx-example/*"],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}

--- a/.changeset/luxon-adapter.md
+++ b/.changeset/luxon-adapter.md
@@ -1,0 +1,5 @@
+---
+'@kalyx/adapter-luxon': minor
+---
+
+New package: **`@kalyx/adapter-luxon`** — a luxon-backed `DateAdapter`, drop-in for teams already shipping luxon (common in enterprise / timezone-heavy stacks). It parses every value as a UTC `DateTime` for the same UTC / ISO-8601 semantics as `@kalyx/adapter-date-fns` and `@kalyx/adapter-dayjs`, delegates all timezone-aware operations to `@kalyx/core` (the correctness moat lives in core, not the adapter), and is validated against the full `@kalyx/core/test-helpers` conformance suite — the suite's third backend, further proving the `DateAdapter` contract is portable rather than tied to any one date library.

--- a/.changeset/rtl-support.md
+++ b/.changeset/rtl-support.md
@@ -1,0 +1,5 @@
+---
+'@kalyx/react': minor
+---
+
+Add RTL support via a `dir` prop (`"ltr"` | `"rtl"`, default `"ltr"`) on every picker Root (DatePicker, RangePicker, TimePicker via DateTimePicker, MonthPicker, YearPicker, WeekPicker). In `dir="rtl"` the calendar/month/year grid carries `dir="rtl"` for styling and mirrors the physical ArrowLeft/ArrowRight keys per the WAI-ARIA grid pattern — the visually-left cell is the *next* date, the visually-right cell the *previous* — while ArrowUp/ArrowDown, PageUp/PageDown, and Home/End keep their logical direction. The disabled-cell skip loop is direction-aware so it continues along the same logical path. Also exports the `Direction` type from the main and `/headless` entries.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,13 @@ jobs:
         # after the ceiling was raised to 17KB (B10 A-G1).
         run: node scripts/check-bundle-size.js
 
+      - name: Changeset 검증 (ignored/publishable 혼합 차단)
+        # Fail early on the changesets footgun: a changeset that bumps both an
+        # `ignore`d package (docs / @kalyx-example/*) and a publishable one makes
+        # `changeset publish` fail mid-release. This turns that opaque failure
+        # into an actionable pre-flight error. (See AGENTS.md §14 cleanup #3.)
+        run: node scripts/verify-changesets.mjs
+
       - name: Changesets 릴리즈
         id: changesets
         uses: changesets/action@v1

--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -37,11 +37,24 @@ import {
 
 ## Adapters
 
-`DateFnsAdapter` — re-exported from `@kalyx/core`.
+`DateFnsAdapter` is re-exported from `@kalyx/react` for convenience (it's the
+default the main entry already installs):
 
 ```ts
 import { DateFnsAdapter } from '@kalyx/react';
 ```
+
+Two more prebuilt adapters ship as separate packages, for use with the
+`@kalyx/react/headless` entry:
+
+```ts
+import { DayjsAdapter } from '@kalyx/adapter-dayjs';
+import { LuxonAdapter } from '@kalyx/adapter-luxon';
+```
+
+All three implement the same `DateAdapter` contract, run in UTC, and are
+validated against `@kalyx/core/test-helpers`. See the
+[adapters guide](../guides/adapters.md).
 
 ## Types
 
@@ -180,6 +193,9 @@ import type {
 - `@floating-ui/react ^0.27.0`
 
 Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
+
+Optional adapter packages (install only if you use the `/headless` entry with a
+non-default backend): `@kalyx/adapter-dayjs`, `@kalyx/adapter-luxon`.
 
 ## Bundle size
 

--- a/apps/docs-site/docs/components/datepicker.md
+++ b/apps/docs-site/docs/components/datepicker.md
@@ -141,6 +141,7 @@ Holds state and provides context to sub-components. Controlled when `value` is p
 | `weekStartsOn` | `0 \| 1` | `0` | `0` = Sunday, `1` = Monday. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | date-fns format string. |
 | `locale` | `string` | `'en-US'` | BCP 47 locale tag. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | Layout direction. In `'rtl'` the calendar grid carries `dir="rtl"` and ArrowLeft/ArrowRight are mirrored to follow the visual layout (WAI-ARIA grid pattern); ArrowUp/Down, PageUp/Down, and Home/End keep their logical direction. See [Internationalization](../concepts/internationalization.md#right-to-left-rtl). |
 | `displayTimezone` | `string` | — | IANA zone (e.g., `"Asia/Seoul"`). When set, Input formats in this zone, Calendar highlights match civil days, and `onChange` emits civil midnight in this zone. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom date adapter. |
 | `labels` | `Partial<DatePickerLabels>` | — | Override ARIA labels (defaults to English). Keys: `triggerOpen`, `triggerClose`, `popoverLabel`, `prevMonth`, `nextMonth`, `prevYear`, `nextYear`, `prevDecade`, `nextDecade`. |

--- a/apps/docs-site/docs/components/datetimepicker.md
+++ b/apps/docs-site/docs/components/datetimepicker.md
@@ -124,6 +124,7 @@ function BasicDateTime() {
 | `weekStartsOn` | `0 \| 1` | `0` | Week start. |
 | `displayFormat` | `string` | `'yyyy-MM-dd HH:mm'` | date-fns format. |
 | `locale` | `string` | `'en-US'` | BCP 47 locale. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | Layout direction, forwarded to the calendar grid. In `'rtl'` ArrowLeft/ArrowRight are mirrored (WAI-ARIA grid pattern). See [Internationalization](../concepts/internationalization.md#right-to-left-rtl). |
 | `displayTimezone` | `string` | — | IANA zone. Calendar highlights by civil day in this zone, TimePicker reads/writes time-of-day in this zone, and `onChange` emits the UTC instant that corresponds to the zone-local date+time. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
 | `labels` | `Partial<DateTimePickerLabels>` | — | Override ARIA labels. Union of DatePicker + TimePicker label keys, plus `dateTimeInput`. |

--- a/apps/docs-site/docs/components/monthpicker.md
+++ b/apps/docs-site/docs/components/monthpicker.md
@@ -94,7 +94,7 @@ function BasicMonthPicker() {
 
 | Part | Source | Purpose |
 |------|--------|---------|
-| `MonthPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules |
+| `MonthPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules, `dir` (RTL mirrors the month grid) |
 | `MonthPicker.Input` | = `DatePicker.Input` | text input (combobox role) |
 | `MonthPicker.Trigger` | = `DatePicker.Trigger` | icon button |
 | `MonthPicker.Popover` | = `DatePicker.Popover` | Floating UI positioning |

--- a/apps/docs-site/docs/components/rangepicker.md
+++ b/apps/docs-site/docs/components/rangepicker.md
@@ -107,6 +107,7 @@ function BasicRange() {
 | `weekStartsOn` | `0 \| 1` | `0` | Week start. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | Format string. |
 | `locale` | `string` | `'en-US'` | BCP 47 locale. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | Layout direction. In `'rtl'` the calendar grid carries `dir="rtl"` and ArrowLeft/ArrowRight are mirrored (WAI-ARIA grid pattern). See [Internationalization](../concepts/internationalization.md#right-to-left-rtl). |
 | `displayTimezone` | `string` | — | IANA zone. When set, `start`/`end` are civil midnight of the clicked day in this zone. See [Timezone](../concepts/timezone.md). |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | Custom adapter. |
 | `labels` | `Partial<RangePickerLabels>` | — | Override ARIA labels. Adds `startInput`, `endInput`, `presetsGroup` on top of DatePicker's label keys. |

--- a/apps/docs-site/docs/components/weekpicker.md
+++ b/apps/docs-site/docs/components/weekpicker.md
@@ -149,7 +149,7 @@ With `weekStartsOn={1}`, clicking any date in, for example, April 14 2026 (Tuesd
 
 | Part | Source | Purpose |
 |------|--------|---------|
-| `WeekPicker.Root` | wraps `RangePicker.Root` | controlled/uncontrolled `DateRange`, `displayTimezone`, `disabled` rules |
+| `WeekPicker.Root` | wraps `RangePicker.Root` | controlled/uncontrolled `DateRange`, `displayTimezone`, `disabled` rules, `dir` (RTL mirrors the calendar grid) |
 | `WeekPicker.Input` | = `RangePicker.Input` | start/end text inputs (`part="start" \| "end"`) |
 | `WeekPicker.Popover` | = `RangePicker.Popover` | Floating UI positioning |
 | **`WeekPicker.Calendar`** | wraps `RangePicker.Calendar` with `selectionMode="week"` | single-click selects the full week |

--- a/apps/docs-site/docs/components/yearpicker.md
+++ b/apps/docs-site/docs/components/yearpicker.md
@@ -92,7 +92,7 @@ function BasicYearPicker() {
 
 | Part | Source | Purpose |
 |------|--------|---------|
-| `YearPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules |
+| `YearPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules, `dir` (RTL mirrors the year grid) |
 | `YearPicker.Input` | = `DatePicker.Input` | text input (combobox role) |
 | `YearPicker.Trigger` | = `DatePicker.Trigger` | icon button |
 | `YearPicker.Popover` | = `DatePicker.Popover` | Floating UI positioning |

--- a/apps/docs-site/docs/concepts/adapters.md
+++ b/apps/docs-site/docs/concepts/adapters.md
@@ -123,8 +123,10 @@ and is auto-installed by the main `@kalyx/react` entry, so installing
 
 If you already ship `dayjs`, `luxon`, or `Temporal`, you can swap the
 adapter out and drop `date-fns` from your bundle entirely by importing from
-`@kalyx/react/headless`. See the [adapters guide](../guides/adapters.md) for
-the full how-to.
+`@kalyx/react/headless`. Kalyx publishes drop-in adapters for two of these
+(`@kalyx/adapter-dayjs` and `@kalyx/adapter-luxon`), so you don't have to write
+one yourself. See the [adapters guide](../guides/adapters.md) for the full
+how-to.
 
 ## Next
 

--- a/apps/docs-site/docs/concepts/internationalization.md
+++ b/apps/docs-site/docs/concepts/internationalization.md
@@ -151,7 +151,12 @@ Both are independent — you can use `locale="ko-KR"` with English labels, or vi
 
 ## Right-to-left (RTL)
 
-Kalyx renders semantic HTML and reads no layout direction of its own, so RTL "just works" — set `dir="rtl"` on any ancestor (or `<html dir="rtl">`) and the calendar grid, inputs, and popover mirror with the document. Use a matching `locale` (e.g. `ar-EG`) for Arabic weekday / month names.
+RTL support has two layers, and you usually want both:
+
+1. **Visual mirroring** comes from the document. Set `dir="rtl"` on any ancestor (or `<html dir="rtl">`) and the calendar grid, inputs, and popover mirror with the page. Kalyx renders semantic HTML and adds no layout direction of its own, so this "just works".
+2. **Keyboard navigation** comes from the picker's own `dir` prop. Pass `dir="rtl"` to any picker Root (`DatePicker`, `RangePicker`, `DateTimePicker`, `MonthPicker`, `YearPicker`, `WeekPicker`) so ArrowLeft/ArrowRight are mirrored to follow the visual layout per the WAI-ARIA grid pattern: the visually-left cell is the *next* date, the visually-right cell the *previous*. ArrowUp/Down, PageUp/Down, and Home/End keep their logical direction. The Root also stamps `dir` onto the grid element, so setting it on the picker covers the visual layer for the calendar too.
+
+Use a matching `locale` (e.g. `ar-EG`) for Arabic weekday / month names.
 
 Toggle the direction below to see the same picker mirror:
 
@@ -168,7 +173,7 @@ function RtlToggle() {
         dir = {dir} (toggle)
       </button>
       <div dir={dir}>
-        <DatePicker value={date} onChange={setDate} locale={dir === 'rtl' ? 'ar-EG' : 'en-US'}>
+        <DatePicker dir={dir} value={date} onChange={setDate} locale={dir === 'rtl' ? 'ar-EG' : 'en-US'}>
           <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
           <DatePicker.Popover className="kx-live-popover">
             <DatePicker.Calendar
@@ -188,6 +193,8 @@ function RtlToggle() {
 ```
 
 The navigation chevrons keep their visual "previous / next" meaning because the whole grid mirrors with `dir` — you don't need to swap them yourself. Provide localized `labels` (see [above](#label-keys-reference)) so screen-reader announcements match the language.
+
+> Passing `dir` on the ancestor `<div>` handles the CSS mirroring; passing it on the `<DatePicker>` Root is what mirrors the arrow-key navigation. Set both (as above) for a fully mirrored, keyboard-correct picker.
 
 ## Next
 

--- a/apps/docs-site/docs/guides/adapters.md
+++ b/apps/docs-site/docs/guides/adapters.md
@@ -12,6 +12,39 @@ This guide is for the second case: you already ship `dayjs`, `luxon`, or
 `Temporal` in your app, and you'd rather not bundle a second date library just
 because Kalyx is here.
 
+## Prebuilt adapter packages
+
+Before writing your own, check whether Kalyx already ships one. Each is a thin,
+UTC-pinned `DateAdapter` validated against the shared conformance suite
+(`@kalyx/core/test-helpers`), so they behave identically to the default:
+
+| Package | Backend | When to use |
+| --- | --- | --- |
+| `@kalyx/adapter-date-fns` | date-fns | Default. Auto-installed by `@kalyx/react`. |
+| `@kalyx/adapter-dayjs` | dayjs | You already ship dayjs (Mantine and many app stacks). |
+| `@kalyx/adapter-luxon` | luxon | You already ship luxon (common in enterprise / timezone-heavy stacks). |
+
+```bash npm2yarn
+npm install @kalyx/adapter-luxon   # or @kalyx/adapter-dayjs
+```
+
+```tsx
+import { DatePicker } from '@kalyx/react/headless';
+import { LuxonAdapter } from '@kalyx/adapter-luxon';
+
+<DatePicker adapter={LuxonAdapter} value={iso} onChange={setIso}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+All three run every operation in UTC for the same ISO 8601 (`...Z`) semantics,
+and delegate timezone-aware work to `@kalyx/core` (the correctness logic lives
+in core, not in each adapter). If none fits your backend, write your own with the
+[interface below](#writing-your-own-adapter).
+
 ---
 
 ## Default (date-fns)
@@ -65,8 +98,8 @@ surface is otherwise identical to `@kalyx/react`:
 ```tsx
 import { DatePicker } from '@kalyx/react/headless';
 import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
-// or your own:
-// import { DayjsAdapter } from './my-dayjs-adapter';
+// or a prebuilt one: import { LuxonAdapter } from '@kalyx/adapter-luxon';
+// or your own: import { MyAdapter } from './my-adapter';
 
 <DatePicker adapter={DateFnsAdapter} value={iso} onChange={setIso}>
   <DatePicker.Input />
@@ -105,7 +138,9 @@ only the default-adapter installation differs.
 
 ## Writing your own adapter
 
-The `DateAdapter` interface has **21 methods**. All of them take ISO 8601 UTC
+If your date library isn't in the [prebuilt list](#prebuilt-adapter-packages)
+(date-fns, dayjs, luxon), implement the `DateAdapter` interface yourself. It has
+**21 methods**. All of them take ISO 8601 UTC
 strings as input and return either ISO strings, booleans, or numbers. Native
 `Date` objects never cross the boundary.
 
@@ -264,10 +299,23 @@ import { DayjsAdapter } from './my-dayjs-adapter';
 
 The fastest sanity check is to render `<DatePicker.Calendar />` with the
 adapter and step through a month with arrow keys. If the dates align with
-what your library reports, the contract holds. For full confidence, copy the
-test cases from `packages/adapter-date-fns/src/__tests__/` and run them
-against your adapter — they cover leap years, DST transitions, and
-end-of-month rollover.
+what your library reports, the contract holds.
+
+For full confidence, run the shared conformance suite. `@kalyx/core/test-helpers`
+exports `runAdapterConformanceTests`, the exact suite the prebuilt adapters are
+validated against. It covers leap years, DST transitions, end-of-month
+rollover, and the weekday / month-index conventions:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { runAdapterConformanceTests } from '@kalyx/core/test-helpers';
+import { MyAdapter } from './my-adapter';
+
+runAdapterConformanceTests(MyAdapter, { describe, it, expect });
+```
+
+If every case passes, your adapter satisfies the same contract as
+`@kalyx/adapter-date-fns`, `@kalyx/adapter-dayjs`, and `@kalyx/adapter-luxon`.
 
 ---
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -37,11 +37,24 @@ import {
 
 ## Adapters
 
-`DateFnsAdapter` — re-exported from `@kalyx/core`.
+`DateFnsAdapter` is re-exported from `@kalyx/react` for convenience (it's the
+default the main entry already installs):
 
 ```ts
 import { DateFnsAdapter } from '@kalyx/react';
 ```
+
+Two more prebuilt adapters ship as separate packages, for use with the
+`@kalyx/react/headless` entry:
+
+```ts
+import { DayjsAdapter } from '@kalyx/adapter-dayjs';
+import { LuxonAdapter } from '@kalyx/adapter-luxon';
+```
+
+All three implement the same `DateAdapter` contract, run in UTC, and are
+validated against `@kalyx/core/test-helpers`. See the
+[adapters guide](../guides/adapters.md).
 
 ## Types
 
@@ -180,6 +193,9 @@ import type {
 - `@floating-ui/react ^0.27.0`
 
 Peer dependencies: `react ^19.0.0`, `react-dom ^19.0.0`.
+
+Optional adapter packages (install only if you use the `/headless` entry with a
+non-default backend): `@kalyx/adapter-dayjs`, `@kalyx/adapter-luxon`.
 
 ## Bundle size
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datepicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datepicker.md
@@ -52,6 +52,7 @@ function Example() {
 | `weekStartsOn` | `0 \| 1` | `0` | `0` = 일요일, `1` = 월요일. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | date-fns 포맷 문자열. |
 | `locale` | `string` | `'en-US'` | BCP 47 로케일 태그. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. `'rtl'`이면 캘린더 그리드에 `dir="rtl"`이 붙고 ArrowLeft/ArrowRight가 시각적 레이아웃을 따르도록 반전된다(WAI-ARIA grid 패턴). ArrowUp/Down, PageUp/Down, Home/End는 논리적 방향을 유지한다. [국제화](../concepts/internationalization.md#right-to-left-rtl) 참고. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | 커스텀 날짜 어댑터. |
 | `children` | `ReactNode` | — | 서브 컴포넌트. |
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datepicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datepicker.md
@@ -52,7 +52,7 @@ function Example() {
 | `weekStartsOn` | `0 \| 1` | `0` | `0` = 일요일, `1` = 월요일. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | date-fns 포맷 문자열. |
 | `locale` | `string` | `'en-US'` | BCP 47 로케일 태그. |
-| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. `'rtl'`이면 캘린더 그리드에 `dir="rtl"`이 붙고 ArrowLeft/ArrowRight가 시각적 레이아웃을 따르도록 반전된다(WAI-ARIA grid 패턴). ArrowUp/Down, PageUp/Down, Home/End는 논리적 방향을 유지한다. [국제화](../concepts/internationalization.md#right-to-left-rtl) 참고. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. `'rtl'`이면 캘린더 그리드에 `dir="rtl"`이 붙고 ArrowLeft/ArrowRight가 시각적 레이아웃을 따르도록 반전된다(WAI-ARIA grid 패턴). ArrowUp/Down, PageUp/Down, Home/End는 논리적 방향을 유지한다. [국제화](../concepts/internationalization.md#오른쪽-왼쪽-rtl) 참고. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | 커스텀 날짜 어댑터. |
 | `children` | `ReactNode` | — | 서브 컴포넌트. |
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datetimepicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datetimepicker.md
@@ -55,7 +55,7 @@ function Example() {
 | `weekStartsOn` | `0 \| 1` | `0` | 주 시작. |
 | `displayFormat` | `string` | `'yyyy-MM-dd HH:mm'` | date-fns 포맷. |
 | `locale` | `string` | `'en-US'` | BCP 47 로케일. |
-| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. 캘린더 그리드로 전달된다. `'rtl'`이면 ArrowLeft/ArrowRight가 반전된다(WAI-ARIA grid 패턴). [국제화](../concepts/internationalization.md#right-to-left-rtl) 참고. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. 캘린더 그리드로 전달된다. `'rtl'`이면 ArrowLeft/ArrowRight가 반전된다(WAI-ARIA grid 패턴). [국제화](../concepts/internationalization.md#오른쪽-왼쪽-rtl) 참고. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | 커스텀 어댑터. |
 | `children` | `ReactNode` | — | 서브 컴포넌트. |
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datetimepicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/datetimepicker.md
@@ -55,6 +55,7 @@ function Example() {
 | `weekStartsOn` | `0 \| 1` | `0` | 주 시작. |
 | `displayFormat` | `string` | `'yyyy-MM-dd HH:mm'` | date-fns 포맷. |
 | `locale` | `string` | `'en-US'` | BCP 47 로케일. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. 캘린더 그리드로 전달된다. `'rtl'`이면 ArrowLeft/ArrowRight가 반전된다(WAI-ARIA grid 패턴). [국제화](../concepts/internationalization.md#right-to-left-rtl) 참고. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | 커스텀 어댑터. |
 | `children` | `ReactNode` | — | 서브 컴포넌트. |
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/monthpicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/monthpicker.md
@@ -45,7 +45,7 @@ The default `displayFormat` is `"yyyy-MM"`. Override it if you prefer a differen
 
 | Part | Source | Purpose |
 |------|--------|---------|
-| `MonthPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules |
+| `MonthPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules, `dir` (RTL mirrors the month grid) |
 | `MonthPicker.Input` | = `DatePicker.Input` | text input (combobox role) |
 | `MonthPicker.Trigger` | = `DatePicker.Trigger` | icon button |
 | `MonthPicker.Popover` | = `DatePicker.Popover` | Floating UI positioning |

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/rangepicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/rangepicker.md
@@ -52,7 +52,7 @@ function Example() {
 | `weekStartsOn` | `0 \| 1` | `0` | 주 시작. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | 포맷 문자열. |
 | `locale` | `string` | `'en-US'` | BCP 47 로케일. |
-| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. `'rtl'`이면 캘린더 그리드에 `dir="rtl"`이 붙고 ArrowLeft/ArrowRight가 반전된다(WAI-ARIA grid 패턴). [국제화](../concepts/internationalization.md#right-to-left-rtl) 참고. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. `'rtl'`이면 캘린더 그리드에 `dir="rtl"`이 붙고 ArrowLeft/ArrowRight가 반전된다(WAI-ARIA grid 패턴). [국제화](../concepts/internationalization.md#오른쪽-왼쪽-rtl) 참고. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | 커스텀 어댑터. |
 | `children` | `ReactNode` | — | 서브 컴포넌트. |
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/rangepicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/rangepicker.md
@@ -52,6 +52,7 @@ function Example() {
 | `weekStartsOn` | `0 \| 1` | `0` | 주 시작. |
 | `displayFormat` | `string` | `'yyyy-MM-dd'` | 포맷 문자열. |
 | `locale` | `string` | `'en-US'` | BCP 47 로케일. |
+| `dir` | `'ltr' \| 'rtl'` | `'ltr'` | 레이아웃 방향. `'rtl'`이면 캘린더 그리드에 `dir="rtl"`이 붙고 ArrowLeft/ArrowRight가 반전된다(WAI-ARIA grid 패턴). [국제화](../concepts/internationalization.md#right-to-left-rtl) 참고. |
 | `adapter` | `DateAdapter` | `DateFnsAdapter` | 커스텀 어댑터. |
 | `children` | `ReactNode` | — | 서브 컴포넌트. |
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/weekpicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/weekpicker.md
@@ -55,7 +55,7 @@ With `weekStartsOn={1}`, clicking any date in, for example, April 14 2026 (Tuesd
 
 | Part | Source | Purpose |
 |------|--------|---------|
-| `WeekPicker.Root` | wraps `RangePicker.Root` | controlled/uncontrolled `DateRange`, `displayTimezone`, `disabled` rules |
+| `WeekPicker.Root` | wraps `RangePicker.Root` | controlled/uncontrolled `DateRange`, `displayTimezone`, `disabled` rules, `dir` (RTL mirrors the calendar grid) |
 | `WeekPicker.Input` | = `RangePicker.Input` | start/end text inputs (`part="start" \| "end"`) |
 | `WeekPicker.Popover` | = `RangePicker.Popover` | Floating UI positioning |
 | **`WeekPicker.Calendar`** | wraps `RangePicker.Calendar` with `selectionMode="week"` | single-click selects the full week |

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/yearpicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/yearpicker.md
@@ -43,7 +43,7 @@ The default `displayFormat` is `"yyyy"`.
 
 | Part | Source | Purpose |
 |------|--------|---------|
-| `YearPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules |
+| `YearPicker.Root` | wraps `DatePicker.Root` | controlled/uncontrolled state, `displayTimezone`, `disabled` rules, `dir` (RTL mirrors the year grid) |
 | `YearPicker.Input` | = `DatePicker.Input` | text input (combobox role) |
 | `YearPicker.Trigger` | = `DatePicker.Trigger` | icon button |
 | `YearPicker.Popover` | = `DatePicker.Popover` | Floating UI positioning |

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/adapters.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/adapters.md
@@ -68,7 +68,12 @@ import { DatePicker, DateFnsAdapter } from '@kalyx/react';
 
 ## 커스텀 어댑터 작성
 
-`DateAdapter` 타입을 만족하는 객체면 됩니다. Day.js 기반 간단 예시:
+직접 만들기 전에, Kalyx가 이미 제공하는 어댑터가 있는지 확인하세요.
+`@kalyx/adapter-dayjs`(dayjs)와 `@kalyx/adapter-luxon`(luxon)은 공유
+conformance 스위트로 검증된 drop-in 어댑터라 직접 작성할 필요가 없습니다.
+자세한 사용법은 [어댑터 가이드](../guides/adapters.md) 참고.
+
+백엔드가 맞는 게 없다면, `DateAdapter` 타입을 만족하는 객체면 됩니다. Day.js 기반 간단 예시:
 
 ```ts
 import dayjs from 'dayjs';

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -149,9 +149,14 @@ export const ja: DatePickerLabels = {
 
 둘은 독립적입니다 — `locale="ko-KR"`과 영어 라벨을 함께 쓸 수도 있고, 그 반대도 가능합니다.
 
-## 오른쪽-왼쪽 (RTL)
+## 오른쪽-왼쪽 (RTL) {#right-to-left-rtl}
 
-Kalyx는 의미론적 HTML을 렌더링하며 자체적으로 레이아웃 방향을 읽지 않으므로 RTL이 "그냥 동작"합니다 — 상위 요소(또는 `<html dir="rtl">`)에 `dir="rtl"`을 주면 캘린더 그리드·입력·popover가 문서와 함께 미러링됩니다. 아랍어 요일/월 이름을 위해 맞는 `locale`(예: `ar-EG`)을 사용하세요.
+RTL 지원은 두 계층이며, 보통 둘 다 필요합니다:
+
+1. **시각적 미러링**은 문서에서 옵니다. 상위 요소(또는 `<html dir="rtl">`)에 `dir="rtl"`을 주면 캘린더 그리드·입력·popover가 페이지와 함께 미러링됩니다. Kalyx는 의미론적 HTML을 렌더링하며 자체적으로 레이아웃 방향을 더하지 않으므로 이 부분은 "그냥 동작"합니다.
+2. **키보드 내비게이션**은 picker 자신의 `dir` prop에서 옵니다. 어느 picker Root든(`DatePicker`, `RangePicker`, `DateTimePicker`, `MonthPicker`, `YearPicker`, `WeekPicker`) `dir="rtl"`을 넘기면 ArrowLeft/ArrowRight가 WAI-ARIA grid 패턴에 따라 시각적 레이아웃을 따르도록 반전됩니다. 즉 시각적으로 왼쪽 셀이 *다음* 날짜, 오른쪽 셀이 *이전* 날짜가 됩니다. ArrowUp/Down, PageUp/Down, Home/End는 논리적 방향을 유지합니다. Root는 그리드 요소에 `dir`도 찍어주므로, picker에 지정하면 캘린더의 시각 계층까지 함께 처리됩니다.
+
+아랍어 요일/월 이름을 위해 맞는 `locale`(예: `ar-EG`)을 사용하세요.
 
 아래에서 방향을 토글해 같은 picker가 미러링되는 것을 확인하세요:
 
@@ -168,7 +173,7 @@ function RtlToggle() {
         dir = {dir} (토글)
       </button>
       <div dir={dir}>
-        <DatePicker value={date} onChange={setDate} locale={dir === 'rtl' ? 'ar-EG' : 'en-US'}>
+        <DatePicker dir={dir} value={date} onChange={setDate} locale={dir === 'rtl' ? 'ar-EG' : 'en-US'}>
           <DatePicker.Input className="kx-live-input" placeholder="YYYY-MM-DD" />
           <DatePicker.Popover className="kx-live-popover">
             <DatePicker.Calendar
@@ -188,6 +193,8 @@ function RtlToggle() {
 ```
 
 내비게이션 화살표는 그리드 전체가 `dir`과 함께 미러링되므로 "이전 / 다음"의 시각적 의미를 그대로 유지합니다 — 직접 바꿀 필요가 없습니다. 스크린 리더 안내가 언어와 맞도록 지역화된 `labels`(위 라벨 키 레퍼런스 참고)를 제공하세요.
+
+> 상위 `<div>`에 `dir`을 주면 CSS 미러링이 처리되고, `<DatePicker>` Root에 `dir`을 주면 화살표 키 내비게이션이 미러링됩니다. 완전히 미러링되고 키보드까지 올바른 picker를 위해서는 위 예시처럼 둘 다 설정하세요.
 
 ## 다음
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/internationalization.md
@@ -149,7 +149,7 @@ export const ja: DatePickerLabels = {
 
 둘은 독립적입니다 — `locale="ko-KR"`과 영어 라벨을 함께 쓸 수도 있고, 그 반대도 가능합니다.
 
-## 오른쪽-왼쪽 (RTL) {#right-to-left-rtl}
+## 오른쪽-왼쪽 (RTL)
 
 RTL 지원은 두 계층이며, 보통 둘 다 필요합니다:
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/guides/adapters.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/guides/adapters.md
@@ -12,6 +12,39 @@ This guide is for the second case: you already ship `dayjs`, `luxon`, or
 `Temporal` in your app, and you'd rather not bundle a second date library just
 because Kalyx is here.
 
+## 미리 만들어진 어댑터 패키지
+
+직접 만들기 전에, Kalyx가 이미 제공하는 어댑터가 있는지 확인하세요. 각각은
+공유 conformance 스위트(`@kalyx/core/test-helpers`)로 검증된, UTC로 고정된
+얇은 `DateAdapter`이므로 기본 어댑터와 동일하게 동작합니다:
+
+| 패키지 | 백엔드 | 사용 시점 |
+| --- | --- | --- |
+| `@kalyx/adapter-date-fns` | date-fns | 기본값. `@kalyx/react`가 자동 설치. |
+| `@kalyx/adapter-dayjs` | dayjs | 이미 dayjs를 쓰는 경우 (Mantine 등 다수 스택). |
+| `@kalyx/adapter-luxon` | luxon | 이미 luxon을 쓰는 경우 (엔터프라이즈 / timezone 중심 스택에서 흔함). |
+
+```bash npm2yarn
+npm install @kalyx/adapter-luxon   # or @kalyx/adapter-dayjs
+```
+
+```tsx
+import { DatePicker } from '@kalyx/react/headless';
+import { LuxonAdapter } from '@kalyx/adapter-luxon';
+
+<DatePicker adapter={LuxonAdapter} value={iso} onChange={setIso}>
+  <DatePicker.Input />
+  <DatePicker.Popover>
+    <DatePicker.Calendar />
+  </DatePicker.Popover>
+</DatePicker>
+```
+
+셋 모두 모든 연산을 UTC로 수행해 동일한 ISO 8601(`...Z`) 시맨틱을 지키며,
+timezone 관련 작업은 `@kalyx/core`에 위임합니다. 정확성 로직은 각 어댑터가
+아니라 core에 있습니다. 백엔드가 맞는 게 없으면
+[아래 인터페이스](#writing-your-own-adapter)로 직접 작성하세요.
+
 ---
 
 ## Default (date-fns)
@@ -65,8 +98,8 @@ surface is otherwise identical to `@kalyx/react`:
 ```tsx
 import { DatePicker } from '@kalyx/react/headless';
 import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
-// or your own:
-// import { DayjsAdapter } from './my-dayjs-adapter';
+// or a prebuilt one: import { LuxonAdapter } from '@kalyx/adapter-luxon';
+// or your own: import { MyAdapter } from './my-adapter';
 
 <DatePicker adapter={DateFnsAdapter} value={iso} onChange={setIso}>
   <DatePicker.Input />
@@ -105,7 +138,10 @@ only the default-adapter installation differs.
 
 ## Writing your own adapter
 
-The `DateAdapter` interface has **21 methods**. All of them take ISO 8601 UTC
+If your date library isn't already covered by a prebuilt package
+(date-fns, dayjs, luxon, see the section above), implement the `DateAdapter`
+interface yourself. It has
+**21 methods**. All of them take ISO 8601 UTC
 strings as input and return either ISO strings, booleans, or numbers. Native
 `Date` objects never cross the boundary.
 
@@ -264,10 +300,23 @@ import { DayjsAdapter } from './my-dayjs-adapter';
 
 The fastest sanity check is to render `<DatePicker.Calendar />` with the
 adapter and step through a month with arrow keys. If the dates align with
-what your library reports, the contract holds. For full confidence, copy the
-test cases from `packages/adapter-date-fns/src/__tests__/` and run them
-against your adapter — they cover leap years, DST transitions, and
-end-of-month rollover.
+what your library reports, the contract holds.
+
+For full confidence, run the shared conformance suite. `@kalyx/core/test-helpers`
+exports `runAdapterConformanceTests`, the exact suite the prebuilt adapters are
+validated against. It covers leap years, DST transitions, end-of-month
+rollover, and the weekday / month-index conventions:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { runAdapterConformanceTests } from '@kalyx/core/test-helpers';
+import { MyAdapter } from './my-adapter';
+
+runAdapterConformanceTests(MyAdapter, { describe, it, expect });
+```
+
+If every case passes, your adapter satisfies the same contract as
+`@kalyx/adapter-date-fns`, `@kalyx/adapter-dayjs`, and `@kalyx/adapter-luxon`.
 
 ---
 

--- a/packages/adapter-luxon/package.json
+++ b/packages/adapter-luxon/package.json
@@ -1,0 +1,69 @@
+{
+	"name": "@kalyx/adapter-luxon",
+	"version": "0.1.0",
+	"description": "luxon adapter for @kalyx/core — implements the DateAdapter contract using luxon (UTC mode). Timezone work is delegated to @kalyx/core's Intl-based utilities.",
+	"license": "MIT",
+	"author": "jiji-hoon96",
+	"homepage": "https://github.com/jiji-hoon96/kalyx#readme",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jiji-hoon96/kalyx.git",
+		"directory": "packages/adapter-luxon"
+	},
+	"bugs": {
+		"url": "https://github.com/jiji-hoon96/kalyx/issues"
+	},
+	"keywords": [
+		"luxon",
+		"adapter",
+		"kalyx",
+		"datepicker"
+	],
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"files": [
+		"dist",
+		"CHANGELOG.md",
+		"LICENSE"
+	],
+	"scripts": {
+		"build": "tsup src/index.ts --format esm,cjs --dts --clean",
+		"typecheck": "tsc --noEmit",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@kalyx/core": "workspace:^",
+		"luxon": "^3.5.0"
+	},
+	"devDependencies": {
+		"@types/luxon": "^3.4.2"
+	},
+	"peerDependencies": {
+		"@kalyx/core": "workspace:^"
+	},
+	"peerDependenciesMeta": {
+		"@kalyx/core": {
+			"optional": false
+		}
+	},
+	"engines": {
+		"node": ">=20.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/adapter-luxon/src/__tests__/conformance.test.ts
+++ b/packages/adapter-luxon/src/__tests__/conformance.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { runAdapterConformanceTests } from '@kalyx/core/test-helpers';
+import { LuxonAdapter } from '../index.js';
+
+// The luxon adapter must satisfy the exact same DateAdapter contract as the
+// reference date-fns adapter and the dayjs adapter. Running the shared
+// conformance suite against a third backend proves the contract is genuinely
+// portable, not tied to any one date library.
+runAdapterConformanceTests(LuxonAdapter, { describe, it, expect });
+
+// A couple of luxon-specific sanity checks beyond the shared contract.
+describe('LuxonAdapter — UTC mode sanity', () => {
+  it('operates in UTC regardless of host timezone', () => {
+    // 00:00 UTC must read back as day 15, not shifted into the local zone.
+    expect(LuxonAdapter.getDate('2026-01-15T00:00:00.000Z')).toBe(15);
+    expect(LuxonAdapter.format('2026-01-15T00:00:00.000Z', 'yyyy-MM-dd HH:mm')).toBe(
+      '2026-01-15 00:00',
+    );
+  });
+
+  it('emits a "Z"-suffixed ISO string, not "+00:00"', () => {
+    expect(LuxonAdapter.addDays('2026-01-15T00:00:00.000Z', 1)).toBe('2026-01-16T00:00:00.000Z');
+  });
+
+  it('round-trips a value through parse → format', () => {
+    expect(LuxonAdapter.format(LuxonAdapter.parse('2026-07-04'), 'yyyy-MM-dd')).toBe('2026-07-04');
+  });
+});

--- a/packages/adapter-luxon/src/index.ts
+++ b/packages/adapter-luxon/src/index.ts
@@ -1,0 +1,175 @@
+import { DateTime } from 'luxon';
+import type { DateAdapter } from '@kalyx/core';
+import {
+  formatInTimezone,
+  isSameDayInTimezone,
+  startOfDayInTimezone,
+  todayInTimezone,
+} from '@kalyx/core';
+
+/**
+ * Parse an ISO string into a luxon DateTime pinned to UTC, so every operation
+ * matches Kalyx's UTC/ISO-8601 contract regardless of the host's local zone.
+ */
+const d = (iso: string): DateTime => DateTime.fromISO(iso, { zone: 'utc' });
+
+/** Normalize an ISO date string: "YYYY-MM-DD" → "YYYY-MM-DDTHH:mm:ss.sssZ". */
+function normalize(value: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T00:00:00.000Z`;
+  }
+  return value;
+}
+
+/** luxon emits ISO with a "+00:00" UTC offset; Kalyx's contract wants a "Z". */
+function toISO(dt: DateTime): string {
+  // { suppressMilliseconds: false } keeps ".000"; force UTC then swap offset.
+  const iso = dt.toUTC().toISO({ suppressMilliseconds: false });
+  if (iso === null) return '';
+  return iso.replace(/\+00:00$/, 'Z');
+}
+
+/**
+ * DateAdapter implementation backed by luxon (UTC mode). A drop-in alternative
+ * to `@kalyx/adapter-date-fns` for teams already shipping luxon — same UTC
+ * semantics, validated against `@kalyx/core/test-helpers`. Timezone-aware
+ * operations delegate to `@kalyx/core`'s Intl-based utilities (the correctness
+ * moat lives in core, not the adapter).
+ *
+ * @example
+ * ```ts
+ * import { LuxonAdapter } from '@kalyx/adapter-luxon';
+ * import { DatePicker } from '@kalyx/react/headless';
+ *
+ * <DatePicker adapter={LuxonAdapter} value={iso} onChange={setIso}>…</DatePicker>
+ * ```
+ */
+export const LuxonAdapter: DateAdapter = {
+  parse(value: string): string {
+    if (!value) return '';
+    return normalize(value);
+  },
+
+  format(iso: string, formatStr: string, timezone?: string): string {
+    if (timezone) {
+      return formatInTimezone(iso, formatStr, timezone);
+    }
+    const t = d(iso);
+    const tokens: Record<string, string> = {
+      yyyy: String(t.year),
+      MM: String(t.month).padStart(2, '0'),
+      dd: String(t.day).padStart(2, '0'),
+      HH: String(t.hour).padStart(2, '0'),
+      mm: String(t.minute).padStart(2, '0'),
+      ss: String(t.second).padStart(2, '0'),
+      M: String(t.month),
+      d: String(t.day),
+    };
+    let result = formatStr;
+    // Replace longer tokens first to prevent partial matches.
+    for (const [token, value] of Object.entries(tokens).sort((a, b) => b[0].length - a[0].length)) {
+      result = result.split(token).join(value);
+    }
+    return result;
+  },
+
+  addDays(iso: string, n: number): string {
+    return toISO(d(iso).plus({ days: n }));
+  },
+
+  addMonths(iso: string, n: number): string {
+    return toISO(d(iso).plus({ months: n }));
+  },
+
+  addYears(iso: string, n: number): string {
+    return toISO(d(iso).plus({ years: n }));
+  },
+
+  isBefore(a: string, b: string): boolean {
+    return d(a) < d(b);
+  },
+
+  isAfter(a: string, b: string): boolean {
+    return d(a) > d(b);
+  },
+
+  isSameDay(a: string, b: string, timezone?: string): boolean {
+    if (!a || !b) return false;
+    if (timezone) {
+      return isSameDayInTimezone(a, b, timezone);
+    }
+    const da = d(a);
+    const db = d(b);
+    return da.year === db.year && da.month === db.month && da.day === db.day;
+  },
+
+  isSameMonth(a: string, b: string): boolean {
+    const da = d(a);
+    const db = d(b);
+    return da.year === db.year && da.month === db.month;
+  },
+
+  startOfDay(iso: string, timezone?: string): string {
+    if (timezone) {
+      return startOfDayInTimezone(iso, timezone);
+    }
+    return toISO(d(iso).startOf('day'));
+  },
+
+  startOfMonth(iso: string): string {
+    return toISO(d(iso).startOf('month'));
+  },
+
+  endOfMonth(iso: string): string {
+    return toISO(d(iso).endOf('month'));
+  },
+
+  startOfWeek(iso: string, weekStartsOn: 0 | 1 = 0): string {
+    const t = d(iso);
+    // luxon weekday: 1=Monday … 7=Sunday. Convert to 0=Sunday … 6=Saturday.
+    const dow = t.weekday % 7;
+    const diff = (dow - weekStartsOn + 7) % 7;
+    return toISO(t.minus({ days: diff }).startOf('day'));
+  },
+
+  endOfWeek(iso: string, weekStartsOn: 0 | 1 = 0): string {
+    const t = d(iso);
+    const dow = t.weekday % 7;
+    const diff = (dow - weekStartsOn + 7) % 7;
+    return toISO(t.minus({ days: diff }).plus({ days: 6 }).endOf('day'));
+  },
+
+  now(): string {
+    return toISO(DateTime.utc());
+  },
+
+  today(timezone?: string): string {
+    if (timezone) {
+      return todayInTimezone(timezone);
+    }
+    return toISO(DateTime.utc().startOf('day'));
+  },
+
+  isValid(value: string): boolean {
+    if (!value) return false;
+    return d(normalize(value)).isValid;
+  },
+
+  getYear(iso: string): number {
+    return d(iso).year;
+  },
+
+  getMonth(iso: string): number {
+    // luxon month is 1-based; the contract wants 0-based.
+    return d(iso).month - 1;
+  },
+
+  getDate(iso: string): number {
+    return d(iso).day;
+  },
+
+  getDay(iso: string): number {
+    // luxon weekday: 1=Monday … 7=Sunday. Contract wants 0=Sunday … 6=Saturday.
+    return d(iso).weekday % 7;
+  },
+};

--- a/packages/adapter-luxon/tsconfig.json
+++ b/packages/adapter-luxon/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -10,6 +10,7 @@ import {
 } from '@kalyx/core';
 import type { CalendarDay } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
+import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
 
 export interface DatePickerCalendarClassNames {
   root?: string;
@@ -68,6 +69,7 @@ export function DatePickerCalendar({
   const gridRef = useRef<HTMLTableElement>(null);
 
   const { adapter, viewMonth, focusedDate, weekStartsOn, disabled, locale, displayTimezone } = ctx;
+  const dir = ctx.dir;
   // Memoized — weekday header tuples only change when locale or week start changes.
   const weekdays = useMemo(() => getWeekdayNames(locale, weekStartsOn), [locale, weekStartsOn]);
 
@@ -139,57 +141,59 @@ export function DatePickerCalendar({
     (e: React.KeyboardEvent) => {
       let newFocused: string | null = null;
 
-      switch (e.key) {
-        case 'ArrowLeft':
-          newFocused = adapter.addDays(focusedDate, -1);
-          break;
-        case 'ArrowRight':
-          newFocused = adapter.addDays(focusedDate, 1);
-          break;
-        case 'ArrowUp':
-          newFocused = adapter.addDays(focusedDate, -7);
-          break;
-        case 'ArrowDown':
-          newFocused = adapter.addDays(focusedDate, 7);
-          break;
-        case 'PageUp':
-          if (e.shiftKey) {
-            newFocused = adapter.addYears(focusedDate, -1);
-          } else {
-            newFocused = adapter.addMonths(focusedDate, -1);
-          }
-          break;
-        case 'PageDown':
-          if (e.shiftKey) {
-            newFocused = adapter.addYears(focusedDate, 1);
-          } else {
-            newFocused = adapter.addMonths(focusedDate, 1);
-          }
-          break;
-        case 'Home':
-          newFocused = adapter.startOfWeek(focusedDate, weekStartsOn);
-          break;
-        case 'End':
-          newFocused = adapter.endOfWeek(focusedDate, weekStartsOn);
-          // endOfWeek returns 23:59:59; normalize to start of day
-          newFocused = adapter.startOfDay(newFocused);
-          break;
-        case 'Enter':
-        case ' ':
-          e.preventDefault();
-          if (!isDateDisabled(focusedDate, disabled, adapter)) {
-            ctx.selectDate(focusedDate);
-          }
-          return;
-        case 'Escape':
-          // Stop the synthetic Escape from bubbling to a host modal/dialog
-          // whose own Escape handler would otherwise also close.
-          e.preventDefault();
-          e.stopPropagation();
-          ctx.close();
-          return;
-        default:
-          return;
+      // In RTL the physical ArrowLeft/ArrowRight are swapped (WAI-ARIA grid
+      // follows visual layout). horizontalDayStep resolves the correct ±1-day
+      // offset for the current direction; other keys fall through unchanged.
+      const hStep = horizontalDayStep(e.key, dir);
+      if (hStep !== null) {
+        newFocused = adapter.addDays(focusedDate, hStep);
+      } else {
+        switch (e.key) {
+          case 'ArrowUp':
+            newFocused = adapter.addDays(focusedDate, -7);
+            break;
+          case 'ArrowDown':
+            newFocused = adapter.addDays(focusedDate, 7);
+            break;
+          case 'PageUp':
+            if (e.shiftKey) {
+              newFocused = adapter.addYears(focusedDate, -1);
+            } else {
+              newFocused = adapter.addMonths(focusedDate, -1);
+            }
+            break;
+          case 'PageDown':
+            if (e.shiftKey) {
+              newFocused = adapter.addYears(focusedDate, 1);
+            } else {
+              newFocused = adapter.addMonths(focusedDate, 1);
+            }
+            break;
+          case 'Home':
+            newFocused = adapter.startOfWeek(focusedDate, weekStartsOn);
+            break;
+          case 'End':
+            newFocused = adapter.endOfWeek(focusedDate, weekStartsOn);
+            // endOfWeek returns 23:59:59; normalize to start of day
+            newFocused = adapter.startOfDay(newFocused);
+            break;
+          case 'Enter':
+          case ' ':
+            e.preventDefault();
+            if (!isDateDisabled(focusedDate, disabled, adapter)) {
+              ctx.selectDate(focusedDate);
+            }
+            return;
+          case 'Escape':
+            // Stop the synthetic Escape from bubbling to a host modal/dialog
+            // whose own Escape handler would otherwise also close.
+            e.preventDefault();
+            e.stopPropagation();
+            ctx.close();
+            return;
+          default:
+            return;
+        }
       }
 
       if (newFocused) {
@@ -198,11 +202,9 @@ export function DatePickerCalendar({
         // WAI-ARIA grid pattern: disabled cells should be skipped during keyboard
         // navigation. Keep stepping in the original direction until we land on an
         // enabled day, capped at 42 attempts (one full grid) to avoid infinite loops
-        // when every day in range is disabled.
-        const skipStep =
-          e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp' || e.key === 'Home'
-            ? -1
-            : 1;
+        // when every day in range is disabled. `isBackwardKey` is RTL-aware so the
+        // skip continues along the same *logical* direction the keypress moved.
+        const skipStep = isBackwardKey(e.key, dir) ? -1 : 1;
         let attempts = 0;
         while (isDateDisabled(newFocused, disabled, adapter) && attempts < 42) {
           newFocused = adapter.addDays(newFocused, skipStep);
@@ -221,7 +223,7 @@ export function DatePickerCalendar({
         }
       }
     },
-    [adapter, focusedDate, viewMonth, weekStartsOn, disabled, ctx],
+    [adapter, focusedDate, viewMonth, weekStartsOn, disabled, ctx, dir],
   );
 
   return (
@@ -265,6 +267,7 @@ export function DatePickerCalendar({
         aria-label={title}
         aria-rowcount={weeks.length + 1}
         aria-colcount={7}
+        dir={dir}
         className={classNames?.grid}
         onKeyDown={handleKeyDown}
       >

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1462,3 +1462,103 @@ describe('DatePicker — announce() live-region parity (B10 A-G1)', () => {
     expect(screen.getByRole('status')).toHaveTextContent(/January 20, 2026/i);
   });
 });
+
+describe('DatePicker — RTL (dir="rtl")', () => {
+  function renderRtl(onChange = vi.fn()) {
+    render(
+      <DatePicker value="2026-01-15T00:00:00.000Z" onChange={onChange} dir="rtl">
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    return { onChange };
+  }
+
+  it('marks the grid with dir="rtl"', async () => {
+    const user = userEvent.setup();
+    renderRtl();
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'rtl');
+  });
+
+  it('mirrors ArrowLeft/ArrowRight: ArrowLeft advances a day, ArrowRight goes back', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderRtl();
+    await user.click(screen.getByRole('combobox'));
+
+    // In RTL the physically-left cell is the *next* day.
+    await user.keyboard('{ArrowLeft}{Enter}');
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-16T/));
+
+    onChange.mockClear();
+    await user.click(screen.getByRole('combobox'));
+    // ArrowRight moves back a day.
+    await user.keyboard('{ArrowRight}{Enter}');
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-14T/));
+  });
+
+  it('keeps ArrowUp/ArrowDown vertical (unaffected by direction)', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderRtl();
+    await user.click(screen.getByRole('combobox'));
+
+    // ArrowDown = +7 days regardless of layout direction.
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-22T/));
+  });
+
+  it('defaults to LTR when dir is not set', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DatePicker value="2026-01-15T00:00:00.000Z" onChange={onChange}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'ltr');
+
+    // LTR: ArrowLeft goes back a day.
+    await user.keyboard('{ArrowLeft}{Enter}');
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-14T/));
+  });
+
+  it('applies dir="rtl" to the MonthGrid element', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value="2026-04-15T00:00:00.000Z" onChange={vi.fn()} dir="rtl">
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.MonthGrid />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'rtl');
+  });
+
+  it('applies dir="rtl" to the YearGrid element and mirrors index navigation', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value="2026-04-15T00:00:00.000Z" onChange={vi.fn()} dir="rtl">
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.YearGrid />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'rtl');
+
+    // 12-year block starts at 2016 (2026 - 2026%12 = 2016). Focus is 2026 (index 10).
+    screen.getByRole('gridcell', { name: '2026' }).focus();
+    // RTL: physically-left cell is the *next* (higher-index) year → 2027.
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: '2027' })).toHaveFocus();
+  });
+});

--- a/packages/react/src/components/DatePicker/MonthGrid.tsx
+++ b/packages/react/src/components/DatePicker/MonthGrid.tsx
@@ -80,6 +80,7 @@ export function DatePickerMonthGrid({
     onPageUp: () => navigateYear(-1),
     onPageDown: () => navigateYear(1),
     onEscape: ctx.close,
+    dir: ctx.dir,
   });
 
   return (
@@ -114,6 +115,7 @@ export function DatePickerMonthGrid({
         ref={gridRef}
         role="grid"
         aria-label={`${currentYear} months`}
+        dir={ctx.dir}
         className={classNames?.grid}
         style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)' }}
         onKeyDown={handleKeyDown}

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@kalyx/core';
 import { DatePickerContext } from '../../context/DatePickerContext.js';
 import type { DatePickerContextValue } from '../../context/DatePickerContext.js';
+import type { Direction } from '../_shared/rtl.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
 import { SR_ONLY } from '../../internal/srOnly.js';
@@ -63,6 +64,14 @@ export interface DatePickerRootProps {
   /** BCP 47 locale (e.g., "en-US", "ko-KR", "ja-JP") */
   locale?: string;
   /**
+   * Layout direction: "ltr" (default) or "rtl". In "rtl" the calendar grid
+   * swaps ArrowLeft/ArrowRight so keyboard navigation follows the visual
+   * layout (WAI-ARIA grid pattern), and the grid element carries `dir="rtl"`.
+   * Pair with the corresponding writing-direction on your own container for a
+   * fully mirrored layout.
+   */
+  dir?: Direction;
+  /**
    * IANA timezone used for display and selection semantics (e.g., "Asia/Seoul").
    * When set, the Input formats the value in this zone, Calendar highlights the matching civil
    * day, and selecting a date emits the civil midnight of that day (UTC-ISO form).
@@ -87,6 +96,7 @@ export function DatePickerRoot({
   weekStartsOn: weekStartsOnProp,
   displayFormat = 'yyyy-MM-dd',
   locale = 'en-US',
+  dir = 'ltr',
   displayTimezone,
   adapter: adapterProp,
   labels: labelsProp,
@@ -199,6 +209,7 @@ export function DatePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      dir,
       displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
@@ -220,6 +231,7 @@ export function DatePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      dir,
       displayTimezone,
       isDisabled,
       readOnly,

--- a/packages/react/src/components/DatePicker/YearGrid.tsx
+++ b/packages/react/src/components/DatePicker/YearGrid.tsx
@@ -72,6 +72,7 @@ export function DatePickerYearGrid({ classNames, onSelect, ...props }: DatePicke
     onPageUp: () => navigateDecade(-1),
     onPageDown: () => navigateDecade(1),
     onEscape: ctx.close,
+    dir: ctx.dir,
   });
 
   const rangeLabel = `${decadeStart}–${decadeStart + 11}`;
@@ -102,6 +103,7 @@ export function DatePickerYearGrid({ classNames, onSelect, ...props }: DatePicke
         ref={gridRef}
         role="grid"
         aria-label={rangeLabel}
+        dir={ctx.dir}
         className={classNames?.grid}
         style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)' }}
         onKeyDown={handleKeyDown}

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -19,6 +19,7 @@ import type {
 } from '@kalyx/core';
 import { DatePickerContext } from '../../context/DatePickerContext.js';
 import type { DatePickerContextValue } from '../../context/DatePickerContext.js';
+import type { Direction } from '../_shared/rtl.js';
 import { TimePickerContext } from '../../context/TimePickerContext.js';
 import type { TimePickerContextValue, TimePickerFormat } from '../../context/TimePickerContext.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
@@ -79,6 +80,11 @@ export interface DateTimePickerRootProps {
   /** BCP 47 locale */
   locale?: string;
   /**
+   * Layout direction: "ltr" (default) or "rtl". Forwarded to the calendar grid,
+   * which swaps ArrowLeft/ArrowRight for RTL keyboard navigation.
+   */
+  dir?: Direction;
+  /**
    * IANA timezone used for display (e.g., "Asia/Seoul"). When set, Calendar highlights match
    * civil days in this zone, TimePicker reads/writes the time in this zone, and the Input
    * formats the combined date+time in this zone.
@@ -119,6 +125,7 @@ export function DateTimePickerRoot({
   weekStartsOn = 0,
   displayFormat = 'yyyy-MM-dd HH:mm',
   locale = 'en-US',
+  dir = 'ltr',
   displayTimezone,
   adapter: adapterProp,
   labels: labelsProp,
@@ -284,6 +291,7 @@ export function DateTimePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      dir,
       displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
@@ -306,6 +314,7 @@ export function DateTimePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      dir,
       displayTimezone,
       isDisabled,
       readOnly,

--- a/packages/react/src/components/MonthPicker/Grid.tsx
+++ b/packages/react/src/components/MonthPicker/Grid.tsx
@@ -123,6 +123,7 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
     onPageUp: () => navigateYear(-1),
     onPageDown: () => navigateYear(1),
     onEscape: ctx.close,
+    dir: ctx.dir,
   });
 
   return (
@@ -151,6 +152,7 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
         ref={gridRef}
         role="grid"
         aria-label={`${currentYear} months`}
+        dir={ctx.dir}
         className={classNames?.grid}
         onKeyDown={handleKeyDown}
       >

--- a/packages/react/src/components/MonthPicker/MonthPicker.test.tsx
+++ b/packages/react/src/components/MonthPicker/MonthPicker.test.tsx
@@ -501,3 +501,57 @@ describe('MonthPicker — localization', () => {
     expect(input).toHaveFocus();
   });
 });
+
+describe('MonthPicker — RTL (dir="rtl")', () => {
+  it('mirrors ArrowLeft/ArrowRight in the month grid', async () => {
+    const user = userEvent.setup();
+    render(
+      <MonthPicker value="2026-04-15T00:00:00.000Z" onChange={vi.fn()} dir="rtl">
+        <MonthPicker.Input aria-label="Select month" />
+        <MonthPicker.Popover>
+          <MonthPicker.Grid />
+        </MonthPicker.Popover>
+      </MonthPicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    screen.getByRole('gridcell', { name: 'April' }).focus();
+
+    // RTL: physically-left cell is the *next* (higher-index) month.
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: 'May' })).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}{ArrowRight}');
+    expect(screen.getByRole('gridcell', { name: 'March' })).toHaveFocus();
+  });
+
+  it('keeps ArrowUp/ArrowDown vertical (±3) in RTL', async () => {
+    const user = userEvent.setup();
+    render(
+      <MonthPicker value="2026-04-15T00:00:00.000Z" onChange={vi.fn()} dir="rtl">
+        <MonthPicker.Input aria-label="Select month" />
+        <MonthPicker.Popover>
+          <MonthPicker.Grid />
+        </MonthPicker.Popover>
+      </MonthPicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    screen.getByRole('gridcell', { name: 'April' }).focus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('gridcell', { name: 'July' })).toHaveFocus();
+  });
+
+  it('marks the month grid element with dir="rtl"', async () => {
+    const user = userEvent.setup();
+    render(
+      <MonthPicker value="2026-04-15T00:00:00.000Z" onChange={vi.fn()} dir="rtl">
+        <MonthPicker.Input aria-label="Select month" />
+        <MonthPicker.Popover>
+          <MonthPicker.Grid />
+        </MonthPicker.Popover>
+      </MonthPicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'rtl');
+  });
+});

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -10,6 +10,7 @@ import {
 } from '@kalyx/core';
 import type { CalendarDay, DateRange } from '@kalyx/core';
 import { useRangePickerContext } from '../../context/RangePickerContext.js';
+import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
 
 export interface RangePickerCalendarClassNames {
   root?: string;
@@ -89,6 +90,7 @@ export function RangePickerCalendar({
   } = ctx;
 
   const { locale } = ctx;
+  const dir = ctx.dir;
   // Memoized — see DatePicker/Calendar.tsx for the rationale.
   const weekdays = useMemo(() => getWeekdayNames(locale, weekStartsOn), [locale, weekStartsOn]);
 
@@ -208,50 +210,51 @@ export function RangePickerCalendar({
     (e: React.KeyboardEvent) => {
       let newFocused: string | null = null;
 
-      switch (e.key) {
-        case 'ArrowLeft':
-          newFocused = adapter.addDays(focusedDate, -1);
-          break;
-        case 'ArrowRight':
-          newFocused = adapter.addDays(focusedDate, 1);
-          break;
-        case 'ArrowUp':
-          newFocused = adapter.addDays(focusedDate, -7);
-          break;
-        case 'ArrowDown':
-          newFocused = adapter.addDays(focusedDate, 7);
-          break;
-        case 'PageUp':
-          newFocused = e.shiftKey
-            ? adapter.addYears(focusedDate, -1)
-            : adapter.addMonths(focusedDate, -1);
-          break;
-        case 'PageDown':
-          newFocused = e.shiftKey
-            ? adapter.addYears(focusedDate, 1)
-            : adapter.addMonths(focusedDate, 1);
-          break;
-        case 'Home':
-          newFocused = adapter.startOfWeek(focusedDate, weekStartsOn);
-          break;
-        case 'End':
-          newFocused = adapter.startOfDay(adapter.endOfWeek(focusedDate, weekStartsOn));
-          break;
-        case 'Enter':
-        case ' ':
-          e.preventDefault();
-          if (!isDateDisabled(focusedDate, disabled, adapter)) {
-            commitDay(focusedDate);
-          }
-          return;
-        case 'Escape':
-          // Stop the synthetic Escape from bubbling to a host modal/dialog.
-          e.preventDefault();
-          e.stopPropagation();
-          ctx.close();
-          return;
-        default:
-          return;
+      // RTL swaps the physical ArrowLeft/ArrowRight (WAI-ARIA grid follows visual
+      // layout). See _shared/rtl.ts.
+      const hStep = horizontalDayStep(e.key, dir);
+      if (hStep !== null) {
+        newFocused = adapter.addDays(focusedDate, hStep);
+      } else {
+        switch (e.key) {
+          case 'ArrowUp':
+            newFocused = adapter.addDays(focusedDate, -7);
+            break;
+          case 'ArrowDown':
+            newFocused = adapter.addDays(focusedDate, 7);
+            break;
+          case 'PageUp':
+            newFocused = e.shiftKey
+              ? adapter.addYears(focusedDate, -1)
+              : adapter.addMonths(focusedDate, -1);
+            break;
+          case 'PageDown':
+            newFocused = e.shiftKey
+              ? adapter.addYears(focusedDate, 1)
+              : adapter.addMonths(focusedDate, 1);
+            break;
+          case 'Home':
+            newFocused = adapter.startOfWeek(focusedDate, weekStartsOn);
+            break;
+          case 'End':
+            newFocused = adapter.startOfDay(adapter.endOfWeek(focusedDate, weekStartsOn));
+            break;
+          case 'Enter':
+          case ' ':
+            e.preventDefault();
+            if (!isDateDisabled(focusedDate, disabled, adapter)) {
+              commitDay(focusedDate);
+            }
+            return;
+          case 'Escape':
+            // Stop the synthetic Escape from bubbling to a host modal/dialog.
+            e.preventDefault();
+            e.stopPropagation();
+            ctx.close();
+            return;
+          default:
+            return;
+        }
       }
 
       if (newFocused) {
@@ -259,10 +262,7 @@ export function RangePickerCalendar({
 
         // WAI-ARIA grid pattern: skip disabled cells while keyboard-navigating.
         // Step in the original direction up to one full grid (42 cells) before giving up.
-        const skipStep =
-          e.key === 'ArrowLeft' || e.key === 'ArrowUp' || e.key === 'PageUp' || e.key === 'Home'
-            ? -1
-            : 1;
+        const skipStep = isBackwardKey(e.key, dir) ? -1 : 1;
         let attempts = 0;
         while (isDateDisabled(newFocused, disabled, adapter) && attempts < 42) {
           newFocused = adapter.addDays(newFocused, skipStep);
@@ -293,6 +293,7 @@ export function RangePickerCalendar({
       selectingTarget,
       value.start,
       commitDay,
+      dir,
     ],
   );
 
@@ -328,6 +329,7 @@ export function RangePickerCalendar({
         aria-label={title}
         aria-rowcount={weeks.length + 1}
         aria-colcount={7}
+        dir={dir}
         className={classNames?.grid}
         onKeyDown={handleKeyDown}
       >

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -887,3 +887,47 @@ describe('RangePicker.Popover — style merging', () => {
     expect(dialog.style.position).toBe('absolute');
   });
 });
+
+describe('RangePicker — RTL (dir="rtl")', () => {
+  it('marks the grid with dir="rtl" and mirrors horizontal navigation', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <RangePicker
+        value={{ start: '2026-01-15T00:00:00.000Z', end: null }}
+        onChange={onChange}
+        dir="rtl"
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+
+    await user.click(screen.getAllByRole('combobox')[0]);
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'rtl');
+
+    // RTL: physically-left cell is the *next* day.
+    await user.keyboard('{ArrowLeft}{Enter}');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ start: expect.stringMatching(/^2026-01-16T/) }),
+    );
+  });
+
+  it('defaults the grid to dir="ltr"', async () => {
+    const user = userEvent.setup();
+    render(
+      <RangePicker value={{ start: '2026-01-15T00:00:00.000Z', end: null }} onChange={vi.fn()}>
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+    await user.click(screen.getAllByRole('combobox')[0]);
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'ltr');
+  });
+});

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -18,6 +18,7 @@ import type {
   RangePickerContextValue,
   RangeSelectingTarget,
 } from '../../context/RangePickerContext.js';
+import type { Direction } from '../_shared/rtl.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
 import { SR_ONLY } from '../../internal/srOnly.js';
@@ -63,6 +64,11 @@ export interface RangePickerRootProps {
   /** BCP 47 locale */
   locale?: string;
   /**
+   * Layout direction: "ltr" (default) or "rtl". In "rtl" the calendar grid
+   * swaps ArrowLeft/ArrowRight for keyboard navigation and carries `dir="rtl"`.
+   */
+  dir?: Direction;
+  /**
    * IANA timezone for display (e.g., "Asia/Seoul"). When set, inputs format in this zone,
    * calendar highlighting uses civil-day comparison in this zone, and selected start/end are
    * emitted as civil midnight of the clicked day in this zone (UTC-ISO form).
@@ -87,6 +93,7 @@ export function RangePickerRoot({
   weekStartsOn: weekStartsOnProp,
   displayFormat = 'yyyy-MM-dd',
   locale = 'en-US',
+  dir = 'ltr',
   displayTimezone,
   adapter: adapterProp,
   labels: labelsProp,
@@ -240,6 +247,7 @@ export function RangePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      dir,
       displayTimezone,
       isDisabled,
       isReadOnly: readOnly,
@@ -264,6 +272,7 @@ export function RangePickerRoot({
       weekStartsOn,
       displayFormat,
       locale,
+      dir,
       displayTimezone,
       isDisabled,
       readOnly,

--- a/packages/react/src/components/YearPicker/Grid.tsx
+++ b/packages/react/src/components/YearPicker/Grid.tsx
@@ -124,6 +124,7 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
     onPageUp: () => navigateDecade(-1),
     onPageDown: () => navigateDecade(1),
     onEscape: ctx.close,
+    dir: ctx.dir,
   });
 
   const rangeLabel = `${decadeStart}–${decadeStart + 11}`;
@@ -154,6 +155,7 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
         ref={gridRef}
         role="grid"
         aria-label={rangeLabel}
+        dir={ctx.dir}
         className={classNames?.grid}
         onKeyDown={handleKeyDown}
       >

--- a/packages/react/src/components/YearPicker/YearPicker.test.tsx
+++ b/packages/react/src/components/YearPicker/YearPicker.test.tsx
@@ -425,3 +425,24 @@ describe('YearPicker — SSR safety', () => {
     expect(renderToString(tree)).toBe(renderToString(tree));
   });
 });
+
+describe('YearPicker — RTL (dir="rtl")', () => {
+  it('applies dir="rtl" to the year grid and mirrors index navigation', async () => {
+    const user = userEvent.setup();
+    render(
+      <YearPicker value="2026-01-01T00:00:00.000Z" onChange={vi.fn()} dir="rtl">
+        <YearPicker.Input aria-label="Select year" />
+        <YearPicker.Popover>
+          <YearPicker.Grid />
+        </YearPicker.Popover>
+      </YearPicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('grid')).toHaveAttribute('dir', 'rtl');
+
+    // 12-year block starts at 2016; focus 2026, RTL ArrowLeft → next year 2027.
+    screen.getByRole('gridcell', { name: '2026' }).focus();
+    await user.keyboard('{ArrowLeft}');
+    expect(screen.getByRole('gridcell', { name: '2027' })).toHaveFocus();
+  });
+});

--- a/packages/react/src/components/__tests__/rtl.test.ts
+++ b/packages/react/src/components/__tests__/rtl.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
+
+// Pure-function contract for the RTL keyboard helpers. In a WAI-ARIA date grid
+// the arrow keys follow the *physical* layout, so when the calendar is laid out
+// right-to-left the horizontal arrows must be mirrored. Vertical / page / Home
+// / End keys keep their logical direction regardless of layout.
+describe('rtl — horizontalDayStep', () => {
+  it('LTR: ArrowLeft = −1 day, ArrowRight = +1 day', () => {
+    expect(horizontalDayStep('ArrowLeft', 'ltr')).toBe(-1);
+    expect(horizontalDayStep('ArrowRight', 'ltr')).toBe(1);
+  });
+
+  it('RTL: ArrowLeft = +1 day, ArrowRight = −1 day (mirrored)', () => {
+    expect(horizontalDayStep('ArrowLeft', 'rtl')).toBe(1);
+    expect(horizontalDayStep('ArrowRight', 'rtl')).toBe(-1);
+  });
+
+  it('returns null for keys it does not own (vertical / page / home / other)', () => {
+    for (const dir of ['ltr', 'rtl'] as const) {
+      expect(horizontalDayStep('ArrowUp', dir)).toBeNull();
+      expect(horizontalDayStep('ArrowDown', dir)).toBeNull();
+      expect(horizontalDayStep('PageUp', dir)).toBeNull();
+      expect(horizontalDayStep('Home', dir)).toBeNull();
+      expect(horizontalDayStep('Enter', dir)).toBeNull();
+    }
+  });
+});
+
+describe('rtl — isBackwardKey', () => {
+  it('LTR: ArrowLeft/Up/PageUp/Home step backwards, ArrowRight forwards', () => {
+    expect(isBackwardKey('ArrowLeft', 'ltr')).toBe(true);
+    expect(isBackwardKey('ArrowRight', 'ltr')).toBe(false);
+    expect(isBackwardKey('ArrowUp', 'ltr')).toBe(true);
+    expect(isBackwardKey('PageUp', 'ltr')).toBe(true);
+    expect(isBackwardKey('Home', 'ltr')).toBe(true);
+    expect(isBackwardKey('ArrowDown', 'ltr')).toBe(false);
+  });
+
+  it('RTL: only the horizontal arrows flip; vertical/page/home keep logical direction', () => {
+    // Physically-left cell is a *later* date in RTL → ArrowLeft is forward.
+    expect(isBackwardKey('ArrowLeft', 'rtl')).toBe(false);
+    expect(isBackwardKey('ArrowRight', 'rtl')).toBe(true);
+    // Row / page / home are unaffected by layout direction.
+    expect(isBackwardKey('ArrowUp', 'rtl')).toBe(true);
+    expect(isBackwardKey('PageUp', 'rtl')).toBe(true);
+    expect(isBackwardKey('Home', 'rtl')).toBe(true);
+    expect(isBackwardKey('ArrowDown', 'rtl')).toBe(false);
+  });
+});

--- a/packages/react/src/components/_shared/grid-keyboard.ts
+++ b/packages/react/src/components/_shared/grid-keyboard.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import type { DateAdapter, DisabledRule, ISODateString } from '@kalyx/core';
+import type { Direction } from './rtl.js';
 
 /**
  * A range of dates `[start, end]` is "fully disabled" when every day in it is
@@ -40,6 +41,12 @@ export interface UseGridStateOptions {
   onPageDown: () => void;
   /** Escape — typically closes the popover. */
   onEscape: () => void;
+  /**
+   * Layout direction. In "rtl" the physical ArrowLeft/ArrowRight (and the
+   * disabled-cell skip step) are swapped so navigation follows visual layout.
+   * Defaults to "ltr".
+   */
+  dir?: Direction;
 }
 
 /**
@@ -58,20 +65,32 @@ export interface UseGridStateOptions {
  *   without an extra dependency.)
  */
 export function useGridState(opts: UseGridStateOptions) {
-  const { initialIndex, disabledFlags, onSelect, onPageUp, onPageDown, onEscape } = opts;
+  const {
+    initialIndex,
+    disabledFlags,
+    onSelect,
+    onPageUp,
+    onPageDown,
+    onEscape,
+    dir = 'ltr',
+  } = opts;
   const gridRef = useRef<HTMLDivElement>(null);
   const [focusedIndex, setFocusedIndex] = useState<number>(initialIndex);
+
+  const rtl = dir === 'rtl';
 
   const handleKeyDown = (e: KeyboardEvent) => {
     let next: number | null = null;
     let step = 1;
     switch (e.key) {
       case 'ArrowLeft':
-        next = Math.max(0, focusedIndex - 1);
-        step = -1;
+        // RTL: physically-left is the next (higher-index) cell.
+        next = rtl ? Math.min(11, focusedIndex + 1) : Math.max(0, focusedIndex - 1);
+        step = rtl ? 1 : -1;
         break;
       case 'ArrowRight':
-        next = Math.min(11, focusedIndex + 1);
+        next = rtl ? Math.max(0, focusedIndex - 1) : Math.min(11, focusedIndex + 1);
+        step = rtl ? -1 : 1;
         break;
       case 'ArrowUp':
         next = Math.max(0, focusedIndex - 3);

--- a/packages/react/src/components/_shared/rtl.ts
+++ b/packages/react/src/components/_shared/rtl.ts
@@ -1,0 +1,52 @@
+/** Layout direction for the picker. Mirrors the HTML `dir` attribute. */
+export type Direction = 'ltr' | 'rtl';
+
+/**
+ * In a WAI-ARIA date grid the arrow keys follow *physical* layout, not logical
+ * order. When the calendar is laid out right-to-left (`dir="rtl"`), the visually
+ * left cell is the *next* day and the visually right cell is the *previous* day,
+ * so ArrowLeft/ArrowRight must be swapped. ArrowUp/ArrowDown (row movement) and
+ * Home/End (start/end of the visual row) are unaffected — the grid still reads
+ * top-to-bottom and Home/End map to the week's first/last day via `weekStartsOn`.
+ *
+ * Returns the day offset for the four horizontal-relevant keys, or `null` for
+ * keys this helper doesn't own.
+ *
+ * @example
+ * // LTR: ArrowLeft = −1 day, ArrowRight = +1 day
+ * // RTL: ArrowLeft = +1 day, ArrowRight = −1 day
+ */
+export function horizontalDayStep(key: string, dir: Direction): number | null {
+  const rtl = dir === 'rtl';
+  switch (key) {
+    case 'ArrowLeft':
+      return rtl ? 1 : -1;
+    case 'ArrowRight':
+      return rtl ? -1 : 1;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether a navigation key moves focus "backwards" (towards earlier dates) for
+ * the disabled-cell skip loop. In RTL the physical ArrowLeft/ArrowRight are
+ * swapped, so this must account for `dir`; the vertical / page / Home keys keep
+ * their logical direction regardless of layout.
+ */
+export function isBackwardKey(key: string, dir: Direction): boolean {
+  const rtl = dir === 'rtl';
+  switch (key) {
+    case 'ArrowLeft':
+      // Physically-left cell is a *later* date in RTL, so it's forward there.
+      return !rtl;
+    case 'ArrowRight':
+      return rtl;
+    case 'ArrowUp':
+    case 'PageUp':
+    case 'Home':
+      return true;
+    default:
+      return false;
+  }
+}

--- a/packages/react/src/context/DatePickerContext.ts
+++ b/packages/react/src/context/DatePickerContext.ts
@@ -7,6 +7,7 @@ import type {
   ISODateString,
   WeekStartsOn,
 } from '@kalyx/core';
+import type { Direction } from '../components/_shared/rtl.js';
 
 export interface DatePickerContextValue {
   /** Floating UI reference element (set by Input/Trigger, read by Popover) */
@@ -48,6 +49,13 @@ export interface DatePickerContextValue {
   displayFormat: string;
   /** BCP 47 locale (e.g., "en-US", "ko-KR") */
   locale: string;
+  /**
+   * Layout direction ("ltr" | "rtl"). Defaults to "ltr". In "rtl" the calendar
+   * grid swaps ArrowLeft/ArrowRight so keyboard navigation follows the visual
+   * (physical) layout per the WAI-ARIA grid pattern, and the grid element
+   * carries `dir="rtl"` so consumers can style it.
+   */
+  dir: Direction;
   /**
    * IANA timezone for display (e.g., "Asia/Seoul"). When set, the Input formats the value in
    * this zone, Calendar highlights the matching civil day, and selecting a date emits the civil

--- a/packages/react/src/context/RangePickerContext.ts
+++ b/packages/react/src/context/RangePickerContext.ts
@@ -8,6 +8,7 @@ import type {
   RangePickerLabels,
   WeekStartsOn,
 } from '@kalyx/core';
+import type { Direction } from '../components/_shared/rtl.js';
 
 /** Which part to select next (start | end) */
 export type RangeSelectingTarget = 'start' | 'end';
@@ -47,6 +48,12 @@ export interface RangePickerContextValue {
   displayFormat: string;
   /** BCP 47 locale */
   locale: string;
+  /**
+   * Layout direction ("ltr" | "rtl"). Defaults to "ltr". In "rtl" the calendar
+   * grid swaps ArrowLeft/ArrowRight for keyboard navigation and the grid
+   * element carries `dir="rtl"`.
+   */
+  dir: Direction;
   /** IANA timezone for display (see DatePickerContext#displayTimezone) */
   displayTimezone?: string;
   /** Whether entire picker is disabled */

--- a/packages/react/src/headless.ts
+++ b/packages/react/src/headless.ts
@@ -131,6 +131,7 @@ export type {
 } from './hooks/useMonthPicker.js';
 export type { UseYearPickerOptions, UseYearPickerReturn, YearCell } from './hooks/useYearPicker.js';
 export type { UseWeekPickerOptions, UseWeekPickerReturn } from './hooks/useWeekPicker.js';
+export type { Direction } from './components/_shared/rtl.js';
 export type {
   UseDateTimePickerOptions,
   UseDateTimePickerReturn,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -98,6 +98,9 @@ export type { UseDatePickerOptions, UseDatePickerReturn } from './hooks/useDateP
 export type { UseRangePickerOptions, UseRangePickerReturn } from './hooks/useRangePicker.js';
 export type { UseTimePickerOptions, UseTimePickerReturn } from './hooks/useTimePicker.js';
 
+// Layout direction shared across all picker Roots (`dir` prop).
+export type { Direction } from './components/_shared/rtl.js';
+
 // Re-export the default adapter so consumers can `import { DateFnsAdapter } from '@kalyx/react'`
 // without pulling in the adapter package directly. Source lives in @kalyx/adapter-date-fns now.
 export { DateFnsAdapter } from '@kalyx/adapter-date-fns';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,6 +415,19 @@ importers:
         specifier: ^1.11.13
         version: 1.11.21
 
+  packages/adapter-luxon:
+    dependencies:
+      '@kalyx/core':
+        specifier: workspace:^
+        version: link:../core
+      luxon:
+        specifier: ^3.5.0
+        version: 3.7.2
+    devDependencies:
+      '@types/luxon':
+        specifier: ^3.4.2
+        version: 3.7.2
+
   packages/core:
     devDependencies:
       '@kalyx/adapter-date-fns':
@@ -3146,6 +3159,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/luxon@3.7.2':
+    resolution: {integrity: sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -5463,6 +5479,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -11714,6 +11734,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/luxon@3.7.2': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -14249,6 +14271,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
 

--- a/scripts/__tests__/verify-changesets.test.mjs
+++ b/scripts/__tests__/verify-changesets.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  globToRegExp,
+  isIgnored,
+  parseChangesetPackages,
+  findMixedChangesets,
+} from '../verify-changesets.mjs';
+
+const patterns = ['@kalyx/docs', 'docs-site', '@kalyx-example/*'].map((glob) => ({
+  glob,
+  re: globToRegExp(glob),
+}));
+
+describe('globToRegExp', () => {
+  it('matches an exact package name', () => {
+    expect(globToRegExp('@kalyx/docs').test('@kalyx/docs')).toBe(true);
+    expect(globToRegExp('@kalyx/docs').test('@kalyx/core')).toBe(false);
+  });
+
+  it('matches a scoped wildcard but not across the scope slash', () => {
+    const re = globToRegExp('@kalyx-example/*');
+    expect(re.test('@kalyx-example/datepicker-basic')).toBe(true);
+    expect(re.test('@kalyx-example/timepicker-12h')).toBe(true);
+    // The wildcard must not swallow the scope separator into a different scope.
+    expect(re.test('@kalyx/react')).toBe(false);
+  });
+});
+
+describe('isIgnored', () => {
+  it('flags docs + example packages, not publishable ones', () => {
+    expect(isIgnored('@kalyx/docs', patterns)).toBe(true);
+    expect(isIgnored('docs-site', patterns)).toBe(true);
+    expect(isIgnored('@kalyx-example/rangepicker-presets', patterns)).toBe(true);
+    expect(isIgnored('@kalyx/react', patterns)).toBe(false);
+    expect(isIgnored('@kalyx/adapter-luxon', patterns)).toBe(false);
+  });
+});
+
+describe('parseChangesetPackages', () => {
+  it('parses single-quoted frontmatter entries', () => {
+    const md = `---\n'@kalyx/react': minor\n---\n\nSome summary.`;
+    expect(parseChangesetPackages(md)).toEqual(['@kalyx/react']);
+  });
+
+  it('parses multiple packages and mixed quoting', () => {
+    const md = `---\n"@kalyx/core": patch\n'@kalyx/react': patch\n---\nbody`;
+    expect(parseChangesetPackages(md)).toEqual(['@kalyx/core', '@kalyx/react']);
+  });
+
+  it('returns empty for a changeset with no frontmatter', () => {
+    expect(parseChangesetPackages('just a body, no frontmatter')).toEqual([]);
+  });
+});
+
+describe('findMixedChangesets', () => {
+  it('passes when only publishable packages are bumped', () => {
+    const problems = findMixedChangesets(
+      [{ file: 'a.md', packages: ['@kalyx/react', '@kalyx/core'] }],
+      patterns,
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it('passes when only ignored packages are bumped', () => {
+    const problems = findMixedChangesets(
+      [{ file: 'a.md', packages: ['@kalyx-example/datepicker-basic'] }],
+      patterns,
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it('flags a changeset mixing ignored + publishable', () => {
+    const problems = findMixedChangesets(
+      [{ file: 'bad.md', packages: ['@kalyx/react', '@kalyx-example/datepicker-basic'] }],
+      patterns,
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0].file).toBe('bad.md');
+    expect(problems[0].ignored).toEqual(['@kalyx-example/datepicker-basic']);
+    expect(problems[0].publishable).toEqual(['@kalyx/react']);
+  });
+
+  it('ignores empty changesets', () => {
+    expect(findMixedChangesets([{ file: 'empty.md', packages: [] }], patterns)).toEqual([]);
+  });
+});

--- a/scripts/bundle-diff.mjs
+++ b/scripts/bundle-diff.mjs
@@ -2,10 +2,10 @@
 // scripts/bundle-diff.mjs
 //
 // Surfaces the *byte-level* bundle delta and remaining ceiling margin so a PR
-// author sees, before merge, exactly how much of the tight 16KB budget a change
-// consumes. The working headroom is small and CJS-bound (~126 B CJS / ~221 B
-// ESM as of v1.1.0), so a feature that costs "only a few hundred bytes" can
-// silently break the CI gate — this script makes that cost visible per PR.
+// author sees, before merge, exactly how much of the 17KB budget a change
+// consumes. The working headroom is CJS-bound (~901 B CJS / ~1033 B
+// ESM as of v1.2.0, ceiling 17KB), so a feature that costs "only a few hundred
+// bytes" can silently break the CI gate — this script makes that cost visible per PR.
 //
 // Measurement reuses getGzipBytes() from check-bundle-size.js, so base-vs-head
 // numbers share the exact same zlib defaults as the CI gate and the tsup

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -9,7 +9,7 @@
 // 3. CI (`.github/workflows/pr-check.yml` `bundle-size` job) invokes this
 //    script directly instead of running its own `gzip -c | wc -c` pipeline,
 //    so shell-gzip vs. Node-zlib defaults can't drift apart inside the
-//    tight 16KB margin (currently ~126 B on CJS / ~221 B on ESM — CJS binds).
+//    17KB margin (currently ~901 B on CJS / ~1033 B on ESM — CJS binds).
 //
 // When `$GITHUB_OUTPUT` is set, the script appends per-bundle gzip KB values
 // (kb_esm, kb_cjs) so the workflow can read them back for the PR comment
@@ -45,8 +45,8 @@ export const BUNDLES = [
 
 // Single source of truth for the gzip primitive. bundle-diff.mjs imports this
 // so base-vs-head deltas are measured with the exact same zlib defaults as the
-// CI gate and tsup post-build hook — no shell-gzip drift inside the tight
-// 16KB margin (~126 B CJS / ~221 B ESM).
+// CI gate and tsup post-build hook — no shell-gzip drift inside the
+// 17KB margin (~901 B CJS / ~1033 B ESM).
 export function getGzipBytes(filePath) {
 	return gzipSync(readFileSync(filePath)).length;
 }

--- a/scripts/verify-changesets.mjs
+++ b/scripts/verify-changesets.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// scripts/verify-changesets.mjs
+//
+// Pre-release guard against a specific changesets failure mode: a single
+// changeset that bumps BOTH an `ignore`d package and a publishable one.
+//
+// Per the changesets docs, when a package listed in `.changeset/config.json`
+// `ignore` is mentioned in a changeset that ALSO includes a non-ignored
+// package, `changeset publish` FAILS ("If the package is mentioned in a
+// changeset that also includes a package that is not ignored, publishing will
+// fail."). In this repo the ignore list covers docs + the `@kalyx-example/*`
+// demo apps, so a stray changeset touching, say, `@kalyx/react` and
+// `@kalyx-example/datepicker-basic` together would block the whole release.
+//
+// This script parses every `.changeset/*.md` frontmatter, resolves each named
+// package against the ignore globs, and fails early with a clear message if any
+// changeset mixes the two — turning an opaque mid-publish failure into an
+// actionable local/CI error. Runs in release.yml before the changesets action.
+//
+// Run locally: `node scripts/verify-changesets.mjs`
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const changesetDir = resolve(repoRoot, ".changeset");
+
+/** Minimal picomatch-style matcher for the `foo/*` and exact-name patterns
+ *  changesets `ignore` supports. We only need `*` (any run of non-empty chars,
+ *  including `/` — changesets uses picomatch defaults where `*` does not cross
+ *  `/`, but package names use `/` as a scope separator and the practical
+ *  patterns here are `@scope/*`, so we treat `*` greedily after the scope). */
+export function globToRegExp(glob) {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const pattern = "^" + escaped.replace(/\*/g, "[^/]+") + "$";
+  return new RegExp(pattern);
+}
+
+function loadIgnorePatterns() {
+  const configPath = resolve(changesetDir, "config.json");
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  const ignore = Array.isArray(config.ignore) ? config.ignore : [];
+  return ignore.map((g) => ({ glob: g, re: globToRegExp(g) }));
+}
+
+export function isIgnored(pkg, patterns) {
+  return patterns.some(({ re }) => re.test(pkg));
+}
+
+/** Parse the `---`-delimited YAML frontmatter of a changeset into a list of
+ *  `"pkg": bump` package names. Changeset frontmatter is a flat map of quoted
+ *  package name → semver bump, so a line-based parse is sufficient and avoids a
+ *  YAML dependency. */
+export function parseChangesetPackages(contents) {
+  const match = contents.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return [];
+  const body = match[1];
+  const packages = [];
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // e.g.  '@kalyx/react': minor   or   "@kalyx/react": patch
+    const m = trimmed.match(/^['"]?([^'":]+)['"]?\s*:\s*(major|minor|patch)\s*$/);
+    if (m) packages.push(m[1]);
+  }
+  return packages;
+}
+
+/** Pure core: given a list of `{ file, packages }` and ignore patterns, return
+ *  the changesets that illegally mix an ignored package with a publishable one. */
+export function findMixedChangesets(changesets, patterns) {
+  const problems = [];
+  for (const { file, packages } of changesets) {
+    if (!packages || packages.length === 0) continue;
+    const ignored = packages.filter((p) => isIgnored(p, patterns));
+    const publishable = packages.filter((p) => !isIgnored(p, patterns));
+    if (ignored.length > 0 && publishable.length > 0) {
+      problems.push({ file, ignored, publishable });
+    }
+  }
+  return problems;
+}
+
+function main() {
+  if (!existsSync(changesetDir)) {
+    console.log("No .changeset directory — nothing to verify.");
+    return;
+  }
+
+  const patterns = loadIgnorePatterns();
+  const files = readdirSync(changesetDir).filter(
+    (f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md",
+  );
+
+  const changesets = files.map((file) => ({
+    file,
+    packages: parseChangesetPackages(readFileSync(resolve(changesetDir, file), "utf8")),
+  }));
+
+  const problems = findMixedChangesets(changesets, patterns);
+
+  if (problems.length > 0) {
+    console.error("\n❌ Changeset validation failed.\n");
+    console.error(
+      "A changeset must not mix an ignored package with a publishable one —\n" +
+        "`changeset publish` would fail mid-release. Split these into separate\n" +
+        "changesets (or drop the ignored package from the changeset):\n",
+    );
+    for (const { file, ignored, publishable } of problems) {
+      console.error(`  .changeset/${file}`);
+      console.error(`    ignored:     ${ignored.join(", ")}`);
+      console.error(`    publishable: ${publishable.join(", ")}\n`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ Changeset validation passed (${files.length} changeset file(s), no ignored/publishable mix).`,
+  );
+}
+
+// Only run the file-scanning entrypoint when invoked directly, so tests can
+// import the pure helpers without side effects.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary

Three related pieces of work from the current-state analysis (AGENTS.md §14 Track B/C + cleanup):

1. **`@kalyx/adapter-luxon` (Track B / B3)** — a luxon-backed `DateAdapter`, the third prebuilt backend alongside date-fns and dayjs. UTC-pinned, timezone work delegated to `@kalyx/core`, validated against the shared `@kalyx/core/test-helpers` conformance suite (21/21).
2. **RTL support via `dir` prop (Track C / TC-M4)** — `dir="ltr" | "rtl"` on every picker Root. In RTL the grid carries `dir="rtl"` and mirrors ArrowLeft/ArrowRight per the WAI-ARIA grid pattern; vertical/page/Home/End keep logical direction. Includes a **bug fix found in review**: the 4 month/year `<div role="grid">` elements were missing the `dir` attribute (keyboard ran RTL while the DOM declared no direction).
3. **`verify-changesets.mjs` release guard (cleanup #3)** — fails early when a changeset mixes an `ignore`d package (docs / `@kalyx-example/*`) with a publishable one, which would otherwise break `changeset publish` mid-release.

## Commits

- `ci(release)`: changeset ignored/publishable mix guard + tests, `@kalyx-example/*` added to ignore list
- `feat(adapter-luxon)`: new package + conformance test + changeset
- `feat(react)`: `dir` prop across all pickers, grid-element `dir` bug fix, RTL tests, docs (en + ko), adapters-guide luxon entries, bundle-script comment refresh

## Verification

- `pnpm test:run` — **737 passed** (incl. new RTL unit + integration + regression tests)
- `pnpm typecheck` / `pnpm lint` — clean
- Bundle: ESM 16.25KB / CJS 16.34KB gzip (≤ 17KB ceiling)
- luxon conformance: 21/21
- `node scripts/verify-changesets.mjs` — passes (2 changesets, no mix)

## Changesets

- `@kalyx/adapter-luxon`: minor (new package)
- `@kalyx/react`: minor (`dir` prop)

## Notes

- TimePicker intentionally has no `dir` prop (no calendar grid to mirror).
- The i18n RTL docs were corrected: ancestor `dir` handles CSS mirroring, the Root `dir` prop is what mirrors arrow-key navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RTL 레이아웃 지원이 추가되어 피커에서 `ltr`/`rtl` 방향을 지정할 수 있게 되었습니다.
  * Luxon 기반 날짜 어댑터가 새로 제공되어 선택형 백엔드로 사용할 수 있습니다.

* **Bug Fixes**
  * RTL에서 화살표 키 이동과 비활성 날짜 건너뛰기 동작이 시각적 방향에 맞게 개선되었습니다.

* **Documentation**
  * DatePicker, RangePicker, MonthPicker, WeekPicker, YearPicker, DateTimePicker 및 국제화/어댑터 가이드를 업데이트했습니다.

* **Chores**
  * 릴리스 전에 Changeset 구성을 사전 검증하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->