### PR TITLE
fix(calendar): disabled 날짜로 열 때 키보드 그리드 사망 수정 — core getCalendarDays 재타겟 (HIGH-2)

### DIFF
--- a/.changeset/calendar-refocus-disabled-day.md
+++ b/.changeset/calendar-refocus-disabled-day.md
@@ -1,0 +1,18 @@
+---
+"@kalyx/core": patch
+---
+
+fix(calendar): retarget focus off a disabled day in `getCalendarDays` (HIGH-2)
+
+When the requested `focusedDate` fell on a disabled day, that day still carried the
+`isFocused` flag. In the React grid that made a disabled `<button>` the only tabbable
+cell — and a disabled button can't receive DOM focus, so opening a calendar whose value
+(or today, when no value is set) was disabled left keyboard navigation stranded with no
+focusable cell (e.g. a weekend-disabling picker opened on a weekend, or
+`disabled: [{ before: tomorrow }]` with no value).
+
+`getCalendarDays` now moves the focus flag to the first enabled day (preferring the
+current month) whenever the requested focus lands on a disabled day, so every grid opens
+with a focusable anchor. Enabled requested dates are unchanged, and no anchor is added
+when `focusedDate` is omitted. This fixes DatePicker, RangePicker, and WeekPicker in one
+place, at zero bundle cost.

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -342,3 +342,43 @@ describe('getCalendarDays — range handling', () => {
     expect(day15?.isInRange).toBe(false);
   });
 });
+
+describe('getCalendarDays — focus retargets off disabled days (HIGH-2)', () => {
+  // 2026-01-01 is a Thursday, so 2026-01-17 is a Saturday.
+  it('moves isFocused to the first enabled day when the requested focus is disabled', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      weekStartsOn: 0,
+      focusedDate: '2026-01-17T00:00:00.000Z', // Saturday → disabled
+      disabled: [{ dayOfWeek: [0, 6] }],
+    });
+    const flat = weeks.flat();
+    const focused = flat.filter((d) => d.isFocused);
+    // Exactly one focus anchor, and it must be enabled (a disabled <button> can't take focus).
+    expect(focused).toHaveLength(1);
+    expect(focused[0]!.isDisabled).toBe(false);
+    // The requested (disabled) day must not remain the focus anchor.
+    const requested = flat.find((d) => d.isoString.startsWith('2026-01-17'));
+    expect(requested?.isFocused).toBe(false);
+    // Prefers the current month: first enabled current-month day is Thu Jan 1.
+    expect(focused[0]!.isoString).toMatch(/^2026-01-01/);
+    expect(focused[0]!.isCurrentMonth).toBe(true);
+  });
+
+  it('leaves isFocused on the requested day when it is enabled', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      weekStartsOn: 0,
+      focusedDate: '2026-01-15T00:00:00.000Z', // Thursday → enabled
+      disabled: [{ dayOfWeek: [0, 6] }],
+    });
+    const focused = weeks.flat().filter((d) => d.isFocused);
+    expect(focused).toHaveLength(1);
+    expect(focused[0]!.isoString).toMatch(/^2026-01-15/);
+  });
+
+  it('does not add a focus anchor when no focusedDate is requested', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      disabled: [{ dayOfWeek: [0, 6] }],
+    });
+    expect(weeks.flat().some((d) => d.isFocused)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -93,6 +93,23 @@ export function getCalendarDays(
     }
   }
 
+  // If the requested focus landed on a disabled day, its <button> can't take DOM focus —
+  // leaving it as the grid's only tabbable cell would strand keyboard navigation. Retarget
+  // the focused flag to the first enabled day (preferring the current month) so the grid
+  // always opens with a focusable anchor.
+  if (focusedDate) {
+    const flat = weeks.flat();
+    const focusedCell = flat.find((d) => d.isFocused);
+    if (focusedCell?.isDisabled) {
+      const fallback =
+        flat.find((d) => !d.isDisabled && d.isCurrentMonth) ?? flat.find((d) => !d.isDisabled);
+      if (fallback) {
+        focusedCell.isFocused = false;
+        fallback.isFocused = true;
+      }
+    }
+  }
+
   return weeks;
 }
 

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { DatePicker } from './index.js';
@@ -1560,5 +1560,60 @@ describe('DatePicker — RTL (dir="rtl")', () => {
     // RTL: physically-left cell is the *next* (higher-index) year → 2027.
     await user.keyboard('{ArrowLeft}');
     expect(screen.getByRole('gridcell', { name: '2027' })).toHaveFocus();
+  });
+});
+
+describe('DatePicker — keyboard focus survives opening on a disabled day (HIGH-2 regression)', () => {
+  // 2026-01-17 is a Saturday; with weekends disabled it can't be the focus anchor
+  // (a disabled <button> can't take DOM focus). getCalendarDays must retarget the
+  // focused flag to an enabled day so the grid opens navigable.
+  it('lands focus on an enabled day when the value/today is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      // @ts-expect-error — DisabledRule[] via test literal
+      <DatePicker
+        value="2026-01-17T00:00:00.000Z"
+        disabled={[{ dayOfWeek: [0, 6] }]}
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    await waitFor(() => {
+      const active = document.activeElement;
+      expect(active).toBeInstanceOf(HTMLButtonElement);
+      expect(active).toHaveAttribute('data-focused', 'true');
+      expect(active).not.toBeDisabled();
+    });
+  });
+
+  it('keeps the grid keyboard-navigable after opening on a disabled day', async () => {
+    const user = userEvent.setup();
+    render(
+      // @ts-expect-error — DisabledRule[] via test literal
+      <DatePicker
+        value="2026-01-17T00:00:00.000Z"
+        disabled={[{ dayOfWeek: [0, 6] }]}
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+    await user.click(screen.getByRole('combobox'));
+    // A focusable day cell exists → arrow keys move focus to another enabled day
+    // (not stranded on a disabled, unfocusable cell).
+    await user.keyboard('{ArrowRight}');
+    await waitFor(() => {
+      const active = document.activeElement;
+      expect(active).toHaveAttribute('data-focused', 'true');
+      expect(active).not.toBeDisabled();
+    });
   });
 });

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { RangePicker } from './index.js';
@@ -929,5 +929,32 @@ describe('RangePicker — RTL (dir="rtl")', () => {
     );
     await user.click(screen.getAllByRole('combobox')[0]);
     expect(screen.getByRole('grid')).toHaveAttribute('dir', 'ltr');
+  });
+});
+
+describe('RangePicker — keyboard focus survives opening on a disabled day (HIGH-2 regression)', () => {
+  it('lands focus on an enabled day when the range start is disabled', async () => {
+    const user = userEvent.setup();
+    const disabled: DisabledRule[] = [{ dayOfWeek: [0, 6] }];
+    render(
+      <RangePicker
+        value={{ start: '2026-01-17T00:00:00.000Z', end: null }} // Saturday → disabled
+        onChange={vi.fn()}
+        disabled={disabled}
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Input part="end" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+    await user.click(screen.getAllByRole('combobox')[0]!);
+    await waitFor(() => {
+      const active = document.activeElement;
+      expect(active).toBeInstanceOf(HTMLButtonElement);
+      expect(active).toHaveAttribute('data-focused', 'true');
+      expect(active).not.toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
## HIGH-2 — disabled 날짜로 캘린더 열면 키보드 그리드 사망 (core-side fix)

Claude 라이브러리 평가(#176)에서 발견한 두 번째 실 버그. **core `getCalendarDays`에서 근본 수정** — react-side 재앵커는 ~200B를 더해 ≤17KB CJS 게이트를 초과하므로(마진 110B), gzip이 기존 토큰을 재사용하는 core 접근으로 **번들 delta 0**에 해결.

### 문제
요청된 `focusedDate`가 disabled 날짜에 떨어지면 그 셀이 `isFocused`를 계속 들고 있었습니다. react 그리드에서 그 셀은 유일한 tabbable 셀(`tabIndex=0`)인데 `disabled` 버튼이라 **DOM 포커스를 못 받아**, disabled 값(또는 value 없을 때 today)으로 캘린더를 열면 **어떤 날짜 셀도 키보드로 도달 불가** → 그리드 `onKeyDown`이 안 뜸. (주말 disable 픽커를 주말에 open, `disabled:[{before: tomorrow}]` + value 없음 등.)

### 수정
`getCalendarDays`가 요청 포커스가 disabled면 **첫 enabled 날짜(현재 달 우선)로 focus 플래그를 이동**. 그리드가 항상 포커스 가능한 앵커로 열립니다. **DatePicker/RangePicker/WeekPicker를 한 곳에서 커버.** enabled 요청일은 불변, `focusedDate` 미지정 시 앵커 없음.

### 검증
- ✅ core 단위 3건 (retarget / enabled-불변 / no-focus) + react 회귀 3건 (DatePicker 2 + RangePicker 1 — focus가 enabled·focusable 셀에 안착 + 화살표 이동 유지)
- ✅ 전체 **782 pass**, typecheck·lint green
- ✅ **번들 delta 0**: CJS **16.89KB** (= baseline) ≤ 17KB

### 알려진 잔여 (follow-up)
react `handleKeyDown`은 여전히 `focusedDate` **state**에서 화살표를 계산하므로, disabled 날짜로 연 직후 **첫 화살표 한 번**이 재타겟된 셀이 아니라 원래(disabled) 날짜 기준으로 이동 — 한 번의 비인접 점프 후 정상. 완전 교정은 `Root.open()`에서 enabled 날짜를 seed하는 것이지만 번들 여유가 필요(별도).

> HIGH-1(#178)과 독립. core 소스 변경이라 changeset `@kalyx/core` patch (linked로 react 동반 범프).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
