### PR TITLE
test(core): property-based tests for time + locale utils

### DIFF
--- a/packages/core/src/__tests__/locale.property.test.ts
+++ b/packages/core/src/__tests__/locale.property.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { getWeekdayNames, getWeekStartForLocale, getMonthName } from '../utils/locale.js';
+
+// Property-based hardening of the Intl-backed locale layer. Intl output itself
+// is engine-dependent, so these assert only the *structural* invariants the
+// callers rely on — count, ordering, non-emptiness, and the 0|1 codomain — over
+// a spread of real BCP-47 tags rather than pinning one locale's exact strings.
+
+const localeTag = () =>
+  fc.constantFrom(
+    'en-US',
+    'en-GB',
+    'ko-KR',
+    'ja-JP',
+    'de-DE',
+    'fr-FR',
+    'es-ES',
+    'zh-CN',
+    'ar-SA',
+    'he-IL',
+    'ru-RU',
+    'pt-BR',
+  );
+
+const weekStart = () => fc.constantFrom<0 | 1>(0, 1);
+
+describe('getWeekdayNames structure (property-based)', () => {
+  it('always returns exactly 7 entries with non-empty short/full names', () => {
+    fc.assert(
+      fc.property(localeTag(), weekStart(), (locale, ws) => {
+        const days = getWeekdayNames(locale, ws);
+        expect(days).toHaveLength(7);
+        for (const d of days) {
+          expect(d.short.length).toBeGreaterThan(0);
+          expect(d.full.length).toBeGreaterThan(0);
+        }
+      }),
+    );
+  });
+
+  it('weekStartsOn=1 is the Sunday-first order rotated left by one', () => {
+    fc.assert(
+      fc.property(localeTag(), (locale) => {
+        const sundayFirst = getWeekdayNames(locale, 0);
+        const mondayFirst = getWeekdayNames(locale, 1);
+        // Monday-first = [Mon..Sat, Sun] = sundayFirst[1..6] + sundayFirst[0].
+        const rotated = [...sundayFirst.slice(1), sundayFirst[0]];
+        expect(mondayFirst).toEqual(rotated);
+      }),
+    );
+  });
+
+  it('the two orderings are permutations of the same 7 names', () => {
+    fc.assert(
+      fc.property(localeTag(), (locale) => {
+        const a = getWeekdayNames(locale, 0)
+          .map((d) => d.full)
+          .sort();
+        const b = getWeekdayNames(locale, 1)
+          .map((d) => d.full)
+          .sort();
+        expect(a).toEqual(b);
+      }),
+    );
+  });
+});
+
+describe('getWeekStartForLocale codomain (property-based)', () => {
+  it('always returns 0 or 1, for both known tags and arbitrary strings', () => {
+    fc.assert(
+      fc.property(fc.oneof(localeTag(), fc.string()), (locale) => {
+        const result = getWeekStartForLocale(locale);
+        expect(result === 0 || result === 1).toBe(true);
+      }),
+    );
+  });
+
+  it('is deterministic per locale (stable across repeated calls / cache)', () => {
+    fc.assert(
+      fc.property(localeTag(), (locale) => {
+        expect(getWeekStartForLocale(locale)).toBe(getWeekStartForLocale(locale));
+      }),
+    );
+  });
+});
+
+describe('getMonthName structure (property-based)', () => {
+  it('returns a non-empty name for every month 0..11', () => {
+    fc.assert(
+      fc.property(localeTag(), fc.integer({ min: 0, max: 11 }), (locale, month) => {
+        expect(getMonthName(month, locale).length).toBeGreaterThan(0);
+      }),
+    );
+  });
+});

--- a/packages/core/src/__tests__/time.property.test.ts
+++ b/packages/core/src/__tests__/time.property.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  setTime,
+  getTime,
+  parseTimeString,
+  formatTimeString,
+  to12Hour,
+  to24Hour,
+  generateHours,
+  generateMinutes,
+  isSameTime,
+} from '../utils/time.js';
+import type { TimeValue } from '../utils/time.js';
+
+// Property-based hardening of the time-of-day layer (the third leg of the
+// timezone -> calendar -> date sweep). The time utils are pure and total over
+// small integer domains, which makes their algebraic laws — round-trips,
+// bijections, idempotence — cheap to state and expensive to violate. Example
+// tests pin a handful of clock values; these assert the laws across the whole
+// 24h x 60m x 60s space plus every AM/PM hour and every minute step.
+
+const hours = () => fc.integer({ min: 0, max: 23 });
+const minutes = () => fc.integer({ min: 0, max: 59 });
+const seconds = () => fc.integer({ min: 0, max: 59 });
+
+const timeValue = (): fc.Arbitrary<TimeValue> =>
+  fc.record({ hours: hours(), minutes: minutes(), seconds: seconds() });
+
+// A UTC instant that is not a leap-second-adjacent edge, so the H/M/S we read
+// back are exactly the H/M/S we wrote.
+const isoInstant = () =>
+  fc
+    .date({
+      min: new Date('1970-01-01T00:00:00.000Z'),
+      max: new Date('2060-01-01T00:00:00.000Z'),
+      noInvalidDate: true,
+    })
+    .map((d) => d.toISOString());
+
+describe('setTime / getTime round-trip (property-based)', () => {
+  it('getTime reads back exactly what setTime wrote', () => {
+    fc.assert(
+      fc.property(isoInstant(), timeValue(), (iso, time) => {
+        const stamped = setTime(iso, time);
+        expect(getTime(stamped)).toEqual(time);
+      }),
+    );
+  });
+
+  it('setTime only touches the time-of-day, never the calendar date', () => {
+    fc.assert(
+      fc.property(isoInstant(), timeValue(), (iso, time) => {
+        const stamped = setTime(iso, time);
+        // The UTC date portion (YYYY-MM-DD) is preserved because every field we
+        // set is in-range (0-23 / 0-59), so no field ever overflows into the day.
+        expect(stamped.slice(0, 10)).toBe(iso.slice(0, 10));
+      }),
+    );
+  });
+
+  it('setTime is idempotent for a fully-specified TimeValue', () => {
+    fc.assert(
+      fc.property(isoInstant(), timeValue(), (iso, time) => {
+        const once = setTime(iso, time);
+        const twice = setTime(once, time);
+        expect(twice).toBe(once);
+      }),
+    );
+  });
+
+  it('a partial setTime leaves the omitted fields untouched', () => {
+    fc.assert(
+      fc.property(isoInstant(), hours(), (iso, h) => {
+        const before = getTime(iso);
+        const after = getTime(setTime(iso, { hours: h }));
+        expect(after.hours).toBe(h);
+        expect(after.minutes).toBe(before.minutes);
+        expect(after.seconds).toBe(before.seconds);
+      }),
+    );
+  });
+});
+
+describe('to12Hour / to24Hour bijection (property-based)', () => {
+  it('to24Hour(to12Hour(h)) is the identity over 0..23', () => {
+    fc.assert(
+      fc.property(hours(), (h) => {
+        const { hours12, period } = to12Hour(h);
+        expect(to24Hour(hours12, period)).toBe(h);
+      }),
+    );
+  });
+
+  it('to12Hour always yields a 12-hour clock value in 1..12', () => {
+    fc.assert(
+      fc.property(hours(), (h) => {
+        const { hours12 } = to12Hour(h);
+        expect(hours12).toBeGreaterThanOrEqual(1);
+        expect(hours12).toBeLessThanOrEqual(12);
+      }),
+    );
+  });
+
+  it('period is AM strictly below noon and PM at/above noon', () => {
+    fc.assert(
+      fc.property(hours(), (h) => {
+        const { period } = to12Hour(h);
+        expect(period).toBe(h < 12 ? 'AM' : 'PM');
+      }),
+    );
+  });
+
+  it('to12Hour(to24Hour(h12, period)) round-trips the 12-hour form', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 12 }),
+        fc.constantFrom<'AM' | 'PM'>('AM', 'PM'),
+        (h12, period) => {
+          const h24 = to24Hour(h12, period);
+          expect(to12Hour(h24)).toEqual({ hours12: h12, period });
+        },
+      ),
+    );
+  });
+
+  it('to12Hour throws for any integer outside 0..23', () => {
+    fc.assert(
+      fc.property(
+        fc.integer().filter((n) => n < 0 || n > 23),
+        (bad) => {
+          expect(() => to12Hour(bad)).toThrow(RangeError);
+        },
+      ),
+    );
+  });
+
+  it('to24Hour throws for any 12-hour value outside 1..12', () => {
+    fc.assert(
+      fc.property(
+        fc.integer().filter((n) => n < 1 || n > 12),
+        fc.constantFrom<'AM' | 'PM'>('AM', 'PM'),
+        (bad, period) => {
+          expect(() => to24Hour(bad, period)).toThrow(RangeError);
+        },
+      ),
+    );
+  });
+});
+
+describe('parseTimeString / formatTimeString round-trip (property-based)', () => {
+  it('parseTimeString(formatTimeString(t, true)) recovers the TimeValue', () => {
+    fc.assert(
+      fc.property(timeValue(), (t) => {
+        const formatted = formatTimeString(t, true); // HH:MM:SS
+        expect(parseTimeString(formatted)).toEqual(t);
+      }),
+    );
+  });
+
+  it('the HH:MM form round-trips with seconds defaulting to 0', () => {
+    fc.assert(
+      fc.property(hours(), minutes(), (h, m) => {
+        const formatted = formatTimeString({ hours: h, minutes: m, seconds: 0 }, false);
+        expect(parseTimeString(formatted)).toEqual({ hours: h, minutes: m, seconds: 0 });
+      }),
+    );
+  });
+
+  it('formatTimeString always zero-pads to a fixed width', () => {
+    fc.assert(
+      fc.property(timeValue(), (t) => {
+        expect(formatTimeString(t, false)).toMatch(/^\d{2}:\d{2}$/);
+        expect(formatTimeString(t, true)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+      }),
+    );
+  });
+
+  it('parseTimeString rejects any hour/minute/second outside its clock range', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 24, max: 99 }), minutes(), (badHour, m) => {
+        expect(parseTimeString(`${badHour}:${String(m).padStart(2, '0')}`)).toBeNull();
+      }),
+    );
+  });
+});
+
+describe('generateHours / generateMinutes structure (property-based)', () => {
+  it('generateMinutes(step) is a strictly increasing multiples-of-step list within 0..59', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 60 }), (step) => {
+        const list = generateMinutes(step);
+        expect(list[0]).toBe(0);
+        for (let i = 0; i < list.length; i++) {
+          expect(list[i]).toBe(i * step);
+          expect(list[i]).toBeLessThan(60);
+        }
+        // The list is exactly ceil(60/step) long.
+        expect(list.length).toBe(Math.ceil(60 / step));
+      }),
+    );
+  });
+
+  it('generateMinutes throws outside 1..60', () => {
+    fc.assert(
+      fc.property(
+        fc.integer().filter((n) => n < 1 || n > 60),
+        (bad) => {
+          expect(() => generateMinutes(bad)).toThrow();
+        },
+      ),
+    );
+  });
+
+  it('generateHours yields the canonical 24h or 12h ranges', () => {
+    expect(generateHours('24h')).toEqual(Array.from({ length: 24 }, (_, i) => i));
+    expect(generateHours('12h')).toEqual(Array.from({ length: 12 }, (_, i) => i + 1));
+  });
+});
+
+describe('isSameTime is an equivalence relation (property-based)', () => {
+  it('is reflexive', () => {
+    fc.assert(
+      fc.property(timeValue(), (t) => {
+        expect(isSameTime(t, t)).toBe(true);
+      }),
+    );
+  });
+
+  it('is symmetric', () => {
+    fc.assert(
+      fc.property(timeValue(), timeValue(), (a, b) => {
+        expect(isSameTime(a, b)).toBe(isSameTime(b, a));
+      }),
+    );
+  });
+
+  it('agrees with structural equality of all three fields', () => {
+    fc.assert(
+      fc.property(timeValue(), timeValue(), (a, b) => {
+        const structural =
+          a.hours === b.hours && a.minutes === b.minutes && a.seconds === b.seconds;
+        expect(isSameTime(a, b)).toBe(structural);
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds fast-check property tests for the two remaining pure `@kalyx/core` modules that lacked them — `time` and `locale`. Calendar and timezone were already covered by #143 and #140; this completes the property sweep across the pure-function surface.

### time (`time.property.test.ts`)
- `setTime`/`getTime` round-trip; `setTime` never crosses a date boundary and is idempotent for a full `TimeValue`
- `to12Hour`/`to24Hour` bijection over the full `0..23` domain, AM/PM boundary, and `RangeError` on out-of-range input
- `parseTimeString`/`formatTimeString` round-trip + fixed zero-padded width
- `generateMinutes(step)` multiples-of-step structure (`ceil(60/step)` length); throws outside `1..60`
- `isSameTime` as an equivalence relation (reflexive, symmetric, agrees with structural equality)

### locale (`locale.property.test.ts`)
- `getWeekdayNames`: exactly 7 non-empty entries; `weekStartsOn=1` is a left-rotate of the Sunday-first order; both orderings are permutations of the same names
- `getWeekStartForLocale`: `0|1` codomain over arbitrary strings + per-locale determinism
- `getMonthName`: non-empty for every month `0..11`

Intl output is engine-dependent, so the locale suite asserts only the **structural** invariants callers rely on, not exact localized strings.

## Scope

Test-only — no runtime or public-API change (**bundle-0**). Follows the changeset-free convention of the prior property-test PRs (#140, #143).

## Verification

`pnpm test:run` (763 pass), `pnpm typecheck`, `pnpm lint` all green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 날짜/시간 및 로케일 유틸에 대한 property-based 테스트가 추가되었습니다.
  * 요일/월 이름, 주 시작 요일, 시간 변환, 문자열 파싱·포맷, 분·시 생성, 시간 비교의 핵심 동작이 다양한 입력에서 일관되게 유지되는지 검증합니다.
  * 정상 범위 반환, 왕복 변환, 비어 있지 않은 결과, 결정적 동작, 예외 처리 같은 불변식이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->