### PR TITLE
fix(datepicker): 타입드 input이 disabled/min-max 검증을 우회하는 버그 수정 (HIGH-1)

### DIFF
--- a/.changeset/typed-input-disabled-validation.md
+++ b/.changeset/typed-input-disabled-validation.md
@@ -1,0 +1,13 @@
+---
+"@kalyx/react": patch
+---
+
+fix(datepicker): enforce disabled/min-max rules on typed input commits
+
+Typing a date into `DatePicker.Input` (and `MonthPicker`/`YearPicker`, which reuse it)
+committed the value without checking the `disabled` rules — a weekend, out-of-range, or
+otherwise-disabled date that the calendar grid blocks on click could still be entered by
+typing and blurring. `selectDate` now runs the same `isDateDisabled` check the grid uses on
+every commit path, so the `disabled` (and `{ before }`/`{ after }` min-max) contract holds
+regardless of how the value is entered. Clearing the field (empty input → `null`) is
+unaffected.

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { DatePicker } from './index.js';
+import type { DatePickerRootProps } from './Root.js';
 
 function renderDatePicker(
   props: {
@@ -1560,5 +1561,55 @@ describe('DatePicker — RTL (dir="rtl")', () => {
     // RTL: physically-left cell is the *next* (higher-index) year → 2027.
     await user.keyboard('{ArrowLeft}');
     expect(screen.getByRole('gridcell', { name: '2027' })).toHaveFocus();
+  });
+});
+
+describe('DatePicker — typed input honors disable/min-max rules (HIGH-1 regression)', () => {
+  // 2026-01-01 is a Thursday, so 2026-01-17 is a Saturday and 2026-01-18 a Sunday.
+  // The Input commits on change (per-keystroke), so fireEvent.change with the full
+  // string exercises the exact commit path the calendar grid guards but the input did not.
+  function renderWithRules(disabled: DatePickerRootProps['disabled'], onChange = vi.fn()) {
+    render(
+      <DatePicker onChange={onChange} disabled={disabled}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    return onChange;
+  }
+
+  it('does not commit a typed date that violates a dayOfWeek rule', () => {
+    const onChange = renderWithRules([{ dayOfWeek: [0, 6] }]);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '2026-01-17' } }); // Saturday
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not commit a typed date before a {before} (min) rule', () => {
+    const onChange = renderWithRules([{ before: '2026-01-10T00:00:00.000Z' }]);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '2026-01-05' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not commit a typed date after an {after} (max) rule', () => {
+    const onChange = renderWithRules([{ after: '2026-01-20T00:00:00.000Z' }]);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '2026-01-25' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still commits a typed date that passes all rules', () => {
+    const onChange = renderWithRules([{ dayOfWeek: [0, 6] }]);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '2026-01-15' } }); // Thursday
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-15T/));
+  });
+
+  it('still clears the value (null) when typed empty — the guard never blocks clearing', () => {
+    const onChange = renderWithRules([{ dayOfWeek: [0, 6] }]);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: '2026-01-15' } }); // seed an enabled value
+    onChange.mockClear();
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith(null);
   });
 });

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -4,6 +4,7 @@ import {
   DEFAULT_DATEPICKER_LABELS,
   civilMidnightFromUtcDay,
   getWeekStartForLocale,
+  isDateDisabled,
 } from '@kalyx/core';
 import type {
   DateAdapter,
@@ -153,6 +154,13 @@ export function DatePickerRoot({
     (iso: ISODateString | null) => {
       if (isDisabled || readOnly) return;
 
+      // Enforce per-day disable/min-max rules on every commit path, not just grid
+      // clicks. The calendar grid already blocks disabled days, but the text Input
+      // (and MonthPicker/YearPicker, which reuse it) commit through here directly —
+      // without this guard a typed weekend/out-of-range date bypasses `disabled`
+      // entirely. Uses the same 3-arg check the grid uses, so the two stay consistent.
+      if (iso && isDateDisabled(iso, disabledRules, adapter)) return;
+
       // The grid emits UTC-midnight ISO strings. When displayTimezone is set, map those to the
       // civil midnight of the same calendar day in that zone — otherwise "picking Jan 15 in KST"
       // would save Jan 14 15:00 UTC shifted incorrectly.
@@ -167,7 +175,7 @@ export function DatePickerRoot({
       // Close the popover after selection
       setIsOpen(false);
     },
-    [isControlled, isDisabled, readOnly, onChange, displayTimezone],
+    [isControlled, isDisabled, readOnly, onChange, displayTimezone, disabledRules, adapter],
   );
 
   const open = useCallback(() => {


### PR DESCRIPTION
## HIGH-1 — 타입드 input이 disabled/min-max 검증을 우회 (데이터 정합성 fix)

Claude 라이브러리 평가(#176)에서 자체 코드 검증으로 확인한 실 버그를 수정합니다.

### 문제
`DatePicker.Input`(그리고 이를 재사용하는 `MonthPicker`/`YearPicker`)에 날짜를 **타이핑**하면 `disabled` 규칙이 전혀 검사되지 않았습니다. 캘린더 그리드는 클릭·Enter·화살표 이동을 `isDateDisabled`로 막지만, 텍스트 커밋 경로(`Input.commitText` → `ctx.selectDate`)는 파싱한 값을 곧바로 커밋했습니다. → 주말·범위밖(min/max = `{before}`/`{after}`)·기타 disabled 날짜를 **타이핑 후 blur/Enter로 조용히 저장**할 수 있었습니다. `RangePicker`/`WeekPicker`는 Input이 `readOnly`라 영향 없음.

### 수정
`DatePicker.Root`의 `selectDate`가 모든 커밋 경로에서 그리드와 **동일한 3-인자 `isDateDisabled`** 검사를 수행합니다. 진입 방법과 무관하게 `disabled` 계약이 유지됩니다. 빈 입력으로 값을 지우는 것(`null`)은 영향 없음.

### 검증
- ✅ 회귀 테스트 5건 추가 (dayOfWeek / before(min) / after(max) 거부 + 유효 날짜 커밋 유지 + 빈 입력 clear 유지)
- ✅ 전체 유닛 **781 pass**, typecheck·lint green
- ✅ 번들 게이트 유지: CJS **16.90KB** ≤ 17KB (+~10B)

### 스코프 노트
평가에서 함께 발견된 **HIGH-2**(disabled 날짜로 open 시 키보드 그리드 사망)는 **별도 PR로 분리**합니다 — 재앵커를 react-side에서 하면 ~200B가 늘어 ≤17KB CJS 게이트를 초과하므로, core `getCalendarDays`에서 `isFocused`를 enabled로 재타겟하는 더 싼 방식으로 후속 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
