### PR TITLE
fix: TimePicker filterTime 타입드 입력(M-3) + isDateDisabled timezone(M-4) — M-5는 defer

### DIFF
--- a/.changeset/isdatedisabled-timezone.md
+++ b/.changeset/isdatedisabled-timezone.md
@@ -1,0 +1,12 @@
+---
+"@kalyx/core": patch
+---
+
+fix(calendar): honor `displayTimezone` for `{ date }` disable rules (M-4)
+
+`isDateDisabled` compared `{ date }` rules by UTC day, while `selected`/`today`/`range`
+flags compared by civil day in `displayTimezone`. With a timezone active, a `{ date }`
+rule supplied in the civil-midnight-in-tz form the picker emits silently failed to disable
+the matching grid cell. `isDateDisabled` now takes an optional `timezone` argument
+(backward-compatible) and `getCalendarDays` passes `displayTimezone` through, so `{ date }`
+rules disable the right cell regardless of zone.

--- a/.changeset/timepicker-filtertime-typed-input.md
+++ b/.changeset/timepicker-filtertime-typed-input.md
@@ -1,0 +1,11 @@
+---
+"@kalyx/react": patch
+---
+
+fix(timepicker): honor `filterTime` on typed input commits (M-3)
+
+`TimePicker.Input` committed a typed time on blur/Enter without consulting `filterTime`,
+so a blacked-out slot (e.g. a lunch-break or business-hours exclusion) that the
+`HourList`/`MinuteList` correctly disable could still be entered by typing. The typed
+commit path now rejects a time whose `(hours, minutes)` are filtered out, matching the
+list controls. (`filterTime` returns `true` to disable a slot.)

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -342,3 +342,23 @@ describe('getCalendarDays — range handling', () => {
     expect(day15?.isInRange).toBe(false);
   });
 });
+
+describe('isDateDisabled — {date} rule honors displayTimezone (M-4)', () => {
+  it('matches a {date} rule by civil day in the given timezone', () => {
+    // Grid cells iterate in UTC midnight; the picker emits civil-midnight-in-tz for
+    // selections. A {date} rule supplied in that same civil form must still disable the
+    // matching grid cell when a timezone is active.
+    const gridCell = '2026-01-15T00:00:00.000Z'; // Asia/Seoul: Jan 15 09:00
+    const rule = { date: '2026-01-14T15:00:00.000Z' }; // Asia/Seoul: Jan 15 00:00 (same civil day)
+    expect(isDateDisabled(gridCell, [rule], adapter, 'Asia/Seoul')).toBe(true);
+  });
+
+  it('still compares by UTC day when no timezone is given (unchanged)', () => {
+    const gridCell = '2026-01-15T00:00:00.000Z';
+    const rule = { date: '2026-01-14T15:00:00.000Z' };
+    expect(isDateDisabled(gridCell, [rule], adapter)).toBe(false);
+    expect(
+      isDateDisabled('2026-01-15T00:00:00.000Z', [{ date: '2026-01-15T00:00:00.000Z' }], adapter),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -66,7 +66,7 @@ export function getCalendarDays(
       const isTodayDate = adapter.isSameDay(current, todayISO, timezone);
       const isSelected_ = selected ? adapter.isSameDay(current, selected, timezone) : false;
       const isFocused_ = focusedDate ? adapter.isSameDay(current, focusedDate, timezone) : false;
-      const isDisabled_ = isDateDisabled(current, disabled, adapter);
+      const isDisabled_ = isDateDisabled(current, disabled, adapter, timezone);
 
       const rangeFlags = computeRangeFlags(current, normalizedRange, adapter, timezone);
 
@@ -187,11 +187,20 @@ function computeRangeFlags(
 
 /**
  * Checks whether the given date matches any disable rule.
+ *
+ * @param timezone - Optional IANA timezone. When set, `{ date }` rules compare by civil day
+ *   in that zone (matching how `selected`/`today`/`range` flags are computed), so a rule
+ *   supplied in the civil-midnight-in-tz form the picker emits still disables the right cell.
  */
-export function isDateDisabled(iso: string, rules: DisabledRule[], adapter: DateAdapter): boolean {
+export function isDateDisabled(
+  iso: string,
+  rules: DisabledRule[],
+  adapter: DateAdapter,
+  timezone?: string,
+): boolean {
   for (const rule of rules) {
     if ('date' in rule) {
-      if (adapter.isSameDay(iso, rule.date)) return true;
+      if (adapter.isSameDay(iso, rule.date, timezone)) return true;
     } else if ('before' in rule) {
       if (adapter.isBefore(iso, rule.before)) return true;
     } else if ('after' in rule) {

--- a/packages/react/src/components/TimePicker/Input.tsx
+++ b/packages/react/src/components/TimePicker/Input.tsx
@@ -31,7 +31,10 @@ export const TimePickerInput = forwardRef<HTMLInputElement, TimePickerInputProps
     const commitInput = useCallback(() => {
       if (inputText === null) return;
       const parsed = parseTimeString(inputText);
-      if (parsed) {
+      // Honor filterTime on the typed path too. The HourList/MinuteList gate clicks, but a
+      // fully-typed time (h+m at once) commits here — without this a blacked-out slot could be
+      // entered by typing. `filterTime` returns true to *disable* a slot (inverse of react-datepicker).
+      if (parsed && !(ctx.filterTime && ctx.filterTime(parsed.hours, parsed.minutes))) {
         ctx.setTime(parsed);
       }
       setInputText(null);

--- a/packages/react/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { TimePicker } from './index.js';
@@ -785,5 +785,44 @@ describe('TimePicker.Popover — optional floating container', () => {
 
     await user.click(input);
     expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+describe('TimePicker — typed input honors filterTime (M-3 regression)', () => {
+  // filterTime returns true to *disable* a slot (inverse of react-datepicker). The
+  // HourList/MinuteList gate clicks, but the text Input committed on blur without checking
+  // filterTime — a typed blacked-out time slipped through.
+  it('does not commit a typed time rejected by filterTime', () => {
+    const onChange = vi.fn();
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={onChange}
+        filterTime={(_h, m) => m === 30}
+      >
+        <TimePicker.Input />
+      </TimePicker>,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: '10:30' } }); // minute 30 → filtered
+    fireEvent.blur(input);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still commits a typed time allowed by filterTime', () => {
+    const onChange = vi.fn();
+    render(
+      <TimePicker
+        value="2026-01-15T10:00:00.000Z"
+        onChange={onChange}
+        filterTime={(_h, m) => m === 30}
+      >
+        <TimePicker.Input />
+      </TimePicker>,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: '10:15' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/T10:15/));
   });
 });


### PR DESCRIPTION
## MEDIUM 정합성 폴리시 — M-3 + M-4 (M-5는 defer)

Claude 라이브러리 평가(#176)의 MEDIUM findings. **M-3·M-4는 실 correctness fix로 배포**, **M-5(dev 경고)는 번들 게이트 초과로 defer**.

### ✅ M-3 — TimePicker typed input이 `filterTime` 우회 (`@kalyx/react` patch)
`TimePicker.Input`이 blur/Enter로 커밋할 때 `filterTime`을 검사하지 않아, `HourList`/`MinuteList`가 막는 blacked-out 슬롯(점심시간·영업시간 제외 등)을 **타이핑으로 입력** 가능했습니다. `commitInput`이 필터된 `(hours,minutes)`를 거부합니다. list 경로는 partial(hour만/minute만)이라 이미 UI 게이팅 — 2단계 선택 흐름은 불변. (`filterTime`은 true 반환 시 disable.)

### ✅ M-4 — `isDateDisabled`가 `{date}` 규칙에서 `displayTimezone` 무시 (`@kalyx/core` patch)
`{date}` 규칙은 UTC day로 비교하는데 `selected`/`today`/`range`는 `displayTimezone` civil day로 비교 → timezone 활성 시 picker가 emit하는 civil-midnight 형식의 `{date}` 규칙이 **해당 셀을 조용히 disable 못 함**. `isDateDisabled`에 optional `timezone` 인자 추가(하위호환) + `getCalendarDays`가 `displayTimezone` 전달.

### ⏸️ M-5 — controlled↔uncontrolled dev 경고 (defer)
mount 시 모드가 latch되는데 이후 `value`가 defined↔undefined로 바뀌면 조용히 잘못된 모드로 동작. React 자체 input처럼 dev 경고를 넣으려 했으나, `process.env`+문자열+`console.warn`을 3개 Root에 추가하면 **측정 번들에 ~210B**가 붙어 ≤17KB CJS 게이트 초과(tsup은 `process.env.NODE_ENV` 미치환 → dev 코드가 dist에 계상됨). **correctness fix가 아닌 DX 경고**라 게이트 유지를 위해 defer. (번들 여유 생기거나 게이트 정책 바뀌면 재개.)

### 검증
- ✅ 테스트 4건 추가 (M-3 2, M-4 2) · 전체 **780 pass** · typecheck·lint green
- ✅ 번들 게이트: CJS **16.91KB** ≤ 17KB (+~20B)
- changeset: `@kalyx/react` patch (M-3) + `@kalyx/core` patch (M-4)

> HIGH-1(#178)·HIGH-2(#179)와 독립. 이 셋을 합치면 평가에서 발견한 실 버그를 전부 커버(M-5 dev경고 제외).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
