### PR TITLE
docs(agents): log 2026-07-08 session (PR #162 luxon/RTL/changeset guard)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -587,6 +587,16 @@ pnpm changeset publish # npm 배포 (CI 자동)
 
 ## 14. 현재 이니셔티브 (2026-06-18 기준 — Track A 종료, "정확성 먼저" 방향 확정)
 
+> **🟢 2026-07-08 최근 작업 로그 (세션 메모리):**
+> - **PR #162 머지 완료** — `@kalyx/adapter-luxon` + RTL 지원 + release changeset 가드를 한 PR 3커밋으로 묶어 `--squash --admin` 머지(승인 리뷰 부재 + main 1명 승인 보호라 admin 필요, 이 레포 관행). 머지 커밋 `03f1037`. **아직 npm publish 전** — changeset 2건(`@kalyx/adapter-luxon` minor 신규, `@kalyx/react` minor)이 main 에 있으니 다음 release.yml 실행 때 Version PR 생성될 것. dist-tag `latest` 는 여전히 1.2.0.
+>   - **B3 완료 — `@kalyx/adapter-luxon@0.1.0`**: luxon 백엔드 `DateAdapter`(UTC 고정), timezone 은 `@kalyx/core` 위임, `@kalyx/core/test-helpers` conformance 21/21 통과(3번째 백엔드). date-fns/dayjs 와 동일한 8-토큰 `format` 제한 공유(시스템 공통, luxon 특유 결함 아님). `toISO` 의 `+00:00→Z` regex 는 luxon 3.x 에선 dead-code(무해, 안전망).
+>   - **TC-M4 완료 — RTL `dir` prop**: 6개 picker Root(DatePicker/RangePicker/DateTimePicker/MonthPicker/YearPicker/WeekPicker)에 `dir="ltr"|"rtl"`. RTL 시 grid 에 `dir` 스탬프 + ArrowLeft/Right 물리 스왑(WAI-ARIA grid; 세로/PageUp·Down/Home·End 는 논리방향 유지), disabled-skip 방향 인식. `_shared/rtl.ts`(horizontalDayStep·isBackwardKey) + grid-keyboard.ts 인덱스 스왑. `Direction` 타입 main+/headless export. **TimePicker 는 캘린더 grid 없어 의도적으로 `dir` 미지원.**
+>   - **리뷰 중 버그 발견·수정(MODERATE)**: MonthGrid/YearGrid/MonthPicker/YearPicker 의 `<div role="grid">` 4곳에 `dir` 속성 누락(키보드는 RTL 인데 DOM 엔 방향 선언 없어 AT 열순서·CSS 미러링 깨짐). day 캘린더 `<table>` 은 정상이었음. → 4곳 `dir={ctx.dir}` + 회귀 테스트 4건 추가.
+>   - **cleanup #3 완료 — `scripts/verify-changesets.mjs`**: ignored(`docs`/`@kalyx-example/*`)+publishable 혼합 changeset 을 release 전 차단(그대로 두면 `changeset publish` 가 중도 실패). `release.yml` 에 step 추가. `.changeset/config.json` ignore 에 `@kalyx-example/*` 추가. 순수 헬퍼 단위테스트 포함. → §14 "v1.0 직후 처리 필요" 3번의 **남은 부분(ignored changeset publish 차단 사전검증) 이제 완료**.
+>   - **문서(docs-site en+ko)**: `dir` prop 을 DatePicker/RangePicker/DateTimePicker props 표 + MonthPicker/YearPicker/WeekPicker 상속 명시. internationalization RTL 섹션을 "조상 `dir`=CSS 미러링 / Root `dir` prop=화살표키 미러링" 2계층으로 정정(기존 설명이 화살표 스왑을 조상 dir 로 오도). adapters 가이드/concepts/api 에 `@kalyx/adapter-luxon`·`-dayjs` 를 실제 패키지로 등재(기존엔 "가상 예시"였음) + `@kalyx/core/test-helpers` conformance 안내.
+>   - **CI 함정 기록(다음 세션 주의)**: ko `internationalization.md` 헤딩에 Docusaurus 커스텀 id `{#right-to-left-rtl}` 를 붙였더니 **MDX 가 `{...}` 를 JS 표현식으로 파싱하려다 acorn 에러 → ko Docusaurus build 실패**(en 은 커스텀 id 없어 무사). 커스텀 id 제거 + ko 컴포넌트 문서 앵커를 자동 slug `#오른쪽-왼쪽-rtl` 로 교체해 해결(PR 두번째 push `fix(docs)`). **교훈: 한글 헤딩 + `{#custom-id}` 조합 금지.** docs-site 변경 시 `pnpm --filter docs-site build` 로컬 검증 필수(en+ko 둘 다).
+> - **남은 후속(다음 세션 후보)**: (a) release.yml 다음 실행으로 luxon/RTL Version PR → publish 마무리. (b) B1 `@kalyx/adapter-dayjs` 는 이미 존재하나 npm 미배포 상태인지 재확인. (c) `@kalyx/adapter-luxon` npmjs Trusted Publisher(OIDC) 등록 — date-fns 와 동일 이슈(§14 cleanup #1,2). (d) 남은 Track C: fast-check 속성테스트(최우선), `DisabledRule` per-picker narrowing, e2e locale/mid-flight prop 확장.
+
 > **🟢 2026-06-26 최근 작업 로그 (세션 메모리):**
 > - **1.2.0 정식 npm 배포 완료** — `@kalyx/core@1.2.0` + `@kalyx/react@1.2.0` publish (dist-tag `latest`). 내용: **B5**(DateTimePicker.Presets/.Preset on `/headless`) + **B7**(weekStartsOn locale 추론). GitHub Release 2건 자동 생성. (`@kalyx-example/*` 는 private 0.0.x, publish 안 됨.) Changesets action 정상 동작.
 > - **`release.yml` 번들 게이트 버그 수정 (PR #160)** — stale 인라인 `MAX=16` + shell `gzip -c` 가 ESM 16.02KB 를 17KB 천장(B10) 후에도 막아 1.2.0 release 가 #158/#159 푸시마다 실패하고 있었음. → 정식 `node scripts/check-bundle-size.js`(`TARGET_KB=17`) 호출로 교체. 이게 **release 가 막혀 있던 근본 원인**이었음. (§14 "v1.0 직후 처리 필요" 3번 부분 완료.)
@@ -641,7 +651,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 |---|---|---|
 | B1 | `@kalyx/adapter-dayjs` 출시 (P0) | Mantine + ~50% dayjs 사용자에게 drop-in headless 옵션 |
 | B2 | `@kalyx/core/test-helpers` 어댑터 conformance test suite | B1/B3/B6 unblock — adapter 작성자 테스트 부담 제거 |
-| B3 | `@kalyx/adapter-luxon` | B2 후 비용 낮음. enterprise/timezone 사용자 |
+| ~~B3~~ | ~~`@kalyx/adapter-luxon`~~ → **완료** (PR #162, 2026-07-08) | B2 후 비용 낮음. luxon 백엔드 `DateAdapter`, conformance 21/21 통과(3번째 백엔드). npm publish 는 다음 release PR 대기 |
 | B4 | `useMonthPicker` / `useYearPicker` / `useWeekPicker` / `useDateTimePicker` hooks (`/headless` 전용) | audit API-G1. 기본 entry 번들 압력 회피 |
 | ~~B5~~ | ~~`DateTimePicker.Presets` (`/headless`에서 RangePicker.Presets 패턴 재사용)~~ → **완료** | audit API-G2 — `DateTimePicker.Presets`/`.Preset` 가 datetime 전체(날짜+시간)를 원자적으로 커밋. `/headless` 전용 배치(기본 엔트리 천장 회피), `selectDateTime` Root 메서드는 양쪽 엔트리 공통 (+~40 B CJS) |
 | ~~B6~~ | ~~`@kalyx/adapter-temporal@0.x`~~ → **드롭** (2026-06-18) | 정확성 0 검증: 어댑터 인터페이스는 ISO-string in/out이라 Temporal 역량 운반 불가, core Intl로 재위임. 홍보 접어 optics 청중도 없음. Temporal **전략**은 core 레벨 Track D demand-gate로 보존 |
@@ -653,7 +663,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 
 ### Track C — v1.2 (다음 분기)
 
-- RTL 지원 + 테스트 (audit TC-M4)
+- ~~RTL 지원 + 테스트 (audit TC-M4)~~ → **완료** (PR #162, 2026-07-08). 6개 picker Root `dir` prop, grid 화살표키 물리 스왑 + `dir` 스탬프, MonthGrid/YearGrid/MonthPicker/YearPicker grid 요소 `dir` 누락 버그 수정, en+ko 문서화. TimePicker 는 grid 없어 미지원.
 - ~~`fast-check` property test 도입 (audit TC-H2)~~ → **#1로 끌어올림** (2026-06-18, 1.0.4 patch — 해자 강화 최우선). 2026-06-18 spec 참조
 - `DisabledRule` 타입 narrowing per picker 또는 시맨틱 명시 (audit API-G3)
 - e2e 확장: mid-flight prop 변경, locale switch


### PR DESCRIPTION
Records the 2026-07-08 session in AGENTS.md §14 (session memory), following the same convention as PR #161.

## What this logs

- **PR #162 merged** (`03f1037`): `@kalyx/adapter-luxon` (B3) + RTL `dir` prop (TC-M4) + verify-changesets release guard (cleanup #3).
- **Bug found & fixed in review**: MonthGrid/YearGrid/MonthPicker/YearPicker `<div role="grid">` were missing the `dir` attribute.
- Marks **B3** and **Track C RTL** as done in the roadmap tables.
- **CI pitfall recorded** for the next session: a Korean heading with a Docusaurus `{#custom-id}` breaks the ko MDX build (acorn parse error). Always run `pnpm --filter docs-site build` (en + ko) after docs changes.
- **Pending follow-up**: luxon/RTL are not yet published to npm; the next `release.yml` run will open a Version PR (dist-tag `latest` stays 1.2.0 until then).

Docs-only change; no code touched.