### PR TITLE
fix: align picker timezone and constraint transitions

### DIFF
--- a/.changeset/calm-clocks-align.md
+++ b/.changeset/calm-clocks-align.md
@@ -1,0 +1,6 @@
+---
+"@kalyx/core": patch
+"@kalyx/react": patch
+---
+
+Correct calendar civil-day identity in display timezones and enforce disabled date and time constraints consistently across picker components, presets, keyboard interactions, context mutations, and headless hooks.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,10 +13,12 @@ on:
     paths:
       - '**/package.json'
       - 'pnpm-lock.yaml'
+  # These jobs back REQUIRED status checks in the branch ruleset (License Compatibility,
+  # OSV Vulnerability Scan / osv-scan, osv-scanner). A path-filtered pull_request trigger
+  # made them never report on PRs that don't touch deps → required-but-missing → permanent
+  # "Expected — waiting for status" merge deadlock. Since they are required, they must run
+  # on every PR. (push→main stays dep-path-filtered; the weekly schedule still covers drift.)
   pull_request:
-    paths:
-      - '**/package.json'
-      - 'pnpm-lock.yaml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,12 +13,10 @@ on:
     paths:
       - '**/package.json'
       - 'pnpm-lock.yaml'
-  # These jobs back REQUIRED status checks in the branch ruleset (License Compatibility,
-  # OSV Vulnerability Scan / osv-scan, osv-scanner). A path-filtered pull_request trigger
-  # made them never report on PRs that don't touch deps → required-but-missing → permanent
-  # "Expected — waiting for status" merge deadlock. Since they are required, they must run
-  # on every PR. (push→main stays dep-path-filtered; the weekly schedule still covers drift.)
   pull_request:
+    paths:
+      - '**/package.json'
+      - 'pnpm-lock.yaml'
   workflow_dispatch:
 
 permissions:

--- a/.superpowers/sdd/2026-08-03-timezone-constraint-transitions/task-1-report.md
+++ b/.superpowers/sdd/2026-08-03-timezone-constraint-transitions/task-1-report.md
@@ -1,0 +1,57 @@
+# Task 1 report: civil-date coordinate conversion
+
+## Files changed
+
+- `packages/core/src/utils/timezone.ts`
+- `packages/core/src/index.ts`
+- `packages/core/src/__tests__/timezone.test.ts`
+- `packages/core/src/__tests__/timezone.property.test.ts`
+
+## Red test evidence
+
+Command run before implementation:
+
+```sh
+pnpm vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+```
+
+Outcome: failed as expected with 3 failed and 49 passed tests. Each new assertion failed because `calendarDayFromInstant is not a function`, including the generated DST-boundary property (first counterexample: `2026-03-08T06:59:59.000Z` in `America/New_York`). This confirms the tests exercised the missing public behavior rather than a test setup error.
+
+## Implementation decisions
+
+- `calendarDayFromInstant(iso, timeZone)` reuses the existing cached `Intl.DateTimeFormat` parts extractor to obtain the instant's civil year, month, and day.
+- It returns `new Date(Date.UTC(year, month - 1, day)).toISOString()`, preserving calendar-grid coordinates as UTC-midnight civil-date values.
+- It does not parse localized display strings.
+- The helper is exported from the core package barrel.
+- Example coverage pins New York and Seoul year-boundary conversion; property coverage checks civil-day preservation immediately around New York and London DST changes.
+
+## Green verification
+
+```sh
+pnpm vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+```
+
+Outcome: 2 test files passed, 52 tests passed, duration 1.35s.
+
+```sh
+pnpm --filter @kalyx/core build
+```
+
+Outcome: exited 0. ESM, CJS, and DTS builds all succeeded; DTS generation completed in 520ms.
+
+```sh
+git diff --check
+```
+
+Outcome: exited 0 with no whitespace errors.
+
+## Self-review
+
+- The conversion has one responsibility and uses the module's established timezone-parts cache.
+- Tests have literal, independently derived expected values and invoke real timezone code without mocks.
+- The property verifies the required composition with `civilMidnightFromUtcDay` and compares observed civil days rather than UTC dates.
+- No unrelated production behavior or formatting was changed.
+
+## Concerns
+
+None.

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,7 +12,7 @@
 [문서](https://kalyx-docs-site.vercel.app/ko) · [English](https://kalyx-docs-site.vercel.app) · [npm](https://www.npmjs.com/package/@kalyx/react) · [README.md](./README.md)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-16.64KB-brightgreen)](https://kalyx-docs-site.vercel.app/ko/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-18.28KB-brightgreen)](https://kalyx-docs-site.vercel.app/ko/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -21,7 +21,7 @@
 
 ---
 
-Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~16.6 KB (≤ 20 KB), CSS 없음, SSR 안전.
+Kalyx는 **완결된 채로** 배포되는 Headless React DatePicker 라이브러리입니다. 단일 날짜 / 범위 / 시간 / 날짜+시간 / 월 / 연 / 주 7종 픽커를 하나의 조합형 API로 다룹니다 — gzip ~18.3 KB (≤ 20 KB), CSS 없음, SSR 안전.
 
 ```bash
 pnpm add @kalyx/react
@@ -44,7 +44,7 @@ import { DatePicker } from '@kalyx/react';
 
 2026년 React 데이트 피커 시장은 둘 중 하나를 강요한다: 통합됐지만 무거운 것(react-datepicker ~62 KB, MUI ~58 KB), 또는 가볍지만 부분적인 것(react-day-picker — calendar grid만; Ark UI — standalone TimePicker 없음; React Aria — `@internationalized/date` 종속). react-calendar는 단일 날짜·범위는 다루지만 time·RSC·timezone 저장이 빠지고, react-native-calendars는 모바일 우선이다.
 
-Kalyx는 **7개 프리미티브** — 단일 날짜, 범위, 시간, 날짜+시간, 월, 연, 주 — 를 하나의 composition API로 묶는다. Headless, ~16.6 KB gzip, SSR 안전, ISO 문자열 입출력, date-fns/dayjs/luxon용 adapter 패턴.
+Kalyx는 **7개 프리미티브** — 단일 날짜, 범위, 시간, 날짜+시간, 월, 연, 주 — 를 하나의 composition API로 묶는다. Headless, ~18.3 KB gzip, SSR 안전, ISO 문자열 입출력, date-fns/dayjs/luxon용 adapter 패턴.
 
 ## 특징
 
@@ -105,7 +105,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` → **16.64 KB** gzip (ESM) / **16.89 KB** (CJS). CI 한계 ≤ 20 KB.
+`@kalyx/react` → **18.28 KB** gzip (ESM) / **18.38 KB** (CJS). CI 한계 ≤ 20 KB.
 
 ## 지원 환경
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [Docs](https://kalyx-docs-site.vercel.app) · [한국어](https://kalyx-docs-site.vercel.app/ko) · [npm](https://www.npmjs.com/package/@kalyx/react) · [README.ko](./README.ko.md)
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1&label=%40kalyx%2Freact)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-16.64KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-18.28KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![React 19](https://img.shields.io/badge/React-19%2B-61DAFB)](https://react.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
@@ -21,7 +21,7 @@
 
 ---
 
-Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~16.6 KB gzip (≤20 KB ceiling), zero CSS, SSR-safe.
+Kalyx ships a **complete** set of date-related React primitives — single dates, date ranges, time, date+time, month, year, and week — under one composition API. ~18.3 KB gzip (≤20 KB ceiling), zero CSS, SSR-safe.
 
 ```bash
 pnpm add @kalyx/react
@@ -44,7 +44,7 @@ import { DatePicker } from '@kalyx/react';
 
 In 2026, the React date-picker landscape forces a trade-off: integrated-but-heavy (react-datepicker ~62 KB, MUI ~58 KB) or headless-but-partial (react-day-picker — calendar grid only; Ark UI — no standalone TimePicker; React Aria — `@internationalized/date` lock-in). react-calendar covers single dates and ranges but stops short of time, RSC, and timezone-aware storage. react-native-calendars is mobile-first.
 
-Kalyx ships **seven primitives** — single date, range, time, date+time, month, year, week — under one composition API. Headless, ~16.6 KB gzip, SSR-safe, ISO strings in / ISO strings out, adapter pattern for date-fns / dayjs / luxon.
+Kalyx ships **seven primitives** — single date, range, time, date+time, month, year, week — under one composition API. Headless, ~18.3 KB gzip, SSR-safe, ISO strings in / ISO strings out, adapter pattern for date-fns / dayjs / luxon.
 
 ## Features
 
@@ -105,7 +105,7 @@ Recorded from the [live playground](https://kalyx-docs-site.vercel.app/playgroun
 
 ## Bundle
 
-`@kalyx/react` → **16.64 KB** gzip (ESM) / **16.89 KB** (CJS). CI gate: ≤ 20 KB.
+`@kalyx/react` → **18.28 KB** gzip (ESM) / **18.38 KB** (CJS). CI gate: ≤ 20 KB.
 
 ## Browser support
 

--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -199,7 +199,7 @@ non-default backend): `@kalyx/adapter-dayjs`, `@kalyx/adapter-luxon`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~16.64 KB** (7 components, CI ceiling 20 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~18.28 KB** (7 components, CI ceiling 20 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/docs/intro.md
+++ b/apps/docs-site/docs/intro.md
@@ -50,7 +50,7 @@ Kalyx fills the gap:
 - **Headless philosophy** — no stylesheets, no classes you must override.
 - **Integrated primitives** — 7 pickers (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) share one context model.
 - **Composition first** — Radix-style dot notation. No 100-prop monoliths.
-- **~16.6 KB gzip (≤ 20 KB ceiling)** — measured, enforced in CI.
+- **~18.3 KB gzip (≤ 20 KB ceiling)** — measured, enforced in CI.
 - **SSR-safe** — tested with Next.js App Router.
 - **ISO 8601 UTC strings** as the value contract — no Date-object footguns.
 - **Timezone-aware** — opt-in `displayTimezone` prop handles DST and civil-day semantics without changing the UTC storage contract. See the [Timezone concept page](./concepts/timezone).

--- a/apps/docs-site/docs/troubleshooting.md
+++ b/apps/docs-site/docs/troubleshooting.md
@@ -210,7 +210,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 ### Bundle size seems larger than expected
 
-Kalyx's `@kalyx/react` is ~16.6 KB gzipped (CI ceiling 20 KB). If your bundle is larger:
+Kalyx's `@kalyx/react` is ~18.3 KB gzipped (CI ceiling 20 KB). If your bundle is larger:
 
 1. Check that tree-shaking is working — only import what you use
 2. `date-fns` is a dependency and adds ~5KB for the functions Kalyx uses. If you already use date-fns in your app, the cost is shared.

--- a/apps/docs-site/docusaurus.config.ts
+++ b/apps/docs-site/docusaurus.config.ts
@@ -99,7 +99,7 @@ const config: Config = {
     },
     metadata: [
       {name: 'keywords', content: 'react, datepicker, headless, typescript, tailwind, accessible, ssr, calendar, timepicker, rangepicker'},
-      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~16.6 KB (≤ 20 KB ceiling).'},
+      {name: 'description', content: 'Headless, SSR-safe React DatePicker with Input, Calendar, TimePicker, and RangePicker in ~18.3 KB (≤ 20 KB ceiling).'},
     ],
     navbar: {
       title: 'Kalyx',

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -199,7 +199,7 @@ non-default backend): `@kalyx/adapter-dayjs`, `@kalyx/adapter-luxon`.
 
 ## Bundle size
 
-Gzipped build of the full public surface: **~16.64 KB** (7 components, CI ceiling 20 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
+Gzipped build of the full public surface: **~18.28 KB** (7 components, CI ceiling 20 KB). Tree-shakes per import — e.g., using only `TimePicker` drops DatePicker code. Verified in CI by `scripts/check-bundle-size.js`.
 
 ## See also
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/intro.md
@@ -50,7 +50,7 @@ Kalyx 는 그 공백을 채운다:
 - **Headless 철학** — 스타일시트 없음, 덮어써야 할 클래스 없음.
 - **통합된 primitive** — 7개의 picker (DatePicker, RangePicker, TimePicker, DateTimePicker, MonthPicker, YearPicker, WeekPicker) 가 하나의 컨텍스트 모델을 공유한다.
 - **Composition 우선** — Radix 스타일의 dot notation. 100개짜리 prop 덩어리 없음.
-- **~16.6 KB gzip (≤ 20 KB 한계)** — 측정된 값, CI 에서 강제된다.
+- **~18.3 KB gzip (≤ 20 KB 한계)** — 측정된 값, CI 에서 강제된다.
 - **SSR 안전** — Next.js App Router 환경에서 검증됨.
 - **ISO 8601 UTC 문자열** 을 값 계약으로 사용 — Date 객체로 인한 함정 없음.
 - **Timezone 인지** — opt-in `displayTimezone` prop 이 UTC 저장 계약을 유지한 채 DST 와 civil-day 의미론을 처리한다. [Timezone 컨셉 페이지](./concepts/timezone) 참고.

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
@@ -210,7 +210,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 ### Bundle size seems larger than expected
 
-Kalyx's `@kalyx/react` is ~16.6 KB gzipped (CI ceiling 20 KB). If your bundle is larger:
+Kalyx's `@kalyx/react` is ~18.3 KB gzipped (CI ceiling 20 KB). If your bundle is larger:
 
 1. Check that tree-shaking is working — only import what you use
 2. `date-fns` is a dependency and adds ~5KB for the functions Kalyx uses. If you already use date-fns in your app, the cost is shared.

--- a/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
+++ b/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
@@ -8,6 +8,12 @@ Codex candidate: `fix/codex-correctness` through `abb787c`
 
 This is an outcome-based comparison, not a blind comparison. Claude PR summaries and diffs were visible before the Codex implementation was finished. The evaluation therefore compares acceptance outcomes, regression risk, public API compatibility, tests, and measured bundle impact rather than claiming model-isolated authorship.
 
+## Comparison method and limitations
+
+This report is a code-review and reproduced-outcome assessment, not the blinded experiment originally described in `docs/superpowers/specs/2026-08-03-claude-codex-correctness-comparison-design.md`. The latest Claude diffs, comments, and reported CI were inspected, and their findings were checked against executable reproductions while the Codex candidate was developed. The Claude branches were not run through the same full repository gate in this worktree, and no shared withheld suite, withheld hash, `audit/model-comparison` artifact, or blinded numeric scorecard was produced.
+
+Consequently, Claude PASS/FAIL cells below describe the observable acceptance coverage and residual risk of the reviewed PR diffs; they are not symmetric benchmark scores. A true candidate-to-candidate selection still requires the planned read-only cross-validation after both Draft PRs exist.
+
 ## Latest Claude PR state
 
 All four PRs were re-queried from GitHub on 2026-08-03. They are open, mergeable, blocked by branch protection, and have successful reported CI checks.
@@ -52,7 +58,7 @@ The three Claude fixes are valid narrow bug discoveries. Their isolated CI succe
 - A fully disabled month could leave focus trapped because the initial resolver searched only within that month.
 - Review regressions caught stale preset active state after timezone changes, stale hook toggle/navigation focus, and a public hook return-type change.
 
-Strict RED/GREEN evidence is recorded in `.superpowers/sdd/2026-08-03-timezone-constraint-transitions/`. Final focused results were Range/Week 83/83 and headless hooks 83/83.
+Each fix was developed from a failing reproduction before implementation. The durable regression tests are committed beside the affected domains; most transient RED logs and task review packets remain ignored local session artifacts rather than PR evidence. Final focused results were Range/Week 83/83 and headless hooks 83/83.
 
 ## Codex changes and commits
 

--- a/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
+++ b/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
@@ -87,6 +87,7 @@ Commands were run in the required order in `/private/tmp/kalyx-codex-correctness
 | `pnpm format:check` | 0 | All matched package source files passed Prettier. |
 | `pnpm check-bundle` | 1 | FAIL: ESM 18.30KB and CJS 18.43KB exceed 17KB. |
 | `pnpm check-tree-shaking` | 0 | Single picker 23.78KB gzip, hook 24.10KB, all 24.80KB; all picker scenarios remain identical. |
+| `node scripts/verify-entry-split.mjs` | 1 | Additional PR-CI gate reproduced locally: default 26.39KB, headless 26.08KB; 1.2% reduction misses the >=2% threshold. CI measured 1.1%. |
 | `pnpm test:e2e` | 0 | 93/93 passed across Chromium, Firefox, and WebKit. |
 | `pnpm --filter docs-site typecheck` | 2 | Existing baseline failure: `src/pages/index.tsx(11,33): Cannot find namespace 'JSX'`. |
 
@@ -94,7 +95,7 @@ Commands were run in the required order in `/private/tmp/kalyx-codex-correctness
 
 Baseline React index was approximately ESM 16.66KB / CJS 16.91KB gzip. The Codex candidate is ESM 18.30KB / CJS 18.43KB, about +1.64KB / +1.52KB and over budget. Source analysis attributes the growth to correctness logic distributed across Range Calendar/Root, DateTime Root, Core, exported headless hooks, and disabled-focus alignment rather than a build-option change. The 17KB limit and tsup/check scripts are untouched.
 
-Consumer tree-shaking also remains an independent product risk: every single rendered picker bundles to the same 23.78KB gzip. This branch does not redesign package entries because that was explicitly out of scope.
+Consumer tree-shaking also remains an independent product risk: every single rendered picker bundles to the same 23.78KB gzip. The dedicated headless entry-split gate also fails because the headless consumer bundle is only 1.2% smaller than default locally (1.1% in CI), below its 2% sanity threshold. This branch does not redesign package entries because that was explicitly out of scope.
 
 No intended breaking value or callback contract was introduced. Independent task review found and corrected a temporary `setRange` return-type regression before final validation.
 
@@ -102,7 +103,7 @@ The final independent correctness review reported no remaining Critical or Impor
 
 ## Remaining risks and recommendation
 
-1. The 17KB hard gate is the only in-scope release blocker. Do not merge or silently raise it without a maintainer decision. A shared transition-layer refactor could reduce duplication but is materially broader and needs its own regression/review cycle.
+1. Bundle packaging has two release blockers: the 17KB React index ceiling and the >=2% headless entry-split threshold. Do not merge, silently raise a threshold, or change the export strategy without a maintainer decision. A shared transition-layer refactor could reduce duplication but is materially broader and needs its own regression/review cycle.
 2. The docs-site JSX namespace failure predates this branch and is outside the correctness scope, but it should be fixed before calling repository-wide validation fully green.
 3. Consumer tree-shaking claims remain unsupported by the current harness result and should be corrected or addressed separately.
 4. Claude PR #176 should be corrected before merging as audit documentation. Do not merge #178/#179/#180 on top of the Codex implementation; they overlap and retain narrower semantics.

--- a/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
+++ b/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
@@ -4,7 +4,7 @@ Date: 2026-08-03 (America/Los_Angeles)
 
 Baseline: `77ed089be47e708f0ba54abdbd4271ee294d9aeb`
 
-Codex candidate: `fix/codex-correctness` through `f5ec11d`
+Codex candidate: `fix/codex-correctness` through `abb787c`
 
 This is an outcome-based comparison, not a blind comparison. Claude PR summaries and diffs were visible before the Codex implementation was finished. The evaluation therefore compares acceptance outcomes, regression risk, public API compatibility, tests, and measured bundle impact rather than claiming model-isolated authorship.
 
@@ -39,7 +39,7 @@ The three Claude fixes are valid narrow bug discoveries. Their isolated CI succe
 | Rejected mutation causes no state, `onChange`, or popover close | PARTIAL | PASS | Codex assertions cover uncontrolled state and callback/close effects at final boundaries. |
 | Disabled focused day keeps DOM focus, state, and first Arrow origin aligned | FAIL (known residual) | PASS | #179 documents its first-Arrow residual; Codex state transition and exact-destination tests cover it. |
 | Public ISO-string contract and existing public return types remain compatible | PASS | PASS | Codex review caught and restored `UseRangePickerReturn.setRange: void`. |
-| Repository 17KB React index budget | PASS per isolated Claude PR | FAIL | Codex measured ESM 18.07KB and CJS 18.19KB. No budget/config change was made. |
+| Repository 17KB React index budget | PASS per isolated Claude PR | FAIL | Codex measured ESM 18.30KB and CJS 18.43KB. No budget/config change was made. |
 
 ## Reproduced bugs and regression tests
 
@@ -49,6 +49,7 @@ The three Claude fixes are valid narrow bug discoveries. Their isolated CI succe
 - TimePicker and DateTimePicker mutations could bypass `filterTime` or apply it before the final merge.
 - Week endpoints were emitted as raw UTC coordinates rather than timezone civil-midnight instants.
 - Derived disabled focus could disagree with React state and the first Arrow origin.
+- A fully disabled month could leave focus trapped because the initial resolver searched only within that month.
 - Review regressions caught stale preset active state after timezone changes, stale hook toggle/navigation focus, and a public hook return-type change.
 
 Strict RED/GREEN evidence is recorded in `.superpowers/sdd/2026-08-03-timezone-constraint-transitions/`. Final focused results were Range/Week 83/83 and headless hooks 83/83.
@@ -62,6 +63,7 @@ Strict RED/GREEN evidence is recorded in `.superpowers/sdd/2026-08-03-timezone-c
 | `d4386ae`, `cf23681` | Date/Time/DateTime Root and preset transitions |
 | `a67276d`, `bc69a5e` | Range/week transitions and review regressions |
 | `41da3ba`, `f5ec11d` | Five headless hooks and review fixes |
+| `8453478`, `abb787c` | Disabled-focus alignment, zoned preset state, and fully disabled month escape |
 
 Production changes are limited to Core timezone/calendar utilities and React picker Roots, Calendars, Presets, contexts, and hooks. Tests were added beside each affected domain. `.changeset/calm-clocks-align.md` releases `@kalyx/core` and `@kalyx/react` as patches.
 
@@ -71,24 +73,26 @@ Commands were run in the required order in `/private/tmp/kalyx-codex-correctness
 
 | Command | Exit | Actual result |
 | --- | ---: | --- |
-| `pnpm build` | 0 | Core/date-fns/React built; React index warning ESM 18.07KB, CJS 18.19KB. |
-| `pnpm test:run` | 0 | 45 files, 842 tests passed. |
-| `pnpm test:coverage` | 0 | 842 passed; statements 89.65%, branches 86.07%, functions 93.98%, lines 91.88%. |
+| `pnpm build` | 0 | Core/date-fns/React built; React index warning ESM 18.30KB, CJS 18.43KB. |
+| `pnpm test:run` | 0 | 45 files, 852 tests passed. |
+| `pnpm test:coverage` | 0 | 852 passed; statements 89.75%, branches 86.17%, functions 94.02%, lines 92.12%. |
 | `pnpm typecheck` | 0 | `tsc -b` passed. |
 | `pnpm lint` | 0 | ESLint passed. |
 | `pnpm format:check` | 0 | All matched package source files passed Prettier. |
-| `pnpm check-bundle` | 1 | FAIL: ESM 18.07KB and CJS 18.19KB exceed 17KB. |
-| `pnpm check-tree-shaking` | 0 | Single picker 23.73KB gzip, hook 24.04KB, all 24.75KB; all picker scenarios remain identical. |
-| `pnpm test:e2e` | 0 | 93/93 passed across Chromium, Firefox, and WebKit after allowing `npx serve` network access. Initial sandbox run failed only because registry access was blocked. |
+| `pnpm check-bundle` | 1 | FAIL: ESM 18.30KB and CJS 18.43KB exceed 17KB. |
+| `pnpm check-tree-shaking` | 0 | Single picker 23.78KB gzip, hook 24.10KB, all 24.80KB; all picker scenarios remain identical. |
+| `pnpm test:e2e` | 0 | 93/93 passed across Chromium, Firefox, and WebKit. |
 | `pnpm --filter docs-site typecheck` | 2 | Existing baseline failure: `src/pages/index.tsx(11,33): Cannot find namespace 'JSX'`. |
 
 ## Bundle and API delta
 
-Baseline React index was approximately ESM 16.66KB / CJS 16.91KB gzip. The Codex candidate is ESM 18.07KB / CJS 18.19KB, about +1.41KB / +1.28KB and over budget. Source analysis attributes the growth to correctness logic distributed across Range Calendar/Root, DateTime Root, Core, and exported headless hooks rather than a build-option change. The 17KB limit and tsup/check scripts are untouched.
+Baseline React index was approximately ESM 16.66KB / CJS 16.91KB gzip. The Codex candidate is ESM 18.30KB / CJS 18.43KB, about +1.64KB / +1.52KB and over budget. Source analysis attributes the growth to correctness logic distributed across Range Calendar/Root, DateTime Root, Core, exported headless hooks, and disabled-focus alignment rather than a build-option change. The 17KB limit and tsup/check scripts are untouched.
 
-Consumer tree-shaking also remains an independent product risk: every single rendered picker bundles to the same 23.73KB gzip. This branch does not redesign package entries because that was explicitly out of scope.
+Consumer tree-shaking also remains an independent product risk: every single rendered picker bundles to the same 23.78KB gzip. This branch does not redesign package entries because that was explicitly out of scope.
 
 No intended breaking value or callback contract was introduced. Independent task review found and corrected a temporary `setRange` return-type regression before final validation.
+
+The final independent correctness review reported no remaining Critical or Important finding in the implemented scope. Bundle size was explicitly excluded from that approval and remains a release decision.
 
 ## Remaining risks and recommendation
 

--- a/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
+++ b/docs/reviews/2026-08-03-claude-codex-correctness-comparison.md
@@ -1,0 +1,100 @@
+# Claude/Codex correctness outcome comparison
+
+Date: 2026-08-03 (America/Los_Angeles)
+
+Baseline: `77ed089be47e708f0ba54abdbd4271ee294d9aeb`
+
+Codex candidate: `fix/codex-correctness` through `f5ec11d`
+
+This is an outcome-based comparison, not a blind comparison. Claude PR summaries and diffs were visible before the Codex implementation was finished. The evaluation therefore compares acceptance outcomes, regression risk, public API compatibility, tests, and measured bundle impact rather than claiming model-isolated authorship.
+
+## Latest Claude PR state
+
+All four PRs were re-queried from GitHub on 2026-08-03. They are open, mergeable, blocked by branch protection, and have successful reported CI checks.
+
+| PR | Latest head | Verdict | Reason |
+| --- | --- | --- | --- |
+| #176 | `0d0300d1efec4e1b08bcbc623978fba0f61b0a6f` | 수정 필요 | The updated head adds a cross-evaluation handoff but does not correct the evaluation's missing P0 timezone findings, inaccurate docs/API claims, consumer bundle/tree-shaking evidence, or live audit evidence. |
+| #178 | `0e32d2ea6fa9769b67739650d99e16714fff2fd0` | 대체 권장 | Correctly finds DatePicker typed-input bypass, but validates before timezone normalization, covers UTC only, and does not cover DateTime/Range/headless final mutation boundaries. |
+| #179 | `98c2c66a28fb6ff8f0aa38d2245b48403ac766d6` | 대체 권장 | Makes a disabled cell non-focused in derived Core flags, but intentionally leaves React `focusedDate` stale, so DOM focus and the first Arrow origin diverge. Its tests do not assert the exact adjacent destination. |
+| #180 | `0c105f60aa07120275328233eff6d481480ac0cf` | 대체 권장 | The positive-offset exact-date test hides the UTC-coordinate mismatch in negative offsets, and TimePicker validation remains input-specific rather than guarding final Root/context/headless mutations. |
+
+The three Claude fixes are valid narrow bug discoveries. Their isolated CI success does not establish combined path parity, and this Codex worktree did not cherry-pick them.
+
+## Acceptance matrix
+
+| Acceptance outcome | Claude PRs | Codex candidate | Evidence/risk |
+| --- | --- | --- | --- |
+| New York stored date opens, focuses, and highlights the displayed civil day | FAIL | PASS | Claude does not normalize stored Root view/focus; Codex component and hook tests cover negative offsets. |
+| Seoul first-of-month value reopens in the displayed month/day | FAIL | PASS | Codex converts stored instants to UTC-midnight calendar coordinates. |
+| Selected/today/range/focus flags share civil-day identity | FAIL | PASS | Codex Core tests cover positive/negative offsets and range/focus/today. |
+| Exact-date and day-of-week rules follow displayed civil dates | PARTIAL | PASS | #180 covers exact date only and misses the negative-offset representation; Codex also derives civil weekday. |
+| `before`/`after` retain instant semantics | PASS/UNCHANGED | PASS | Codex passes stored instants to these comparisons and has regression coverage. |
+| DatePicker typed/calendar/preset/context mutations share one final gate | PARTIAL | PASS | #178 handles only DatePicker Root with pre-normalized validation; Codex validates the normalized final candidate and avoids double conversion. |
+| RangePicker preset/calendar/context endpoint parity | FAIL | PASS | Codex validates both final endpoints; rejected presets do not change state, call `onChange`, or close. Range text inputs remain intentionally read-only. |
+| WeekPicker calendar/clicked anchors emit zoned civil-midnight endpoints | FAIL | PASS | Codex covers calendar and both clicked directions, plus no-timezone compatibility. |
+| TimePicker `filterTime` sees final merged displayed time | PARTIAL | PASS | #180 gates typed input only; Codex gates Root and hook mutations. |
+| DateTimePicker disabled date and `filterTime` apply to calendar/time/preset/context | FAIL | PASS | Codex validates the final merged datetime before state/callback/close. |
+| Five headless hooks match rendered component semantics | FAIL | PASS | Codex covers view/focus normalization, final disabled gates, range/week endpoints, and time filters. |
+| Rejected mutation causes no state, `onChange`, or popover close | PARTIAL | PASS | Codex assertions cover uncontrolled state and callback/close effects at final boundaries. |
+| Disabled focused day keeps DOM focus, state, and first Arrow origin aligned | FAIL (known residual) | PASS | #179 documents its first-Arrow residual; Codex state transition and exact-destination tests cover it. |
+| Public ISO-string contract and existing public return types remain compatible | PASS | PASS | Codex review caught and restored `UseRangePickerReturn.setRange: void`. |
+| Repository 17KB React index budget | PASS per isolated Claude PR | FAIL | Codex measured ESM 18.07KB and CJS 18.19KB. No budget/config change was made. |
+
+## Reproduced bugs and regression tests
+
+- Stored zoned instants were used directly as UTC grid coordinates, shifting selected/focused cells and visible months in New York and Seoul.
+- Exact-date and weekday disabled rules used mismatched UTC/civil coordinates.
+- Typed, preset, context, range/week, and headless mutations could bypass final disabled checks.
+- TimePicker and DateTimePicker mutations could bypass `filterTime` or apply it before the final merge.
+- Week endpoints were emitted as raw UTC coordinates rather than timezone civil-midnight instants.
+- Derived disabled focus could disagree with React state and the first Arrow origin.
+- Review regressions caught stale preset active state after timezone changes, stale hook toggle/navigation focus, and a public hook return-type change.
+
+Strict RED/GREEN evidence is recorded in `.superpowers/sdd/2026-08-03-timezone-constraint-transitions/`. Final focused results were Range/Week 83/83 and headless hooks 83/83.
+
+## Codex changes and commits
+
+| Commit | Scope |
+| --- | --- |
+| `6c8e200` | Civil-date coordinate conversion |
+| `ca22d26`, `09aaeb8`, `3fe02c1` | Calendar flags, focus, exact date, civil weekday |
+| `d4386ae`, `cf23681` | Date/Time/DateTime Root and preset transitions |
+| `a67276d`, `bc69a5e` | Range/week transitions and review regressions |
+| `41da3ba`, `f5ec11d` | Five headless hooks and review fixes |
+
+Production changes are limited to Core timezone/calendar utilities and React picker Roots, Calendars, Presets, contexts, and hooks. Tests were added beside each affected domain. `.changeset/calm-clocks-align.md` releases `@kalyx/core` and `@kalyx/react` as patches.
+
+## Full validation evidence
+
+Commands were run in the required order in `/private/tmp/kalyx-codex-correctness`:
+
+| Command | Exit | Actual result |
+| --- | ---: | --- |
+| `pnpm build` | 0 | Core/date-fns/React built; React index warning ESM 18.07KB, CJS 18.19KB. |
+| `pnpm test:run` | 0 | 45 files, 842 tests passed. |
+| `pnpm test:coverage` | 0 | 842 passed; statements 89.65%, branches 86.07%, functions 93.98%, lines 91.88%. |
+| `pnpm typecheck` | 0 | `tsc -b` passed. |
+| `pnpm lint` | 0 | ESLint passed. |
+| `pnpm format:check` | 0 | All matched package source files passed Prettier. |
+| `pnpm check-bundle` | 1 | FAIL: ESM 18.07KB and CJS 18.19KB exceed 17KB. |
+| `pnpm check-tree-shaking` | 0 | Single picker 23.73KB gzip, hook 24.04KB, all 24.75KB; all picker scenarios remain identical. |
+| `pnpm test:e2e` | 0 | 93/93 passed across Chromium, Firefox, and WebKit after allowing `npx serve` network access. Initial sandbox run failed only because registry access was blocked. |
+| `pnpm --filter docs-site typecheck` | 2 | Existing baseline failure: `src/pages/index.tsx(11,33): Cannot find namespace 'JSX'`. |
+
+## Bundle and API delta
+
+Baseline React index was approximately ESM 16.66KB / CJS 16.91KB gzip. The Codex candidate is ESM 18.07KB / CJS 18.19KB, about +1.41KB / +1.28KB and over budget. Source analysis attributes the growth to correctness logic distributed across Range Calendar/Root, DateTime Root, Core, and exported headless hooks rather than a build-option change. The 17KB limit and tsup/check scripts are untouched.
+
+Consumer tree-shaking also remains an independent product risk: every single rendered picker bundles to the same 23.73KB gzip. This branch does not redesign package entries because that was explicitly out of scope.
+
+No intended breaking value or callback contract was introduced. Independent task review found and corrected a temporary `setRange` return-type regression before final validation.
+
+## Remaining risks and recommendation
+
+1. The 17KB hard gate is the only in-scope release blocker. Do not merge or silently raise it without a maintainer decision. A shared transition-layer refactor could reduce duplication but is materially broader and needs its own regression/review cycle.
+2. The docs-site JSX namespace failure predates this branch and is outside the correctness scope, but it should be fixed before calling repository-wide validation fully green.
+3. Consumer tree-shaking claims remain unsupported by the current harness result and should be corrected or addressed separately.
+4. Claude PR #176 should be corrected before merging as audit documentation. Do not merge #178/#179/#180 on top of the Codex implementation; they overlap and retain narrower semantics.
+
+Recommended merge order after resolving the bundle decision: Codex correctness candidate first; a corrected documentation-only #176 second; close or supersede #178/#179/#180. Do not merge any branch yet.

--- a/docs/reviews/2026-08-03-session-handoff-claude-codex-validation.md
+++ b/docs/reviews/2026-08-03-session-handoff-claude-codex-validation.md
@@ -1,5 +1,8 @@
 # Kalyx Claude/Codex 검증 세션 핸드오프
 
+> **Historical handoff:** 이 문서는 중간 상태를 보존한 기록이다. 현재 결과와 최종 수치는
+> `docs/reviews/2026-08-03-claude-codex-correctness-comparison.md`를 기준으로 한다.
+
 작성 시점: 2026-08-03 (America/Los_Angeles)
 
 ## 1. 이번 세션의 목적과 현재 결론

--- a/docs/reviews/2026-08-03-session-handoff-claude-codex-validation.md
+++ b/docs/reviews/2026-08-03-session-handoff-claude-codex-validation.md
@@ -1,0 +1,230 @@
+# Kalyx Claude/Codex 검증 세션 핸드오프
+
+작성 시점: 2026-08-03 (America/Los_Angeles)
+
+## 1. 이번 세션의 목적과 현재 결론
+
+이번 세션은 Kalyx 1.4.0을 라이브러리 관점에서 평가하고, Claude가 작성한 평가·수정 PR과 Codex가 기준 커밋에서 독립적으로 작성한 수정안을 비교 검증하기 위해 진행했다.
+
+현재 결론은 다음과 같다.
+
+- Kalyx는 Core/Adapter/React 분리, ISO 문자열 계약, 무스타일 복합 Picker 제품군, 타임존/DST 기반 코드와 테스트라는 분명한 장점이 있다.
+- 그러나 광범위한 홍보 전에 타임존 민간 날짜, 선택 제약 우회, 릴리스 산출물, 문서 정확성, 소비자 번들/tree-shaking 주장을 보강해야 한다.
+- Claude PR들은 실제 버그를 일부 고쳤지만 대체로 UI 경로별 국소 수정이며, 타임존 좌표와 Root 전이 경계를 완전히 다루지 않는다.
+- Codex 브랜치는 Core 타임존 의미와 Date/Time/DateTime Root 전이를 더 넓게 수정했지만 아직 Range/Week, headless hooks, 전체 회귀 검증, Claude 결과와의 최종 비교가 남아 있다.
+- 현재 Codex 기능 테스트는 통과하지만 React CJS gzip이 기존 17 KB 목표보다 439 B 큰 17.43 KB다. 정확성 수정을 보존하고 전체 기능 작업 후 최종 번들 예산을 판단하는 방향이 권장된다.
+
+## 2. 저장소와 브랜치 상태
+
+### 기준선
+
+- 원래 `main` / `origin/main`: `77ed089be47e708f0ba54abdbd4271ee294d9aeb`
+- 비교 설계 문서가 추가된 감사 기준 브랜치: `audit/baseline-77ed089`
+- 감사 기준 브랜치 HEAD: `845ca09e38773c0ef128ee60c293b5af62ee8396`
+- 감사 worktree: `/private/tmp/kalyx-audit-baseline`
+
+기준선에서 먼저 `pnpm build`를 실행한 후 `pnpm test:run`을 실행했고, 45개 파일 / 776개 테스트가 통과했다.
+
+### Codex 구현
+
+- 브랜치: `fix/codex-correctness`
+- worktree: `/private/tmp/kalyx-codex-correctness`
+- 현재 기능 HEAD: `cf23681`
+- upstream 없음, 원격 push 안 됨, Codex PR 없음
+- working tree는 핸드오프 문서 작성 전 clean 상태였다.
+
+주요 계획 문서:
+
+- `docs/superpowers/specs/2026-08-03-claude-codex-correctness-comparison-design.md`
+- `docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md`
+
+SDD 진행 장부는 worktree의 git-ignored 경로에 있다.
+
+- `.superpowers/sdd/2026-08-03-timezone-constraint-transitions/progress.md`
+
+`/private/tmp` worktree는 영구 보존을 보장할 수 없으므로 새 세션은 먼저 worktree와 장부 존재 여부를 확인하고, 없으면 Git 커밋 기록과 이 문서를 기준으로 복구해야 한다.
+
+## 3. Claude PR 최신 상태
+
+2026-08-03 세션 종료 시점 기준 네 PR 모두 OPEN, non-draft, CI 전체 성공, GitHub `mergeStateStatus=BLOCKED`다.
+
+| PR | 브랜치 / 최신 SHA | 내용 | Codex 리뷰 핵심 |
+|---|---|---|---|
+| [#176](https://github.com/jiji-hoon96/kalyx/pull/176) | `claude/library-evaluation-2026-08-03` / `0d0300d1` | Claude 라이브러리 종합 평가·루브릭 | 최초 검토 뒤 head가 갱신됐다. 새 세션에서 `4af0606..0d0300d` 또는 현재 전체 diff를 다시 검토해야 한다. 초기 평가에는 P0 타임존 버그, 문서 컴파일 오류, 소비자 번들/tree-shaking, 실제 audit 결과가 충분히 반영되지 않았다. |
+| [#178](https://github.com/jiji-hoon96/kalyx/pull/178) | `fix/typed-input-disabled-validation` / `0e32d2e` | DatePicker typed input disabled guard | 검증이 타임존 정규화 전 좌표에 적용되고 UTC 테스트만 있다. DateTime/Range/headless에는 적용되지 않아 전체 제약 parity가 아니다. |
+| [#179](https://github.com/jiji-hoon96/kalyx/pull/179) | `fix/calendar-refocus-disabled-day` / `98c2c66` | disabled focused day의 Core flag 재타겟 | 파생 `isFocused` flag만 바꾸고 React `focusedDate` state는 유지한다. DOM은 월초를 포커스하지만 첫 Arrow는 원래 disabled 날짜 부근으로 점프할 수 있다. 정확한 이동 목적지를 검증하는 테스트가 필요하다. |
+| [#180](https://github.com/jiji-hoon96/kalyx/pull/180) | `fix/medium-correctness-polish` / `0c105f6` | TimePicker typed filter + exact date timezone | Core grid UTC 자정 좌표를 실제 타임존 instant로 오인하여 America/New_York 같은 음수 오프셋에서 exact-date 비활성화가 여전히 틀린다. TimePicker 검증도 Input 경로에만 있어 Context/DateTime/headless가 우회한다. |
+
+이번 세션에서 #176, #178, #179, #180에 위 내용을 GitHub review comment로 게시했다. 새 세션에서는 댓글 이후 추가 커밋과 답변이 있는지 먼저 확인한다.
+
+## 4. Codex 구현 커밋과 검증 상태
+
+| 커밋 | 내용 | 검증 |
+|---|---|---|
+| `b1bf461` | 타임존/제약 전이 구현 계획 | 문서 커밋 |
+| `6c8e200` | `calendarDayFromInstant` 민간 날짜 좌표 변환 | timezone 52/52, Core build |
+| `ca22d26` | selected/today/range/disabled를 실제 타임존 민간 자정 기준으로 판정 | Core calendar 집중 테스트 |
+| `09aaeb8` | focused flag도 동일 후보 instant 사용 | 리뷰 수정 라운드 통과 |
+| `3fe02c1` | `dayOfWeek`를 UTC 요일이 아닌 타임존 민간 요일로 판정 | Core calendar 55/55, Core build |
+| `d689a4f` | 계획에서 빠진 TimePicker Root 제약 경계 추가 | 문서 커밋 |
+| `d4386ae` | DatePicker/TimePicker/DateTimePicker Root 최종 검증, 프리셋·키보드·좌표 전이 | 집중 테스트 203/203, React typecheck/build |
+| `cf23681` | 타임존 미지정 time-bearing 값도 자정 grid 좌표로 정규화, DateTime 중복 제거 | 집중 테스트 205/205, React typecheck/build |
+
+### 구현된 핵심 동작
+
+- `CalendarDay.isoString`은 계속 UTC 자정 민간 날짜 좌표다.
+- 저장된 timezone civil-midnight instant는 `calendarDayFromInstant`로 grid 좌표화한다.
+- grid 좌표는 선택 시 `civilMidnightFromUtcDay`로 정확히 한 번만 저장 instant로 변환한다.
+- 선택/today/focus/range/hover/exact-date/day-of-week 플래그가 양·음수 오프셋에서 표시되는 민간 날짜를 따른다.
+- `before` / `after`는 기존 instant 비교 의미를 유지한다.
+- DatePicker Root가 typed input, preset, calendar selection의 최종 disabled gate다.
+- TimePicker Root가 typed input과 Context 기반 mutation의 최종 `filterTime` gate다.
+- DateTimePicker Root가 최종 merged datetime의 날짜 규칙과 표시 시간 규칙을 검증한다.
+- 거절된 mutation은 state/value callback을 변경하지 않는다.
+- DateTime atomic preset은 Root의 성공 boolean을 받아 성공한 경우에만 popover를 닫으며 실제 click의 consumer `onClick`은 유지한다.
+- 타임존 미지정 DateTime 값에 시간이 포함되어도 view/focus state는 UTC 자정 grid 좌표다.
+
+### 독립 리뷰 결과
+
+- Task 1: 리뷰 clean.
+- Task 2: 최초 리뷰에서 focus 누락을 발견해 수정했고, controller 교차 점검에서 민간 요일 누락을 추가 발견해 수정했다. 최종 리뷰 clean.
+- Task 3: 기본 UTC time-bearing 좌표 누락은 수정 완료. 번들 크기만 open finding이다.
+
+### 현재 번들 수치
+
+- 기준선: ESM 16.66 KB, CJS 16.91 KB gzip
+- Task 3 최초: ESM 16.98 KB, CJS 17.45 KB
+- 현재 최적화 후: ESM 16.96 KB, CJS 17.43 KB
+- 기존 목표: 각각 17 KB 이하
+- ESM은 통과, CJS는 439 B 초과
+
+헬퍼 추출 세 번은 raw size를 줄여도 gzip 반복 압축을 깨뜨려 17.49–17.52 KB로 악화돼 제거했다. 마지막으로 DateTime Root의 중복 시간 재계산/null 분기만 제거해 현재 수치를 얻었다. 빌드 설정이나 임계값은 변경하지 않았다.
+
+## 5. 아직 구현·검증하지 않은 작업
+
+### Task 3 종료 결정
+
+현재 SDD 장부에는 CJS 크기 finding이 open으로 남아 Task 3이 완료 처리되지 않았다.
+
+권장 결정:
+
+1. 기능 정확성 수정은 보존한다.
+2. Range/Week/headless까지 완료한다.
+3. 최종 전체 번들 수치를 다시 측정한다.
+4. 소비자 번들 기준과 현재 package artifact gate의 의미를 함께 검토한 뒤, 구조 최적화·예산 조정·별도 성능 PR 중 하나를 선택한다.
+
+단순히 17 KB 숫자를 맞추기 위해 Core 외부화나 빌드 minify 설정으로 측정치를 우회하면 안 된다. 시장/보안 감사에서 현재 번들 gate가 Core·adapter·Floating UI를 외부화해 실제 소비자 비용을 과소 표시한다고 이미 확인했다.
+
+### Task 4: RangePicker / WeekPicker
+
+아직 시작하지 않았다.
+
+- stored range/today의 view/focus 좌표 정규화
+- Range Root의 endpoint 최종 disabled validation
+- typed/direct/predefined preset parity
+- week selection의 timezone civil-midnight endpoint
+- clicked/calendar week anchor 보존
+- keyboard disabled predicate의 좌표/instant 일관성
+
+### Task 5: headless hooks
+
+아직 시작하지 않았다.
+
+- `useDatePicker`, `useRangePicker`, `useWeekPicker`, `useDateTimePicker`, `useTimePicker`
+- rendered Root와 동일한 좌표 변환 및 최종 gate
+- `filterTime` 옵션 추가 및 rejected mutation no-op
+
+### Task 6: 전체 검증·비교·PR
+
+아직 시작하지 않았다.
+
+- changeset 없음
+- Codex branch push 안 됨
+- Codex draft PR 없음
+- 전체 test/coverage/typecheck/lint/format/bundle/tree-shaking/E2E 미실행
+- Claude/Codex 최종 acceptance matrix 미작성
+
+## 6. 새 세션의 권장 실행 순서
+
+1. `/private/tmp/kalyx-codex-correctness` 존재 여부와 `git status`, `git log`를 확인한다. 없으면 `fix/codex-correctness`에서 새 외부 worktree를 만든다.
+2. `origin/main`과 Claude PR #176/#178/#179/#180의 최신 SHA, 댓글, 추가 커밋, CI 상태를 다시 조회한다.
+3. #176은 head가 검토 후 변경됐으므로 새 diff를 우선 리뷰한다.
+4. 계획 문서 Task 3 파일 목록에 실제 승인된 `packages/react/src/context/DatePickerContext.ts`와 `packages/react/src/components/DateTimePicker/Presets.tsx`를 추가한다.
+5. CJS finding을 기능 작업 종료 후 재판정하기로 결정했다면 SDD 장부에 근거와 함께 parked/deferred로 기록하고 Task 3을 완료 처리한다. 무근거로 clean 처리하지 않는다.
+6. Task 4를 strict TDD와 독립 task review로 구현한다.
+7. Task 5를 strict TDD와 독립 task review로 구현한다.
+8. 전체 브랜치 review 전에 다음을 순서대로 실행하고 실제 수치를 기록한다.
+
+```sh
+pnpm build
+pnpm test:run
+pnpm test:coverage
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm check-bundle
+pnpm check-tree-shaking
+pnpm test:e2e
+```
+
+9. docs-site 별도 typecheck도 실행한다. 기존 기준선에서는 `apps/docs-site/src/pages/index.tsx(11,33): Cannot find namespace 'JSX'`로 실패했다.
+10. Claude 각 PR과 Codex branch를 다음 acceptance 기준으로 비교한다.
+
+- New York/Seoul 선택·강조·재오픈
+- today/direct preset 단일 정규화
+- exact-date/day-of-week/before/after/filter 규칙
+- typed/calendar/preset/context/headless parity
+- rejected mutation의 state/callback/close 동작
+- disabled focus의 DOM/state/첫 Arrow 일관성
+- 테스트가 정확한 목적지를 assert하는지
+- 번들 delta와 public API 영향
+
+11. changeset과 최종 비교 문서를 추가하고, 전체 검증 후에만 `fix/codex-correctness`를 push해 draft PR을 만든다.
+
+## 7. 전체 라이브러리 감사에서 확인된 별도 우선순위
+
+이번 correctness 브랜치 범위 밖이지만 홍보 전에 해결하거나 공개적으로 제한을 설명해야 한다.
+
+### 기능/API
+
+- date-fns adapter의 `MMM` / `MMMM` 포맷이 `044`, `0404`처럼 깨진다.
+- parse 계약과 문서 예제가 실제 signature/동작과 다르다.
+- Day.js adapter가 `2026-02-30` 같은 불가능한 날짜를 수용한다.
+- Saturday-first locale을 Monday-first로 축소한다.
+- filtered listbox keyboard navigation이 disabled option에서 정체될 수 있다.
+
+### 릴리스/보안
+
+- root release build가 Day.js/Luxon adapter를 빌드하지 않아 clean publish 산출물이 누락될 수 있다.
+- docs가 production에서 unpinned Tailwind Play CDN을 로드하고 CSP가 없다.
+- live `pnpm audit --prod`는 17 high / 10 moderate / 1 low였으며 현재 확인된 경로는 private docs/build apps였다.
+- workflow action이 immutable SHA가 아니고, lockfile에 없는 `npx license-checker` / `serve` 실행이 있다.
+- release workflow `cancel-in-progress: true`는 multi-package publish 중간 취소 위험이 있다.
+- SECURITY.md가 1.0.0-rc.x만 지원 버전으로 적는다.
+
+### 문서/DX
+
+- Core API 문서가 `DateFnsAdapter`를 잘못 `@kalyx/core`에서 import한다.
+- docs가 제거된 `date-fns-tz` 의존성을 여전히 안내한다.
+- `fixedWeeks`/`timezone` 옵션과 4–6주 grid 계약이 문서에 정확히 반영되지 않았다.
+- docs-site typecheck가 JSX namespace 오류로 실패하며 CI는 이 script를 호출하지 않는다.
+- footer의 `pathname:///llms.txt`, 완화된 broken-link 설정, 오래된 SECURITY/RC/배포 문서가 남아 있다.
+
+### 시장/홍보
+
+Kalyx의 설득력 있는 포지션은 “ISO 문자열을 사용하는 zero-CSS React picker suite로 Date/Range/Time/DateTime/Month/Year/Week와 명시적 displayTimezone 변환을 MIT로 제공”하는 것이다.
+
+반면 “가장 작다”, “pay only for what you import”, “WCAG AA accessible by default” 같은 주장은 현재 근거가 부족하다.
+
+- consumer tree-shaking 측정: 단일 picker가 모두 23.42 KB gzip, 전체가 24.25 KB
+- 단일 picker 간 크기 차이가 없어 현재 tree-shaking 주장은 지지되지 않는다.
+- React peer가 `^19.0.0`만 허용해 React 18 시장을 제외한다.
+- broad promotion 전에 correctness, release integrity, honest consumer bundle claim을 먼저 정리하는 것이 권장된다.
+
+## 8. 세션 종료 체크리스트
+
+- 미완료 목표를 완료로 표시하지 않았다.
+- Claude PR은 merge하지 않았다.
+- Codex branch는 push/PR 생성하지 않았다.
+- main을 수정하거나 reset하지 않았다.
+- 다음 세션은 이 문서, Git 커밋, SDD 장부를 함께 확인해야 한다.

--- a/docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md
+++ b/docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md
@@ -90,6 +90,8 @@ Commit: `fix(core): align calendar flags with display timezone`
 - Modify: `packages/react/src/components/DatePicker/Presets.tsx`
 - Modify: `packages/react/src/components/TimePicker/Root.tsx`
 - Modify: `packages/react/src/components/DateTimePicker/Root.tsx`
+- Modify: `packages/react/src/components/DateTimePicker/Presets.tsx`
+- Modify: `packages/react/src/context/DatePickerContext.ts`
 - Test: `packages/react/src/components/DatePicker/DatePicker.test.tsx`
 - Test: `packages/react/src/components/TimePicker/TimePicker.test.tsx`
 - Test: `packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx`
@@ -107,7 +109,7 @@ Add component tests proving:
 - DateTimePicker rejects date commits whose merged datetime has a disabled civil date.
 - DateTimePicker rejects full presets and time mutations rejected by `filterTime`.
 
-Run the two component test files and observe the expected failures.
+Run the three component test files and observe the expected failures.
 
 **Step 2: Normalize view/focus coordinates**
 
@@ -119,7 +121,7 @@ In DatePicker `selectDate`, convert the coordinate once, then call `isDateDisabl
 
 In TimePicker `setTime`, derive the final displayed hours/minutes from the merged value and reject it through `filterTime` before state/callback. This keeps typed input, lists, and direct context calls on the same policy.
 
-In DateTimePicker, validate the final merged value in `updateValue`: date rules first, then `filterTime` using the final displayed hours/minutes. Permit `null`. This makes calendar, typed input, presets, and time controls share one gate.
+In DateTimePicker, validate the final merged value in `updateValue`: date rules first, then `filterTime` using the final displayed hours/minutes. Permit `null`. This makes calendar, typed input, presets, and time controls share one gate. Return an internal acceptance result for atomic preset commits, and close the preset popover only after an accepted commit; a rejected preset remains open while its consumer click callback still observes the click.
 
 **Step 4: Fix preset and keyboard boundary inputs**
 

--- a/docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md
+++ b/docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md
@@ -81,15 +81,17 @@ Run focused core tests and core build.
 
 Commit: `fix(core): align calendar flags with display timezone`
 
-### Task 3: Normalize DatePicker and DateTimePicker state transitions
+### Task 3: Normalize DatePicker, TimePicker, and DateTimePicker state transitions
 
 **Files:**
 
 - Modify: `packages/react/src/components/DatePicker/Root.tsx`
 - Modify: `packages/react/src/components/DatePicker/Calendar.tsx`
 - Modify: `packages/react/src/components/DatePicker/Presets.tsx`
+- Modify: `packages/react/src/components/TimePicker/Root.tsx`
 - Modify: `packages/react/src/components/DateTimePicker/Root.tsx`
 - Test: `packages/react/src/components/DatePicker/DatePicker.test.tsx`
+- Test: `packages/react/src/components/TimePicker/TimePicker.test.tsx`
 - Test: `packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx`
 
 **Step 1: Write failing transition tests**
@@ -101,6 +103,7 @@ Add component tests proving:
 - DatePicker `today` and direct-date presets emit exactly one timezone conversion.
 - Typed input matching a `{ date }`, `before`, `after`, `dayOfWeek`, or `filter` rule does not call `onChange`.
 - Calendar keyboard Enter and disabled-date focus checks use the same timezone-aware predicate.
+- TimePicker rejects typed and context-driven time mutations rejected by `filterTime` at the Root boundary.
 - DateTimePicker rejects date commits whose merged datetime has a disabled civil date.
 - DateTimePicker rejects full presets and time mutations rejected by `filterTime`.
 
@@ -114,6 +117,8 @@ In both roots, convert `currentValue`/timezone-aware today to `calendarDayFromIn
 
 In DatePicker `selectDate`, convert the coordinate once, then call `isDateDisabled(normalized, rules, adapter, displayTimezone)` before state/callback/close.
 
+In TimePicker `setTime`, derive the final displayed hours/minutes from the merged value and reject it through `filterTime` before state/callback. This keeps typed input, lists, and direct context calls on the same policy.
+
 In DateTimePicker, validate the final merged value in `updateValue`: date rules first, then `filterTime` using the final displayed hours/minutes. Permit `null`. This makes calendar, typed input, presets, and time controls share one gate.
 
 **Step 4: Fix preset and keyboard boundary inputs**
@@ -122,7 +127,7 @@ Resolve DatePicker presets in coordinate space by converting timezone-aware toda
 
 **Step 5: Verify and commit**
 
-Run focused component tests, React typecheck/build, and commit.
+Run all three focused component test files, React typecheck/build, and commit.
 
 Commit: `fix(react): normalize date picker transitions`
 

--- a/docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md
+++ b/docs/superpowers/plans/2026-08-03-timezone-constraint-transitions.md
@@ -1,0 +1,230 @@
+# Timezone and Constraint Transitions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make calendar civil-day identity and selection constraints consistent across rendered components, presets, keyboard input, and headless hooks without changing the public stored-value contract.
+
+**Architecture:** Keep calendar grid cells as UTC-midnight *civil-date coordinates* (`YYYY-MM-DDT00:00:00.000Z`). Convert those coordinates to real instants only at the selection boundary when `displayTimezone` is set. Convert stored instants back to grid coordinates when deriving the visible month or focused cell. Centralize final disabled/time-filter checks in Root and hook mutation functions so every interaction path shares the same policy.
+
+**Tech Stack:** TypeScript, React 19, Vitest, Testing Library, date-fns adapter, tsup.
+
+## Global Constraints
+
+- Work from baseline commit `77ed089be47e708f0ba54abdbd4271ee294d9aeb` plus the approved comparison spec only; do not cherry-pick Claude implementation commits.
+- Preserve the existing stored-value contract: date-only values under `displayTimezone` are UTC instants representing civil midnight in that timezone.
+- Preserve the existing grid-cell contract: `CalendarDay.isoString` remains a UTC-midnight civil-date coordinate.
+- `before` and `after` disabled rules remain instant comparisons for backward compatibility. Only `{ date }` gains timezone-aware civil-day equality.
+- A rejected selection is a no-op: no state change, no callback, and no popover close caused by that attempted commit.
+- Existing controlled values that are now disabled remain renderable; constraints gate new mutations only.
+
+### Task 1: Define the civil-date coordinate conversion
+
+**Files:**
+
+- Modify: `packages/core/src/utils/timezone.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/src/__tests__/timezone.test.ts`
+- Test: `packages/core/src/__tests__/timezone.property.test.ts`
+
+**Step 1: Write failing examples**
+
+Add tests for a new exported `calendarDayFromInstant(iso, timezone)` helper:
+
+- `2026-01-15T05:00:00.000Z` in `America/New_York` becomes `2026-01-15T00:00:00.000Z`.
+- `2025-12-31T15:00:00.000Z` in `Asia/Seoul` becomes `2026-01-01T00:00:00.000Z`.
+- Around generated DST-boundary instants, `civilMidnightFromUtcDay(calendarDayFromInstant(x, tz), tz)` is on the same civil day as `x`.
+
+Run: `pnpm vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts`
+
+Expected: FAIL because the export does not exist.
+
+**Step 2: Implement the minimum helper**
+
+Use the already-cached timezone parts in `timezone.ts`; construct a UTC ISO at midnight from the extracted civil year/month/day. Export it from `packages/core/src/index.ts`. Do not parse localized display strings.
+
+**Step 3: Verify and commit**
+
+Run the focused tests, then `pnpm --filter @kalyx/core build`.
+
+Commit: `fix(core): add civil date coordinate conversion`
+
+### Task 2: Make calendar flags and exact-date constraints timezone-correct
+
+**Files:**
+
+- Modify: `packages/core/src/utils/calendar.ts`
+- Test: `packages/core/src/__tests__/calendar.test.ts`
+- Test: `packages/core/src/__tests__/calendar.property.test.ts`
+
+**Step 1: Write failing calendar tests**
+
+Cover both offset directions:
+
+- A January grid with selected `2026-01-15T05:00:00.000Z` and `America/New_York` marks day 15, not 16.
+- A January grid with selected `2025-12-31T15:00:00.000Z` and `Asia/Seoul` marks January 1.
+- `today`, range start/end/interior, and `{ date }` disabled flags use the same displayed civil day.
+- `before`/`after` tests retain their current instant semantics.
+
+Run: `pnpm vitest run packages/core/src/__tests__/calendar.test.ts packages/core/src/__tests__/calendar.property.test.ts`
+
+Expected: FAIL on selected/range/exact-disabled civil-day assertions.
+
+**Step 2: Implement candidate conversion at the grid boundary**
+
+For each UTC grid coordinate, derive `candidateInstant` with `civilMidnightFromUtcDay` when a timezone is present. Use that instant for today, selected, range, and disabled comparisons while retaining the coordinate as `CalendarDay.isoString`, `dayNumber`, and month/week iteration state. Convert `rangeHover`, which is also a grid coordinate, before range preview comparison.
+
+Extend `isDateDisabled` with an optional timezone argument and pass it only to `{ date }` equality. Keep all other rule behavior unchanged.
+
+**Step 3: Verify and commit**
+
+Run focused core tests and core build.
+
+Commit: `fix(core): align calendar flags with display timezone`
+
+### Task 3: Normalize DatePicker and DateTimePicker state transitions
+
+**Files:**
+
+- Modify: `packages/react/src/components/DatePicker/Root.tsx`
+- Modify: `packages/react/src/components/DatePicker/Calendar.tsx`
+- Modify: `packages/react/src/components/DatePicker/Presets.tsx`
+- Modify: `packages/react/src/components/DateTimePicker/Root.tsx`
+- Test: `packages/react/src/components/DatePicker/DatePicker.test.tsx`
+- Test: `packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx`
+
+**Step 1: Write failing transition tests**
+
+Add component tests proving:
+
+- A stored Seoul January 1 value opens January, highlights January 1, and focuses that cell.
+- A New York January 15 value opens/highlights January 15 rather than January 16.
+- DatePicker `today` and direct-date presets emit exactly one timezone conversion.
+- Typed input matching a `{ date }`, `before`, `after`, `dayOfWeek`, or `filter` rule does not call `onChange`.
+- Calendar keyboard Enter and disabled-date focus checks use the same timezone-aware predicate.
+- DateTimePicker rejects date commits whose merged datetime has a disabled civil date.
+- DateTimePicker rejects full presets and time mutations rejected by `filterTime`.
+
+Run the two component test files and observe the expected failures.
+
+**Step 2: Normalize view/focus coordinates**
+
+In both roots, convert `currentValue`/timezone-aware today to `calendarDayFromInstant` for lazy view/focus initialization and every `open()` reset. Keep stored values untouched. Derive `onCalendarNavigate` from the coordinate view month.
+
+**Step 3: Centralize final validation**
+
+In DatePicker `selectDate`, convert the coordinate once, then call `isDateDisabled(normalized, rules, adapter, displayTimezone)` before state/callback/close.
+
+In DateTimePicker, validate the final merged value in `updateValue`: date rules first, then `filterTime` using the final displayed hours/minutes. Permit `null`. This makes calendar, typed input, presets, and time controls share one gate.
+
+**Step 4: Fix preset and keyboard boundary inputs**
+
+Resolve DatePicker presets in coordinate space by converting timezone-aware today/direct values to a calendar coordinate before calling `selectDate`. In Calendar keyboard checks, convert the focused coordinate to its timezone civil-midnight instant before `isDateDisabled`.
+
+**Step 5: Verify and commit**
+
+Run focused component tests, React typecheck/build, and commit.
+
+Commit: `fix(react): normalize date picker transitions`
+
+### Task 4: Normalize range, week, and preset transitions
+
+**Files:**
+
+- Modify: `packages/react/src/components/RangePicker/Root.tsx`
+- Modify: `packages/react/src/components/RangePicker/Calendar.tsx`
+- Modify: `packages/react/src/components/RangePicker/Presets.tsx`
+- Test: `packages/react/src/components/RangePicker/RangePicker.test.tsx`
+- Test: `packages/react/src/components/WeekPicker/WeekPicker.test.tsx`
+
+**Step 1: Write failing range/week tests**
+
+Add tests proving:
+
+- Stored zoned ranges open and highlight the correct month/endpoints in positive and negative offsets.
+- Typed and direct preset endpoints matching disabled rules are rejected without callback or close.
+- Predefined presets compute this week/month/year in the display timezone at UTC date boundaries.
+- Calendar week mode emits both endpoints as timezone civil-midnight instants.
+- `weekAnchor="clicked"` preserves its directional seven-day behavior after conversion.
+
+Run the focused test files and observe failures.
+
+**Step 2: Normalize Root transitions**
+
+Convert stored start/today to coordinates for view/focus initialization and open. Convert clicked coordinates once in `selectDate`. Put endpoint constraint validation in `setRange` so typed input, presets, week mode, and direct headless-style context calls share it.
+
+**Step 3: Normalize week and preset calculations**
+
+Compute calendar weeks and predefined preset periods in coordinate space, then convert non-null endpoints exactly once before `setRange`. Pass timezone to active-state civil-day comparisons. Convert keyboard candidates before disabled checks.
+
+**Step 4: Verify and commit**
+
+Run focused tests and React build.
+
+Commit: `fix(react): normalize range and week transitions`
+
+### Task 5: Bring headless hooks to parity
+
+**Files:**
+
+- Modify: `packages/react/src/hooks/useDatePicker.ts`
+- Modify: `packages/react/src/hooks/useRangePicker.ts`
+- Modify: `packages/react/src/hooks/useWeekPicker.ts`
+- Modify: `packages/react/src/hooks/useDateTimePicker.ts`
+- Modify: `packages/react/src/hooks/useTimePicker.ts`
+- Test: corresponding `packages/react/src/hooks/*.test.tsx`
+
+**Step 1: Write failing hook tests**
+
+For each hook, prove the same timezone month/focus and rejection outcomes as its component Root. Add `filterTime` to the time and datetime hook options and verify rejected mutations do not update uncontrolled state or call `onChange`. Verify week endpoints are timezone civil midnights.
+
+Run: `pnpm vitest run packages/react/src/hooks/useDatePicker.test.tsx packages/react/src/hooks/useRangePicker.test.tsx packages/react/src/hooks/useWeekPicker.test.tsx packages/react/src/hooks/useDateTimePicker.test.tsx packages/react/src/hooks/useTimePicker.test.tsx`
+
+Expected: FAIL for the new parity assertions and missing options.
+
+**Step 2: Implement shared transition semantics**
+
+Apply the same coordinate conversion and root-level validation order used by the rendered components. Avoid new React-global state or a behavior-heavy abstraction; small pure helpers may be added only where they remove literal duplicated conversion logic.
+
+**Step 3: Verify and commit**
+
+Run focused hook tests, React typecheck/build, and commit.
+
+Commit: `fix(react): enforce constraints in headless hooks`
+
+### Task 6: Full regression and comparison evidence
+
+**Files:**
+
+- Modify if needed: tests only for regressions found during verification
+- Add: `.changeset/<generated-correctness-name>.md`
+- Add: `docs/reviews/2026-08-03-claude-codex-correctness-comparison.md`
+
+**Step 1: Run repository gates**
+
+Run in this exact order:
+
+1. `pnpm build`
+2. `pnpm test:run`
+3. `pnpm test:coverage`
+4. `pnpm typecheck`
+5. `pnpm lint`
+6. `pnpm format:check`
+7. `pnpm check-bundle`
+8. `pnpm check-tree-shaking`
+9. `pnpm test:e2e`
+
+Record command, exit status, test counts, coverage, bundle sizes, and any pre-existing failures. Do not call a gate successful from stale CI or another worktree.
+
+**Step 2: Add release note**
+
+Add patch changesets for `@kalyx/core` and `@kalyx/react` describing civil-day correctness and consistent selection constraint enforcement.
+
+**Step 3: Compare against Claude PRs**
+
+Review PRs #178, #179, and #180 at their current head SHAs. Compare acceptance-test coverage, public API impact, root-cause handling, duplication, regression risk, bundle delta, and residual bugs. Because their summaries were visible before this implementation, label the comparison as outcome-based rather than blind.
+
+**Step 4: Commit and open a draft PR**
+
+Commit verification notes, push `fix/codex-correctness`, and open a draft PR targeting `main`. Include the baseline SHA, verification matrix, known limitations, and links to the Claude PRs.
+
+Commit: `docs: compare Claude and Codex correctness fixes`

--- a/docs/superpowers/specs/2026-08-03-claude-codex-correctness-comparison-design.md
+++ b/docs/superpowers/specs/2026-08-03-claude-codex-correctness-comparison-design.md
@@ -1,0 +1,254 @@
+# Claude/Codex Correctness Comparison Design
+
+**Date:** 2026-08-03  
+**Status:** Approved design, pending maintainer review of this written specification  
+**Audited source baseline:** `77ed089be47e708f0ba54abdbd4271ee294d9aeb`  
+**Purpose:** Compare two independent implementations of the same Kalyx correctness repair without allowing shared-checkout interference or cross-model contamination.
+
+## 1. Decision
+
+Run Claude and Codex as independent implementations from the same immutable baseline. Each implementation receives the same public acceptance contract and uses a separate Git worktree. Both submit Draft PRs against an audit baseline branch, not directly against `main`.
+
+The two Draft PRs are experiments. They must not both be merged. A separate evaluator applies withheld adversarial tests and a predeclared scorecard, then selects one implementation or constructs a small integration branch from the best verified parts.
+
+## 2. Why This Comparison Exists
+
+The current suite passes 776 Vitest tests and 93 cross-browser E2E tests, but audit reproductions found correctness failures at integration boundaries:
+
+- A New York civil-day value can highlight the next UTC calendar cell.
+- A positive-offset first-of-month value can reopen in the previous UTC month.
+- Preset, week-selection, component, and headless paths do not share one timezone-normalization boundary.
+- Typed input and presets can bypass `disabled` or `filterTime` constraints that individual visual controls enforce.
+
+The experiment therefore evaluates domain modeling and regression protection, not code-generation speed or feature volume.
+
+## 3. Repository and Branch Topology
+
+```text
+77ed089be47e708f0ba54abdbd4271ee294d9aeb
+└── audit/baseline-77ed089
+    ├── fix/claude-correctness
+    └── fix/codex-correctness
+
+After both Draft PRs are frozen:
+
+audit/model-comparison
+└── optional fix/timezone-constraints-integration
+```
+
+Rules:
+
+1. `audit/baseline-77ed089` is immutable after this specification is committed.
+2. Claude and Codex use different external worktrees. Neither may use the shared root checkout.
+3. Both implementation branches start from the same head of `audit/baseline-77ed089`: the audited source baseline plus this specification-only commit.
+4. Both Draft PRs target `audit/baseline-77ed089`.
+5. Neither implementation may inspect the other implementation branch or PR until both heads are frozen.
+6. No rebasing, cherry-picking, or merging between experiment branches is allowed before scoring.
+7. Only the selected or separately integrated implementation may later target `main`.
+
+Recommended worktree paths:
+
+```text
+/private/tmp/kalyx-claude-correctness
+/private/tmp/kalyx-codex-correctness
+/private/tmp/kalyx-model-comparison
+```
+
+## 4. First Comparison Scope
+
+The first comparison is intentionally limited to one correctness domain: civil-day/time constraint handling across all selection paths.
+
+### In scope
+
+- Calendar selected/today/range/focus identity with `displayTimezone`.
+- Initial and controlled `viewMonth` derivation at timezone month boundaries.
+- DatePicker and DateTimePicker preset timezone normalization.
+- RangePicker week mode and `useWeekPicker` timezone normalization.
+- A single Root-level constraint boundary for calendar click, typed input, preset, and headless state transitions.
+- `filterTime` enforcement for typed time, list selection, DateTimePicker composition, and presets.
+- Regression tests covering each repaired route.
+- Minimal documentation or comments needed to define the repaired contract.
+
+### Explicitly out of scope
+
+- Adapter `format`/`parse` redesign.
+- Tree-shaking or package-entry redesign.
+- Release workflow and adapter publishing fixes.
+- Documentation-site cleanup.
+- React 18 support.
+- New picker features, Temporal, non-Gregorian calendars, or visual redesign.
+- Unrelated refactoring or formatting.
+
+Out-of-scope findings become separate workstreams after this experiment. Mixing them into the first comparison would make correctness and implementation quality harder to compare.
+
+## 5. Public Domain Contract
+
+Both implementers receive this section verbatim.
+
+### 5.1 Value semantics
+
+- Public values remain ISO 8601 UTC strings. This experiment must not introduce a breaking public value type.
+- With no `displayTimezone`, existing UTC behavior remains unchanged.
+- With `displayTimezone`, a calendar cell represents a civil date in that zone. Selected, today, range, and focused-cell flags must compare civil-date identity rather than reinterpret a UTC-midnight grid cell as an arbitrary instant.
+- Converting a chosen civil date/time to its stored UTC instant happens exactly once.
+- Reopening a stored value derives the visible civil month in `displayTimezone`, including values whose UTC instant falls in the prior or next UTC month.
+
+### 5.2 Selection-path parity
+
+The following paths must produce equivalent canonical values for equivalent user intent:
+
+- Calendar click.
+- Typed input.
+- DatePicker/DateTimePicker preset.
+- RangePicker week selection.
+- Corresponding headless hook action.
+- Controlled value update followed by reopen.
+
+No path may double-normalize an already canonical stored instant or bypass required normalization.
+
+### 5.3 Constraint semantics
+
+- `disabled`, min/max bounds, and `filterTime` are state-transition invariants, not merely visual-control behavior.
+- Calendar cells and time options still expose disabled UI state, but Root-level transitions must reject invalid values regardless of whether the request came from click, keyboard, typed input, preset, composition, or headless action.
+- A rejected transition must not call the public `onChange` callback with the invalid value.
+- Existing valid controlled and uncontrolled flows must remain compatible.
+- Invalid-input UX redesign is out of scope; preserve current visible behavior unless the minimum correction requires a localized change.
+
+### 5.4 Compatibility constraints
+
+- No breaking public API change.
+- No new production dependency without maintainer approval.
+- No weakening or removal of existing tests, accessibility behavior, SSR guarantees, or bundle gates.
+- Changes must be surgical and restricted to the correctness domain.
+
+## 6. Public Acceptance Checks
+
+Each implementation must add visible regression tests for at least these categories:
+
+1. A negative-offset zone reopens and highlights the intended civil day.
+2. A positive-offset zone reopens a first-of-month value in the intended civil month.
+3. Preset selection in a positive-offset zone does not shift by a second normalization.
+4. Week selection returns the intended civil week in positive and negative offsets.
+5. Component and headless paths return the same canonical range.
+6. Typed disabled dates do not commit or call `onChange`.
+7. Disabled presets do not commit or call `onChange`.
+8. Typed or preset times rejected by `filterTime` do not commit or call `onChange`.
+9. Existing no-timezone behavior remains unchanged.
+10. Controlled external value changes still update the visible month and selection.
+
+Required verification commands, run after a clean build:
+
+```bash
+pnpm build
+pnpm test:run
+pnpm test:coverage
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm check-bundle
+pnpm check-tree-shaking
+pnpm test:e2e
+```
+
+The clean-checkout prerequisite is explicit: `pnpm test:run` currently cannot resolve workspace package entries before `pnpm build` creates `dist`.
+
+## 7. Withheld Evaluation
+
+The evaluator keeps exact adversarial fixtures and judge tests outside the baseline and both implementation worktrees until both Draft PR heads are frozen. Implementers know the invariant categories but not the exact withheld cases.
+
+Withheld coverage should include:
+
+- Positive, negative, zero, and fractional UTC offsets.
+- DST gap and overlap dates.
+- Civil month/year boundaries.
+- Controlled prop updates while a picker is open.
+- Equivalent actions through click, keyboard, typed input, preset, and headless APIs.
+- Disabled/filter predicates that reject only a subset of a day or hour.
+- Callback call counts and rejected-transition state stability.
+- SSR render and hydration stability around timezone-derived initial state.
+- Bundle delta and accidental public-export changes.
+
+The exact zones, dates, predicates, and test source are not committed to either experiment branch. The evaluator records their hash and result summary in `audit/model-comparison` after both implementations are frozen.
+
+## 8. Scoring
+
+| Dimension | Weight | Evidence |
+|---|---:|---|
+| Withheld correctness | 35% | Pass rate and severity of failures in adversarial tests |
+| Regression-test quality | 20% | Failure before fix, path coverage, semantic assertions |
+| Public API compatibility | 15% | Type/export diff and consumer smoke tests |
+| Simplicity and change scope | 10% | Diff size, cohesion, duplicated normalization logic |
+| Bundle/performance impact | 10% | ESM/CJS gzip delta and consumer benchmark |
+| Documentation clarity | 5% | Accuracy of changed contract comments/docs |
+| Security/release impact | 5% | New dependencies, unsafe parsing/state behavior |
+
+Tie-break order:
+
+1. Fewer high-severity withheld failures.
+2. Clearer single ownership of normalization and constraints.
+3. Smaller compatible implementation.
+4. Lower bundle increase.
+
+Automatic disqualification:
+
+- Weakening or deleting a relevant existing test to make the suite pass.
+- Breaking the public ISO-string contract.
+- Silently dropping timezone or constraint behavior.
+- Reading or copying the competing implementation before both heads freeze.
+- Introducing unrelated product features or broad refactors.
+
+## 9. Evidence Required in Each Draft PR
+
+Each implementer must provide:
+
+- Root-cause explanation.
+- Explicit representation and normalization invariants.
+- File-level change summary.
+- Tests added and the bug each would have caught.
+- Full verification command results.
+- Bundle sizes and delta from baseline.
+- Known limitations and remaining out-of-scope findings.
+- Confirmation that no competing branch or PR was inspected.
+
+PR titles:
+
+```text
+fix(experiment/claude): unify timezone and constraint transitions
+fix(experiment/codex): unify timezone and constraint transitions
+```
+
+Both PRs remain Draft and carry an `experiment-do-not-merge` label until scoring is complete.
+
+## 10. Evaluation and Integration Flow
+
+1. Freeze both branch heads and record their SHAs.
+2. Run public verification independently on both SHAs.
+3. Apply the same withheld judge suite to both SHAs.
+4. Score without reading model identity where practical; use implementation labels A/B in the score sheet.
+5. Review diffs only after automated results are recorded.
+6. Select one implementation if it satisfies the contract cleanly.
+7. If neither is sufficient, write a short integration design using the verified strengths of each; do not merge both branches wholesale.
+8. Create one final PR against `main` and rerun the complete release gate from a clean checkout.
+9. Close the losing Draft PRs with a link to the comparison report; preserve them for auditability.
+
+## 11. Failure and Collision Handling
+
+- The shared root checkout is considered unsafe for experiment work because a parallel process already changed its active branch during audit setup.
+- An implementer that discovers a dirty or switched worktree stops and reports it; it does not reset, stash, or revert another process's files.
+- If `main` advances, the experiment continues on the frozen baseline. Upstream changes are considered only after comparison scoring.
+- If baseline setup fails, record whether the failure occurs before or after the required clean build. Do not attribute missing `dist` imports to an implementation.
+- Network-dependent tools and browser downloads are setup prerequisites, not product-test failures; record them separately.
+
+## 12. Success Criteria
+
+The comparison is complete only when:
+
+- Both implementations started from the same immutable baseline.
+- Both Draft PR heads are frozen and independently reproducible.
+- Public and withheld results are recorded for both.
+- The scorecard is completed with evidence.
+- Exactly one integration path is selected.
+- The final candidate has no known P0/P1 failure in this experiment's scope.
+- The final candidate passes the clean build, full unit/coverage, type, lint, bundle, and three-browser E2E gates.
+
+Promotion remains out of scope until the separate release, documentation, dependency-security, and honest-bundle-measurement workstreams also pass their gates.

--- a/packages/core/src/__tests__/calendar.property.test.ts
+++ b/packages/core/src/__tests__/calendar.property.test.ts
@@ -98,6 +98,24 @@ describe('getCalendarDays invariants (property-based)', () => {
       RUNS,
     );
   });
+
+  it('marks the grid coordinate matching a stored New York civil midnight', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: 28 }), (day) => {
+        const dayText = String(day).padStart(2, '0');
+        const selected = `2026-01-${dayText}T05:00:00.000Z`;
+        const days = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+          selected,
+          timezone: 'America/New_York',
+        }).flat();
+        const selectedDays = days.filter((calendarDay) => calendarDay.isSelected);
+
+        expect(selectedDays).toHaveLength(1);
+        expect(selectedDays[0]!.dayNumber).toBe(day);
+      }),
+      RUNS,
+    );
+  });
 });
 
 describe('getISOWeekNumber invariants (property-based)', () => {

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -57,6 +57,28 @@ describe('getCalendarDays — basic month grid', () => {
     expect(selectedDays[0]!.dayNumber).toBe(15);
   });
 
+  it('marks the New York civil day of a selected midnight, not the following UTC grid cell', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      selected: '2026-01-15T05:00:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    const selectedDays = weeks.flat().filter((day) => day.isSelected);
+    expect(selectedDays).toHaveLength(1);
+    expect(selectedDays[0]!.dayNumber).toBe(15);
+  });
+
+  it('marks January 1 for a Seoul selected civil midnight stored on the prior UTC day', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      selected: '2025-12-31T15:00:00.000Z',
+      timezone: 'Asia/Seoul',
+    });
+
+    const selectedDays = weeks.flat().filter((day) => day.isSelected);
+    expect(selectedDays).toHaveLength(1);
+    expect(selectedDays[0]!.dayNumber).toBe(1);
+  });
+
   it('flags today correctly', () => {
     const today = '2026-01-20T00:00:00.000Z';
     const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
@@ -65,6 +87,20 @@ describe('getCalendarDays — basic month grid', () => {
     const todayDays = weeks.flat().filter((d) => d.isToday);
     expect(todayDays).toHaveLength(1);
     expect(todayDays[0]!.dayNumber).toBe(20);
+  });
+
+  it('uses the displayed New York civil day for today and exact-date disabled flags', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      today: '2026-01-20T05:00:00.000Z',
+      disabled: [{ date: '2026-01-15T05:00:00.000Z' }],
+      timezone: 'America/New_York',
+    });
+    const days = weeks.flat();
+
+    expect(days.find((day) => day.dayNumber === 20 && day.isCurrentMonth)?.isToday).toBe(true);
+    expect(days.find((day) => day.dayNumber === 21 && day.isCurrentMonth)?.isToday).toBe(false);
+    expect(days.find((day) => day.dayNumber === 15 && day.isCurrentMonth)?.isDisabled).toBe(true);
+    expect(days.find((day) => day.dayNumber === 16 && day.isCurrentMonth)?.isDisabled).toBe(false);
   });
 
   it('flags disabled dates correctly', () => {
@@ -203,6 +239,24 @@ describe('isDateDisabled — combined rules', () => {
     expect(isDateDisabled('2026-06-16T23:00:00.000Z', after, adapter)).toBe(false);
   });
 
+  it('keeps before/after rules as instant comparisons when a display timezone is supplied', () => {
+    const before = [{ before: '2026-06-17T00:00:00.000Z' as const }];
+    const after = [{ after: '2026-06-17T00:00:00.000Z' as const }];
+
+    expect(isDateDisabled('2026-06-16T23:00:00.000Z', before, adapter, 'America/New_York')).toBe(
+      true,
+    );
+    expect(isDateDisabled('2026-06-17T01:00:00.000Z', before, adapter, 'America/New_York')).toBe(
+      false,
+    );
+    expect(isDateDisabled('2026-06-17T01:00:00.000Z', after, adapter, 'America/New_York')).toBe(
+      true,
+    );
+    expect(isDateDisabled('2026-06-16T23:00:00.000Z', after, adapter, 'America/New_York')).toBe(
+      false,
+    );
+  });
+
   it('honors a programmatic filter rule', () => {
     const holidays = new Set(['2026-01-01T00:00:00.000Z', '2026-12-25T00:00:00.000Z']);
     const rules = [{ filter: (iso: string) => holidays.has(iso) }];
@@ -291,6 +345,35 @@ describe('getCalendarDays — range handling', () => {
     expect(outside?.isRangeStart).toBe(false);
     expect(outside?.isRangeEnd).toBe(false);
     expect(outside?.isInRange).toBe(false);
+  });
+
+  it('uses New York civil-midnight instants for range boundaries and interior cells', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      range: {
+        start: '2026-01-10T05:00:00.000Z',
+        end: '2026-01-15T05:00:00.000Z',
+      },
+      timezone: 'America/New_York',
+    });
+    const days = weeks.flat();
+
+    expect(days.find((day) => day.dayNumber === 10 && day.isCurrentMonth)?.isRangeStart).toBe(true);
+    expect(days.find((day) => day.dayNumber === 12 && day.isCurrentMonth)?.isInRange).toBe(true);
+    expect(days.find((day) => day.dayNumber === 15 && day.isCurrentMonth)?.isRangeEnd).toBe(true);
+    expect(days.find((day) => day.dayNumber === 16 && day.isCurrentMonth)?.isRangeEnd).toBe(false);
+  });
+
+  it('converts a New York grid-coordinate hover to a civil-midnight preview endpoint', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      range: { start: '2026-01-10T05:00:00.000Z', end: null },
+      rangeHover: '2026-01-15T00:00:00.000Z',
+      timezone: 'America/New_York',
+    });
+    const days = weeks.flat();
+
+    expect(days.find((day) => day.dayNumber === 10 && day.isCurrentMonth)?.isRangeStart).toBe(true);
+    expect(days.find((day) => day.dayNumber === 12 && day.isCurrentMonth)?.isInRange).toBe(true);
+    expect(days.find((day) => day.dayNumber === 15 && day.isCurrentMonth)?.isRangeEnd).toBe(true);
   });
 
   it('auto-sorts when start comes after end', () => {

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -79,6 +79,17 @@ describe('getCalendarDays — basic month grid', () => {
     expect(selectedDays[0]!.dayNumber).toBe(1);
   });
 
+  it('marks the New York civil day of a focused midnight, not the following UTC grid cell', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      focusedDate: '2026-01-15T05:00:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    const focusedDays = weeks.flat().filter((day) => day.isFocused);
+    expect(focusedDays).toHaveLength(1);
+    expect(focusedDays[0]!.dayNumber).toBe(15);
+  });
+
   it('flags today correctly', () => {
     const today = '2026-01-20T00:00:00.000Z';
     const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {

--- a/packages/core/src/__tests__/calendar.test.ts
+++ b/packages/core/src/__tests__/calendar.test.ts
@@ -126,6 +126,28 @@ describe('getCalendarDays — basic month grid', () => {
     }
   });
 
+  it('disables the Seoul visual Sunday rather than its preceding UTC Saturday', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      disabled: [{ dayOfWeek: [0] }],
+      timezone: 'Asia/Seoul',
+    });
+    const days = weeks.flat();
+
+    expect(days.find((day) => day.dayNumber === 4 && day.isCurrentMonth)?.isDisabled).toBe(true);
+    expect(days.find((day) => day.dayNumber === 3 && day.isCurrentMonth)?.isDisabled).toBe(false);
+  });
+
+  it('disables the New York visual Sunday using its civil weekday', () => {
+    const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter, {
+      disabled: [{ dayOfWeek: [0] }],
+      timezone: 'America/New_York',
+    });
+    const days = weeks.flat();
+
+    expect(days.find((day) => day.dayNumber === 4 && day.isCurrentMonth)?.isDisabled).toBe(true);
+    expect(days.find((day) => day.dayNumber === 5 && day.isCurrentMonth)?.isDisabled).toBe(false);
+  });
+
   it('includes leading and trailing days from adjacent months', () => {
     const weeks = getCalendarDays('2026-01-01T00:00:00.000Z', adapter);
     const outsideDays = weeks.flat().filter((d) => !d.isCurrentMonth);

--- a/packages/core/src/__tests__/timezone.property.test.ts
+++ b/packages/core/src/__tests__/timezone.property.test.ts
@@ -6,6 +6,7 @@ import {
   getTimeInTimezone,
   setTimeInTimezone,
   civilMidnightFromUtcDay,
+  calendarDayFromInstant,
   formatInTimezone,
   todayInTimezone,
 } from '../utils/timezone.js';
@@ -170,6 +171,30 @@ describe('Feb 29 round-trip where the civil date differs from the UTC date (T-R2
       'Asia/Seoul',
     );
     expect(formatInTimezone(at0930, 'yyyy-MM-dd HH:mm', 'Asia/Seoul')).toBe('2024-02-29 09:30');
+  });
+});
+
+describe('calendarDayFromInstant around DST boundaries', () => {
+  const boundaryInstants = [
+    ['2026-03-08T06:59:59.000Z', 'America/New_York'],
+    ['2026-03-08T07:00:00.000Z', 'America/New_York'],
+    ['2026-11-01T05:59:59.000Z', 'America/New_York'],
+    ['2026-11-01T06:00:00.000Z', 'America/New_York'],
+    ['2026-03-29T00:59:59.000Z', 'Europe/London'],
+    ['2026-03-29T01:00:00.000Z', 'Europe/London'],
+    ['2026-10-25T00:59:59.000Z', 'Europe/London'],
+    ['2026-10-25T01:00:00.000Z', 'Europe/London'],
+  ] as const;
+
+  it('round-trips each instant through its UTC calendar-day coordinate without changing civil day', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...boundaryInstants), ([iso, tz]) => {
+        const calendarDay = calendarDayFromInstant(iso, tz);
+        const civilMidnight = civilMidnightFromUtcDay(calendarDay, tz);
+        expect(isSameDayInTimezone(civilMidnight, iso, tz)).toBe(true);
+      }),
+      RUNS,
+    );
   });
 });
 

--- a/packages/core/src/__tests__/timezone.test.ts
+++ b/packages/core/src/__tests__/timezone.test.ts
@@ -5,6 +5,7 @@ import {
   isSameDayInTimezone,
   getTimezoneOffsetMinutes,
   civilMidnightFromUtcDay,
+  calendarDayFromInstant,
   getTimeInTimezone,
   setTimeInTimezone,
 } from '../utils/timezone.js';
@@ -213,6 +214,20 @@ describe('civilMidnightFromUtcDay — calendar-grid cell bridge', () => {
   it('keeps the same day on UTC-midnight → UTC', () => {
     expect(civilMidnightFromUtcDay('2026-06-15T00:00:00.000Z', 'UTC')).toBe(
       '2026-06-15T00:00:00.000Z',
+    );
+  });
+});
+
+describe('calendarDayFromInstant — civil-date calendar coordinate', () => {
+  it('returns the New York civil date as a UTC-midnight coordinate', () => {
+    expect(calendarDayFromInstant('2026-01-15T05:00:00.000Z', 'America/New_York')).toBe(
+      '2026-01-15T00:00:00.000Z',
+    );
+  });
+
+  it('returns the next UTC calendar day when Seoul observes New Year', () => {
+    expect(calendarDayFromInstant('2025-12-31T15:00:00.000Z', 'Asia/Seoul')).toBe(
+      '2026-01-01T00:00:00.000Z',
     );
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export {
   todayInTimezone,
   getTimezoneOffsetMinutes,
   civilMidnightFromUtcDay,
+  calendarDayFromInstant,
   getTimeInTimezone,
   setTimeInTimezone,
 } from './utils/timezone.js';

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -7,7 +7,7 @@ import type {
   DisabledRule,
   ISODateString,
 } from '../types.js';
-import { civilMidnightFromUtcDay } from './timezone.js';
+import { calendarDayFromInstant, civilMidnightFromUtcDay } from './timezone.js';
 
 /**
  * Builds the calendar grid for the given month.
@@ -210,7 +210,8 @@ export function isDateDisabled(
     } else if ('after' in rule) {
       if (adapter.isAfter(iso, rule.after)) return true;
     } else if ('dayOfWeek' in rule) {
-      if (rule.dayOfWeek.includes(adapter.getDay(iso))) return true;
+      const dayOfWeekCoordinate = timezone ? calendarDayFromInstant(iso, timezone) : iso;
+      if (rule.dayOfWeek.includes(adapter.getDay(dayOfWeekCoordinate))) return true;
     } else if ('filter' in rule) {
       if (rule.filter(iso)) return true;
     }

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -71,7 +71,9 @@ export function getCalendarDays(
       const isSelected_ = selected
         ? adapter.isSameDay(candidateInstant, selected, timezone)
         : false;
-      const isFocused_ = focusedDate ? adapter.isSameDay(current, focusedDate, timezone) : false;
+      const isFocused_ = focusedDate
+        ? adapter.isSameDay(candidateInstant, focusedDate, timezone)
+        : false;
       const isDisabled_ = isDateDisabled(candidateInstant, disabled, adapter, timezone);
 
       const rangeFlags = computeRangeFlags(candidateInstant, normalizedRange, adapter, timezone);

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -7,6 +7,7 @@ import type {
   DisabledRule,
   ISODateString,
 } from '../types.js';
+import { civilMidnightFromUtcDay } from './timezone.js';
 
 /**
  * Builds the calendar grid for the given month.
@@ -52,7 +53,9 @@ export function getCalendarDays(
   const gridStart = adapter.startOfWeek(monthStart, weekStartsOn);
 
   // Normalize for range computation (ensures start <= end)
-  const normalizedRange = normalizeRangeForDisplay(range, rangeHover, adapter, timezone);
+  const candidateRangeHover =
+    timezone && rangeHover ? civilMidnightFromUtcDay(rangeHover, timezone) : rangeHover;
+  const normalizedRange = normalizeRangeForDisplay(range, candidateRangeHover, adapter, timezone);
 
   const weeks: CalendarGrid = [];
   let current = gridStart;
@@ -62,13 +65,16 @@ export function getCalendarDays(
     const days: CalendarDay[] = [];
 
     for (let day = 0; day < 7; day++) {
+      const candidateInstant = timezone ? civilMidnightFromUtcDay(current, timezone) : current;
       const isCurrentMonth = adapter.isSameMonth(current, monthISO);
-      const isTodayDate = adapter.isSameDay(current, todayISO, timezone);
-      const isSelected_ = selected ? adapter.isSameDay(current, selected, timezone) : false;
+      const isTodayDate = adapter.isSameDay(candidateInstant, todayISO, timezone);
+      const isSelected_ = selected
+        ? adapter.isSameDay(candidateInstant, selected, timezone)
+        : false;
       const isFocused_ = focusedDate ? adapter.isSameDay(current, focusedDate, timezone) : false;
-      const isDisabled_ = isDateDisabled(current, disabled, adapter);
+      const isDisabled_ = isDateDisabled(candidateInstant, disabled, adapter, timezone);
 
-      const rangeFlags = computeRangeFlags(current, normalizedRange, adapter, timezone);
+      const rangeFlags = computeRangeFlags(candidateInstant, normalizedRange, adapter, timezone);
 
       days.push({
         isoString: current,
@@ -188,10 +194,15 @@ function computeRangeFlags(
 /**
  * Checks whether the given date matches any disable rule.
  */
-export function isDateDisabled(iso: string, rules: DisabledRule[], adapter: DateAdapter): boolean {
+export function isDateDisabled(
+  iso: string,
+  rules: DisabledRule[],
+  adapter: DateAdapter,
+  timezone?: string,
+): boolean {
   for (const rule of rules) {
     if ('date' in rule) {
-      if (adapter.isSameDay(iso, rule.date)) return true;
+      if (adapter.isSameDay(iso, rule.date, timezone)) return true;
     } else if ('before' in rule) {
       if (adapter.isBefore(iso, rule.before)) return true;
     } else if ('after' in rule) {

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -166,6 +166,22 @@ export function civilMidnightFromUtcDay(
 }
 
 /**
+ * Converts a UTC instant to the UTC-midnight calendar coordinate for its civil date in `timeZone`.
+ *
+ * Calendar grids iterate using UTC-midnight coordinates, while stored values are real instants at
+ * civil midnight in the display timezone. This helper bridges the two representations without
+ * parsing localized display strings.
+ *
+ * @example
+ * calendarDayFromInstant('2025-12-31T15:00:00.000Z', 'Asia/Seoul');
+ * // → '2026-01-01T00:00:00.000Z'
+ */
+export function calendarDayFromInstant(iso: ISODateString, timeZone: string): ISODateString {
+  const p = partsInTimezone(new Date(iso), timeZone);
+  return new Date(Date.UTC(p.year, p.month - 1, p.day)).toISOString();
+}
+
+/**
  * Extracts the time-of-day (hours / minutes / seconds) of a UTC instant as observed in
  * `timeZone`. The result differs from reading UTC hours when the zone has a non-zero offset.
  *

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,9 +1,9 @@
 # @kalyx/react
 
-> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~16.64 KB gzip (≤ 20 KB ceiling).
+> The headless React DatePicker, finally complete. Zero CSS · SSR-safe · ~18.28 KB gzip (≤ 20 KB ceiling).
 
 [![npm](https://img.shields.io/npm/v/@kalyx/react?color=5b4fe1)](https://www.npmjs.com/package/@kalyx/react)
-[![Bundle](https://img.shields.io/badge/gzip-16.64KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
+[![Bundle](https://img.shields.io/badge/gzip-18.28KB-brightgreen)](https://kalyx-docs-site.vercel.app/docs/api/react#bundle-size)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/jiji-hoon96/kalyx/blob/main/LICENSE)
 

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
+  civilMidnightFromUtcDay,
   getCalendarDays,
   getISOWeekNumber,
   isDateDisabled,
@@ -81,7 +82,10 @@ export function DatePickerCalendar({
       getCalendarDays(viewMonth, adapter, {
         weekStartsOn,
         selected: ctx.value,
-        focusedDate,
+        focusedDate:
+          displayTimezone && focusedDate
+            ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+            : focusedDate,
         disabled,
         timezone: displayTimezone,
         fixedWeeks,
@@ -180,7 +184,16 @@ export function DatePickerCalendar({
           case 'Enter':
           case ' ':
             e.preventDefault();
-            if (!isDateDisabled(focusedDate, disabled, adapter)) {
+            if (
+              !isDateDisabled(
+                displayTimezone
+                  ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+                  : focusedDate,
+                disabled,
+                adapter,
+                displayTimezone,
+              )
+            ) {
               ctx.selectDate(focusedDate);
             }
             return;
@@ -206,7 +219,15 @@ export function DatePickerCalendar({
         // skip continues along the same *logical* direction the keypress moved.
         const skipStep = isBackwardKey(e.key, dir) ? -1 : 1;
         let attempts = 0;
-        while (isDateDisabled(newFocused, disabled, adapter) && attempts < 42) {
+        while (
+          isDateDisabled(
+            displayTimezone ? civilMidnightFromUtcDay(newFocused, displayTimezone) : newFocused,
+            disabled,
+            adapter,
+            displayTimezone,
+          ) &&
+          attempts < 42
+        ) {
           newFocused = adapter.addDays(newFocused, skipStep);
           attempts++;
         }
@@ -223,7 +244,7 @@ export function DatePickerCalendar({
         }
       }
     },
-    [adapter, focusedDate, viewMonth, weekStartsOn, disabled, ctx, dir],
+    [adapter, focusedDate, viewMonth, weekStartsOn, disabled, ctx, dir, displayTimezone],
   );
 
   return (

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -454,6 +454,27 @@ describe('DatePicker — keyboard navigation', () => {
 
     expect(screen.getByRole('button', { name: /January 2, 2026/ })).toHaveFocus();
   });
+
+  it('moves view and focus to the next enabled month when the selected month is fully disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        value="2026-01-17T00:00:00.000Z"
+        disabled={[{ before: '2026-02-01T00:00:00.000Z' }]}
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-label', 'February 2026');
+    expect(screen.getByRole('button', { name: /February 1, 2026/ })).toHaveFocus();
+  });
 });
 
 describe('DatePicker — context errors', () => {

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -280,7 +280,8 @@ describe('DatePicker — timezone calendar coordinates', () => {
   it('normalizes a time-bearing default-zone value before keyboard disabled checks', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    const filter = vi.fn((iso: string) => iso === '2026-01-15T00:00:00.000Z');
+    let reject = false;
+    const filter = vi.fn((iso: string) => reject && iso === '2026-01-15T00:00:00.000Z');
     render(
       <DatePicker value="2026-01-15T14:30:00.000Z" disabled={[{ filter }]} onChange={onChange}>
         <DatePicker.Input aria-label="날짜 선택" />
@@ -291,6 +292,7 @@ describe('DatePicker — timezone calendar coordinates', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
+    reject = true;
     filter.mockClear();
     fireEvent.keyDown(screen.getByRole('grid'), { key: 'Enter' });
 
@@ -383,7 +385,8 @@ describe('DatePicker — keyboard navigation', () => {
   it('uses the civil instant for timezone-aware Enter disabled checks', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    const filter = vi.fn((iso: string) => iso === '2026-01-15T05:00:00.000Z');
+    let reject = false;
+    const filter = vi.fn((iso: string) => reject && iso === '2026-01-15T05:00:00.000Z');
     render(
       <DatePicker
         value="2026-01-15T05:00:00.000Z"
@@ -399,6 +402,7 @@ describe('DatePicker — keyboard navigation', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
+    reject = true;
     filter.mockClear();
     fireEvent.keyDown(screen.getByRole('grid'), { key: 'Enter' });
 
@@ -426,6 +430,29 @@ describe('DatePicker — keyboard navigation', () => {
     fireEvent.keyDown(screen.getByRole('grid'), { key: 'ArrowRight' });
 
     expect(screen.getByRole('button', { name: /January 17, 2026/ })).toHaveFocus();
+  });
+
+  it('moves the first Arrow from the enabled DOM fallback when the controlled value is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        value="2026-01-17T00:00:00.000Z"
+        disabled={[{ dayOfWeek: [0, 6] }]}
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('button', { name: /January 1, 2026/ })).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('button', { name: /January 2, 2026/ })).toHaveFocus();
   });
 });
 
@@ -1136,6 +1163,23 @@ describe('DatePicker — Presets', () => {
     expect(screen.getByRole('button', { name: "New Year's" })).toHaveAttribute(
       'aria-pressed',
       'false',
+    );
+  });
+
+  it.each([
+    ['Asia/Seoul', '2025-12-31T15:00:00.000Z'],
+    ['America/New_York', '2026-01-01T05:00:00.000Z'],
+  ])('marks a zoned start-of-month preset active at a UTC boundary in %s', (timezone, today) => {
+    const adapter = { ...DateFnsAdapter, today: () => today };
+    render(
+      <DatePicker value={today} adapter={adapter} displayTimezone={timezone} onChange={vi.fn()}>
+        <DatePicker.Preset value="startOfMonth">Start of month</DatePicker.Preset>
+      </DatePicker>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Start of month' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
     );
   });
 

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import type { DisabledRule } from '@kalyx/core';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import { DatePicker } from './index.js';
 
 function renderDatePicker(
@@ -274,6 +276,52 @@ describe('DatePicker — calendar navigation', () => {
   });
 });
 
+describe('DatePicker — timezone calendar coordinates', () => {
+  it('opens January and selects/focuses Seoul January 1 from its stored instant', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker value="2025-12-31T15:00:00.000Z" displayTimezone="Asia/Seoul" onChange={vi.fn()}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-label', 'January 2026');
+    const january1 = screen.getByRole('button', { name: /January 1, 2026/ });
+    expect(january1).toHaveAttribute('data-selected', 'true');
+    expect(january1).toHaveFocus();
+  });
+
+  it('opens, selects, and focuses New York January 15 rather than January 16', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        value="2026-01-15T05:00:00.000Z"
+        displayTimezone="America/New_York"
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-label', 'January 2026');
+    const january15 = screen.getByRole('button', { name: /January 15, 2026/ });
+    const january16 = screen.getByRole('button', { name: /January 16, 2026/ });
+    expect(january15).toHaveAttribute('data-selected', 'true');
+    expect(january15).toHaveFocus();
+    expect(january16).not.toHaveAttribute('data-selected');
+  });
+});
+
 describe('DatePicker — keyboard navigation', () => {
   it('opens the calendar with ArrowDown', async () => {
     const user = userEvent.setup();
@@ -309,6 +357,54 @@ describe('DatePicker — keyboard navigation', () => {
     await user.keyboard('{Enter}');
 
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-16T/));
+  });
+
+  it('uses the civil instant for timezone-aware Enter disabled checks', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const filter = vi.fn((iso: string) => iso === '2026-01-15T05:00:00.000Z');
+    render(
+      <DatePicker
+        value="2026-01-15T05:00:00.000Z"
+        displayTimezone="America/New_York"
+        disabled={[{ filter }]}
+        onChange={onChange}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    filter.mockClear();
+    fireEvent.keyDown(screen.getByRole('grid'), { key: 'Enter' });
+
+    expect(filter.mock.calls).toEqual([['2026-01-15T05:00:00.000Z']]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('skips dates whose timezone civil instant is disabled during keyboard focus movement', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        value="2026-01-15T05:00:00.000Z"
+        displayTimezone="America/New_York"
+        disabled={[{ filter: (iso) => iso === '2026-01-16T05:00:00.000Z' }]}
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    fireEvent.keyDown(screen.getByRole('grid'), { key: 'ArrowRight' });
+
+    expect(screen.getByRole('button', { name: /January 17, 2026/ })).toHaveFocus();
   });
 });
 
@@ -964,6 +1060,44 @@ describe('DatePicker — Presets', () => {
     expect(onChange).toHaveBeenCalledWith('2026-12-25T00:00:00.000Z');
   });
 
+  it('converts a timezone-aware today preset exactly once', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const adapter = {
+      ...DateFnsAdapter,
+      today: () => '2026-01-14T15:00:00.000Z',
+    };
+    render(
+      <DatePicker adapter={adapter} displayTimezone="Asia/Seoul" onChange={onChange}>
+        <DatePicker.Presets>
+          <DatePicker.Preset value="today">Today</DatePicker.Preset>
+        </DatePicker.Presets>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Today' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('2026-01-14T15:00:00.000Z');
+  });
+
+  it('converts a timezone-aware direct-date preset exactly once', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DatePicker displayTimezone="Asia/Seoul" onChange={onChange}>
+        <DatePicker.Presets>
+          <DatePicker.Preset date="2026-12-24T15:00:00.000Z">Christmas</DatePicker.Preset>
+        </DatePicker.Presets>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Christmas' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('2026-12-24T15:00:00.000Z');
+  });
+
   it('marks the matching preset as aria-pressed', () => {
     render(
       <DatePicker value="2026-12-25T00:00:00.000Z" onChange={vi.fn()}>
@@ -1018,6 +1152,67 @@ describe('DatePicker — Presets', () => {
 });
 
 describe('DatePicker — date rules and edge cases (CLAUDE.md §7)', () => {
+  const typedRuleCases: Array<{
+    name: string;
+    text: string;
+    rules: DisabledRule[];
+  }> = [
+    {
+      name: 'exact date',
+      text: '2026-01-15',
+      rules: [{ date: '2026-01-14T15:00:00.000Z' }],
+    },
+    {
+      name: 'before',
+      text: '2026-01-15',
+      rules: [{ before: '2026-01-15T00:00:00.000Z' }],
+    },
+    {
+      name: 'after',
+      text: '2026-01-15',
+      rules: [{ after: '2026-01-14T00:00:00.000Z' }],
+    },
+    {
+      name: 'dayOfWeek',
+      text: '2026-01-17',
+      rules: [{ dayOfWeek: [6] }],
+    },
+    {
+      name: 'filter',
+      text: '2026-01-15',
+      rules: [{ filter: (iso) => iso === '2026-01-14T15:00:00.000Z' }],
+    },
+  ];
+
+  it.each(typedRuleCases)(
+    'rejects a typed date matching the $name rule without changing or closing',
+    async ({ text, rules }) => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <DatePicker
+          defaultValue="2026-01-09T15:00:00.000Z"
+          displayTimezone="Asia/Seoul"
+          disabled={rules}
+          onChange={onChange}
+        >
+          <DatePicker.Input aria-label="날짜 선택" />
+          <DatePicker.Popover>
+            <DatePicker.Calendar />
+          </DatePicker.Popover>
+        </DatePicker>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      fireEvent.change(input, { target: { value: text } });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('2026-01-10');
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    },
+  );
+
   it('emits an ISO string when a leap-year day (Feb 29 2024) is clicked', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
@@ -1070,10 +1265,10 @@ describe('DatePicker — date rules and edge cases (CLAUDE.md §7)', () => {
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-12T/));
   });
 
-  it('before/after bounds (minDate/maxDate) compare UTC instants and are unaffected by displayTimezone (T-G1)', async () => {
-    // The grid emits UTC-midnight ISO cells and isDateDisabled compares pure UTC
-    // instants, so a displayTimezone must NOT shift which day a UTC bound gates —
-    // even a +9:00 zone where the bound sits near the civil-midnight boundary.
+  it('before/after bounds preserve raw instant comparisons after timezone cell normalization (T-G1)', async () => {
+    // Calendar cells are normalized to their civil-midnight instants before the
+    // raw before/after comparison. In Seoul, June 17 civil midnight is June 16
+    // 15:00 UTC, so it is correctly before a June 17 00:00 UTC lower bound.
     const renderWith = (displayTimezone?: string) =>
       render(
         <DatePicker
@@ -1090,18 +1285,17 @@ describe('DatePicker — date rules and edge cases (CLAUDE.md §7)', () => {
 
     const user = userEvent.setup();
 
-    // Asia/Seoul (+9): the boundary days are gated by the UTC instant, not the
-    // Seoul civil day. Equal-to-bound is enabled; strictly outside is disabled.
+    // Asia/Seoul (+9): the calendar cell's civil-midnight instant is compared
+    // directly to the bounds.
     const seoul = renderWith('Asia/Seoul');
     await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('button', { name: /June 16, 2026/ })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /June 17, 2026/ })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /June 17, 2026/ })).toBeDisabled();
     expect(screen.getByRole('button', { name: /June 20, 2026/ })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: /June 21, 2026/ })).toBeDisabled();
     seoul.unmount();
 
-    // Identical disabled set without displayTimezone — proves the zone is inert
-    // for the bound comparison (locks the UTC-only semantics at the React boundary).
+    // Without a display timezone, grid coordinates are already the compared instants.
     renderWith(undefined);
     await user.click(screen.getByRole('combobox'));
     expect(screen.getByRole('button', { name: /June 16, 2026/ })).toBeDisabled();

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -277,6 +277,27 @@ describe('DatePicker — calendar navigation', () => {
 });
 
 describe('DatePicker — timezone calendar coordinates', () => {
+  it('normalizes a time-bearing default-zone value before keyboard disabled checks', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const filter = vi.fn((iso: string) => iso === '2026-01-15T00:00:00.000Z');
+    render(
+      <DatePicker value="2026-01-15T14:30:00.000Z" disabled={[{ filter }]} onChange={onChange}>
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    filter.mockClear();
+    fireEvent.keyDown(screen.getByRole('grid'), { key: 'Enter' });
+
+    expect(filter.mock.calls).toEqual([['2026-01-15T00:00:00.000Z']]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('opens January and selects/focuses Seoul January 1 from its stored instant', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/react/src/components/DatePicker/Presets.tsx
+++ b/packages/react/src/components/DatePicker/Presets.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
 import { calendarDayFromInstant } from '@kalyx/core';
 import type { ISODateString } from '@kalyx/core';
@@ -105,45 +105,39 @@ export function DatePickerPreset({
 }: DatePickerPresetProps) {
   const ctx = useDatePickerContext('DatePicker.Preset');
 
+  const resolved = useMemo<ISODateString | null>(() => {
+    if (directDate) {
+      return ctx.displayTimezone
+        ? calendarDayFromInstant(directDate, ctx.displayTimezone)
+        : directDate;
+    }
+    if (!presetKey) return null;
+    const today = ctx.adapter.today(ctx.displayTimezone);
+    const coordinate = ctx.displayTimezone
+      ? calendarDayFromInstant(today, ctx.displayTimezone)
+      : today;
+    return resolveDatePreset(presetKey, coordinate, ctx.adapter);
+  }, [directDate, presetKey, ctx.adapter, ctx.displayTimezone]);
+
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
       if (ctx.isDisabled || ctx.isReadOnly) return;
-
-      let resolved: ISODateString;
-      if (directDate) {
-        resolved = ctx.displayTimezone
-          ? calendarDayFromInstant(directDate, ctx.displayTimezone)
-          : directDate;
-      } else if (presetKey) {
-        const today = ctx.adapter.today(ctx.displayTimezone);
-        resolved = resolveDatePreset(
-          presetKey,
-          ctx.displayTimezone ? calendarDayFromInstant(today, ctx.displayTimezone) : today,
-          ctx.adapter,
-        );
-      } else {
-        return;
-      }
+      if (!resolved) return;
 
       ctx.selectDate(resolved);
       onClick?.(e);
     },
-    [ctx, presetKey, directDate, onClick],
+    [ctx, resolved, onClick],
   );
 
   // Active when the preset's resolved date equals the current value (same civil day, tz-aware).
-  const isActive = (() => {
-    if (!ctx.value) return false;
-    let target: ISODateString;
-    if (directDate) {
-      target = directDate;
-    } else if (presetKey) {
-      target = resolveDatePreset(presetKey, ctx.adapter.today(ctx.displayTimezone), ctx.adapter);
-    } else {
-      return false;
-    }
-    return ctx.adapter.isSameDay(ctx.value, target, ctx.displayTimezone);
-  })();
+  const isActive =
+    !!ctx.value &&
+    !!resolved &&
+    ctx.adapter.isSameDay(
+      ctx.displayTimezone ? calendarDayFromInstant(ctx.value, ctx.displayTimezone) : ctx.value,
+      resolved,
+    );
 
   // role="option" is invalid outside role="listbox"/role="combobox"; the parent
   // <DatePicker.Presets> is role="group". Use a regular button with aria-pressed

--- a/packages/react/src/components/DatePicker/Presets.tsx
+++ b/packages/react/src/components/DatePicker/Presets.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
+import { calendarDayFromInstant } from '@kalyx/core';
 import type { ISODateString } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
 
@@ -110,11 +111,14 @@ export function DatePickerPreset({
 
       let resolved: ISODateString;
       if (directDate) {
-        resolved = directDate;
+        resolved = ctx.displayTimezone
+          ? calendarDayFromInstant(directDate, ctx.displayTimezone)
+          : directDate;
       } else if (presetKey) {
+        const today = ctx.adapter.today(ctx.displayTimezone);
         resolved = resolveDatePreset(
           presetKey,
-          ctx.adapter.today(ctx.displayTimezone),
+          ctx.displayTimezone ? calendarDayFromInstant(today, ctx.displayTimezone) : today,
           ctx.adapter,
         );
       } else {

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
+  calendarDayFromInstant,
   DEFAULT_DATEPICKER_LABELS,
   civilMidnightFromUtcDay,
   getWeekStartForLocale,
+  isDateDisabled,
 } from '@kalyx/core';
 import type {
   DateAdapter,
@@ -119,13 +121,15 @@ export function DatePickerRoot({
   // Lazy initializers: today() is only computed once per mount instead of on every
   // render. Avoids redundant Date allocations and makes the SSR/hydration contract
   // explicit — neither server nor client re-evaluates the fallback after first render.
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    () => currentValue ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+  });
 
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    () => currentValue ?? adapter.today(displayTimezone),
-  );
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+  });
 
   useChangeEffect(isOpen, onOpenChange);
   const viewMonthStart = useMemo(() => adapter.startOfMonth(viewMonth), [viewMonth, adapter]);
@@ -159,6 +163,10 @@ export function DatePickerRoot({
       const normalized =
         iso && displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
 
+      if (normalized && isDateDisabled(normalized, disabledRules, adapter, displayTimezone)) {
+        return;
+      }
+
       if (!isControlled) {
         setUncontrolledValue(normalized);
       }
@@ -167,7 +175,7 @@ export function DatePickerRoot({
       // Close the popover after selection
       setIsOpen(false);
     },
-    [isControlled, isDisabled, readOnly, onChange, displayTimezone],
+    [isControlled, isDisabled, readOnly, onChange, displayTimezone, disabledRules, adapter],
   );
 
   const open = useCallback(() => {
@@ -175,8 +183,11 @@ export function DatePickerRoot({
     setIsOpen(true);
     // Reset the view to the current value or today when opening
     const target = currentValue ?? adapter.today(displayTimezone);
-    setViewMonth(target);
-    setFocusedDate(target);
+    const calendarTarget = displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : target;
+    setViewMonth(calendarTarget);
+    setFocusedDate(calendarTarget);
   }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -191,10 +191,14 @@ export function DatePickerRoot({
     const calendarTarget = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
-    setViewMonth(calendarTarget);
-    setFocusedDate(
-      resolveEnabledCalendarFocus(calendarTarget, disabledRules, adapter, displayTimezone),
+    const focus = resolveEnabledCalendarFocus(
+      calendarTarget,
+      disabledRules,
+      adapter,
+      displayTimezone,
     );
+    setViewMonth(focus);
+    setFocusedDate(focus);
   }, [isDisabled, readOnly, currentValue, adapter, displayTimezone, disabledRules]);
 
   const close = useCallback(() => {

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -18,6 +18,7 @@ import { DatePickerContext } from '../../context/DatePickerContext.js';
 import type { DatePickerContextValue } from '../../context/DatePickerContext.js';
 import type { Direction } from '../_shared/rtl.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
+import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
 import { SR_ONLY } from '../../internal/srOnly.js';
 
@@ -191,8 +192,10 @@ export function DatePickerRoot({
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
     setViewMonth(calendarTarget);
-    setFocusedDate(calendarTarget);
-  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
+    setFocusedDate(
+      resolveEnabledCalendarFocus(calendarTarget, disabledRules, adapter, displayTimezone),
+    );
+  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone, disabledRules]);
 
   const close = useCallback(() => {
     setIsOpen(false);

--- a/packages/react/src/components/DatePicker/Root.tsx
+++ b/packages/react/src/components/DatePicker/Root.tsx
@@ -123,12 +123,16 @@ export function DatePickerRoot({
   // explicit — neither server nor client re-evaluates the fallback after first render.
   const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
     const target = currentValue ?? adapter.today(displayTimezone);
-    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
   });
 
   const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
     const target = currentValue ?? adapter.today(displayTimezone);
-    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
   });
 
   useChangeEffect(isOpen, onOpenChange);
@@ -185,7 +189,7 @@ export function DatePickerRoot({
     const target = currentValue ?? adapter.today(displayTimezone);
     const calendarTarget = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
-      : target;
+      : adapter.startOfDay(target);
     setViewMonth(calendarTarget);
     setFocusedDate(calendarTarget);
   }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -124,7 +124,8 @@ describe('DateTimePicker — timezone calendar coordinates', () => {
   it('normalizes a time-bearing default-zone value before keyboard disabled checks', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
-    const filter = vi.fn((iso: string) => iso === '2026-01-15T00:00:00.000Z');
+    let reject = false;
+    const filter = vi.fn((iso: string) => reject && iso === '2026-01-15T00:00:00.000Z');
     render(
       <DateTimePicker value="2026-01-15T14:30:00.000Z" disabled={[{ filter }]} onChange={onChange}>
         <DateTimePicker.Input />
@@ -135,6 +136,7 @@ describe('DateTimePicker — timezone calendar coordinates', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
+    reject = true;
     filter.mockClear();
     fireEvent.keyDown(screen.getByRole('grid'), { key: 'Enter' });
 

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -4,8 +4,20 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { DateTimePicker } from './index.js';
+import { DateTimePickerPreset, DateTimePickerPresets } from './Presets.js';
 import { useTimePickerContext } from '../../context/TimePickerContext.js';
+import { useDatePickerContext } from '../../context/DatePickerContext.js';
 import { formatInTimezone } from '@kalyx/core';
+
+function DateMutationProbe({ date }: { date: string }) {
+  const ctx = useDatePickerContext('DateMutationProbe');
+  return <button onClick={() => ctx.selectDate(date)}>set-context-date</button>;
+}
+
+function TimeMutationProbe({ hours }: { hours: number }) {
+  const ctx = useTimePickerContext('TimeMutationProbe');
+  return <button onClick={() => ctx.setTime({ hours })}>set-context-hour-{hours}</button>;
+}
 
 function renderDateTimePicker(
   props: {
@@ -105,6 +117,31 @@ describe('DateTimePicker — basic rendering', () => {
   it('renders an empty input when value is null', () => {
     renderDateTimePicker({ value: null });
     expect(screen.getByLabelText('Date and time')).toHaveValue('');
+  });
+});
+
+describe('DateTimePicker — timezone calendar coordinates', () => {
+  it('opens January and selects/focuses Seoul January 1 from its stored instant', async () => {
+    const user = userEvent.setup();
+    render(
+      <DateTimePicker
+        value="2025-12-31T15:00:00.000Z"
+        displayTimezone="Asia/Seoul"
+        onChange={vi.fn()}
+      >
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePicker.Calendar />
+        </DateTimePicker.Popover>
+      </DateTimePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-label', 'January 2026');
+    const january1 = screen.getByRole('button', { name: /January 1, 2026/ });
+    expect(january1).toHaveAttribute('data-selected', 'true');
+    expect(january1).toHaveFocus();
   });
 });
 
@@ -472,6 +509,25 @@ describe('DateTimePicker — event callbacks', () => {
 });
 
 describe('DateTimePicker — date rules and edge cases (CLAUDE.md §7)', () => {
+  it('rejects a context date commit whose final merged datetime has a disabled civil date', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DateTimePicker
+        value="2026-01-15T01:30:00.000Z"
+        displayTimezone="Asia/Seoul"
+        disabled={[{ dayOfWeek: [6] }]}
+        onChange={onChange}
+      >
+        <DateMutationProbe date="2026-01-17T00:00:00.000Z" />
+      </DateTimePicker>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'set-context-date' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('emits an ISO string when a leap-year day (Feb 29 2024) is clicked', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
@@ -677,6 +733,55 @@ describe('DateTimePicker — composition API forwarding to TimePickerContext', (
     await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: '12 hours' }));
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('rejects a context time mutation using the final merged time', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <DateTimePicker
+        value="2026-01-15T10:30:00.000Z"
+        onChange={onChange}
+        filterTime={(hours, minutes) => hours === 12 && minutes === 30}
+      >
+        <TimeMutationProbe hours={12} />
+      </DateTimePicker>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'set-context-hour-12' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('DateTimePicker — preset policy boundary', () => {
+  it('rejects a filtered full preset without closing and still invokes the click callback', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <DateTimePicker
+        value="2026-01-15T10:30:00.000Z"
+        onChange={onChange}
+        filterTime={(hours, minutes) => hours === 12 && minutes === 30}
+      >
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePickerPresets>
+            <DateTimePickerPreset value="2026-01-15T12:30:00.000Z" onClick={onClick}>
+              Blocked lunch
+            </DateTimePickerPreset>
+          </DateTimePickerPresets>
+        </DateTimePicker.Popover>
+      </DateTimePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Blocked lunch' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });
 

--- a/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/packages/react/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { DateTimePicker } from './index.js';
@@ -121,6 +121,27 @@ describe('DateTimePicker — basic rendering', () => {
 });
 
 describe('DateTimePicker — timezone calendar coordinates', () => {
+  it('normalizes a time-bearing default-zone value before keyboard disabled checks', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const filter = vi.fn((iso: string) => iso === '2026-01-15T00:00:00.000Z');
+    render(
+      <DateTimePicker value="2026-01-15T14:30:00.000Z" disabled={[{ filter }]} onChange={onChange}>
+        <DateTimePicker.Input />
+        <DateTimePicker.Popover>
+          <DateTimePicker.Calendar />
+        </DateTimePicker.Popover>
+      </DateTimePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    filter.mockClear();
+    fireEvent.keyDown(screen.getByRole('grid'), { key: 'Enter' });
+
+    expect(filter.mock.calls).toEqual([['2026-01-15T00:00:00.000Z']]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('opens January and selects/focuses Seoul January 1 from its stored instant', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/react/src/components/DateTimePicker/Presets.tsx
+++ b/packages/react/src/components/DateTimePicker/Presets.tsx
@@ -73,8 +73,10 @@ export function DateTimePickerPreset({
       if (ctx.isDisabled || ctx.isReadOnly) return;
       // selectDateTime is only present on DateTimePicker.Root; fall back to selectDate
       // (date-only) if a Preset is somehow mounted under a plain DatePicker.
-      (ctx.selectDateTime ?? ctx.selectDate)(value);
-      ctx.close();
+      const accepted = ctx.selectDateTime
+        ? ctx.selectDateTime(value)
+        : (ctx.selectDate(value), true);
+      if (accepted) ctx.close();
       onClick?.(e);
     },
     [ctx, value, onClick],

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -278,10 +278,14 @@ export function DateTimePickerRoot({
     const calendarTarget = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
-    setViewMonth(calendarTarget);
-    setFocusedDate(
-      resolveEnabledCalendarFocus(calendarTarget, disabledRules, adapter, displayTimezone),
+    const focus = resolveEnabledCalendarFocus(
+      calendarTarget,
+      disabledRules,
+      adapter,
+      displayTimezone,
     );
+    setViewMonth(focus);
+    setFocusedDate(focus);
   }, [isDisabled, readOnly, currentValue, adapter, displayTimezone, disabledRules]);
 
   const close = useCallback(() => {

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
+  calendarDayFromInstant,
   DEFAULT_DATEPICKER_LABELS,
   DEFAULT_TIMEPICKER_LABELS,
   getTime,
@@ -8,6 +9,7 @@ import {
   getTimeInTimezone,
   setTimeInTimezone,
   civilMidnightFromUtcDay,
+  isDateDisabled,
 } from '@kalyx/core';
 import type {
   DateAdapter,
@@ -156,12 +158,14 @@ export function DateTimePickerRoot({
   const [announcement, setAnnouncement] = useState('');
   const announce = useCallback((message: string) => setAnnouncement(message), []);
   // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    () => currentValue ?? adapter.today(displayTimezone),
-  );
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    () => currentValue ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+  });
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+  });
 
   useChangeEffect(isOpen, onOpenChange);
   const viewMonthStart = useMemo(() => adapter.startOfMonth(viewMonth), [viewMonth, adapter]);
@@ -183,14 +187,31 @@ export function DateTimePickerRoot({
   }, [currentValue, displayTimezone]);
 
   const updateValue = useCallback(
-    (next: ISODateString | null) => {
-      if (isDisabled || readOnly) return;
+    (next: ISODateString | null): boolean => {
+      if (isDisabled || readOnly) return false;
+      if (next) {
+        if (isDateDisabled(next, disabledRules, adapter, displayTimezone)) return false;
+        const finalTime = displayTimezone
+          ? getTimeInTimezone(next, displayTimezone)
+          : getTime(next);
+        if (filterTime?.(finalTime.hours, finalTime.minutes)) return false;
+      }
       if (!isControlled) {
         setUncontrolledValue(next);
       }
       onChange?.(next);
+      return true;
     },
-    [isControlled, isDisabled, readOnly, onChange],
+    [
+      isControlled,
+      isDisabled,
+      readOnly,
+      disabledRules,
+      adapter,
+      displayTimezone,
+      filterTime,
+      onChange,
+    ],
   );
 
   /**
@@ -242,14 +263,13 @@ export function DateTimePickerRoot({
    * where a preset carries both portions and must not race the time-preserving selectDate.
    */
   const selectDateTime = useCallback(
-    (iso: ISODateString | null) => {
+    (iso: ISODateString | null): boolean => {
       if (iso === null) {
-        updateValue(null);
-        return;
+        return updateValue(null);
       }
       // A preset ISO is already a UTC instant; when a display timezone is set the
       // value is interpreted/displayed there, so no civil-midnight remapping is needed.
-      updateValue(iso);
+      return updateValue(iso);
     },
     [updateValue],
   );
@@ -258,8 +278,11 @@ export function DateTimePickerRoot({
     if (isDisabled || readOnly) return;
     setIsOpen(true);
     const target = currentValue ?? adapter.today(displayTimezone);
-    setViewMonth(target);
-    setFocusedDate(target);
+    const calendarTarget = displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : target;
+    setViewMonth(calendarTarget);
+    setFocusedDate(calendarTarget);
   }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -160,11 +160,15 @@ export function DateTimePickerRoot({
   // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
   const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
     const target = currentValue ?? adapter.today(displayTimezone);
-    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
   });
   const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
     const target = currentValue ?? adapter.today(displayTimezone);
-    return displayTimezone ? calendarDayFromInstant(target, displayTimezone) : target;
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
   });
 
   useChangeEffect(isOpen, onOpenChange);
@@ -229,17 +233,12 @@ export function DateTimePickerRoot({
         ? civilMidnightFromUtcDay(newDateIso, displayTimezone)
         : newDateIso;
       // Preserve the current time portion (tz-aware when applicable)
-      const time = currentValue
-        ? displayTimezone
-          ? getTimeInTimezone(currentValue, displayTimezone)
-          : getTime(currentValue)
-        : currentTime;
       const merged = displayTimezone
-        ? setTimeInTimezone(normalizedDate, time, displayTimezone)
-        : setTimeOnIso(normalizedDate, time);
+        ? setTimeInTimezone(normalizedDate, currentTime, displayTimezone)
+        : setTimeOnIso(normalizedDate, currentTime);
       updateValue(merged);
     },
-    [currentValue, currentTime, updateValue, displayTimezone],
+    [currentTime, updateValue, displayTimezone],
   );
 
   /**
@@ -264,9 +263,6 @@ export function DateTimePickerRoot({
    */
   const selectDateTime = useCallback(
     (iso: ISODateString | null): boolean => {
-      if (iso === null) {
-        return updateValue(null);
-      }
       // A preset ISO is already a UTC instant; when a display timezone is set the
       // value is interpreted/displayed there, so no civil-midnight remapping is needed.
       return updateValue(iso);
@@ -280,7 +276,7 @@ export function DateTimePickerRoot({
     const target = currentValue ?? adapter.today(displayTimezone);
     const calendarTarget = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
-      : target;
+      : adapter.startOfDay(target);
     setViewMonth(calendarTarget);
     setFocusedDate(calendarTarget);
   }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);

--- a/packages/react/src/components/DateTimePicker/Root.tsx
+++ b/packages/react/src/components/DateTimePicker/Root.tsx
@@ -25,6 +25,7 @@ import type { Direction } from '../_shared/rtl.js';
 import { TimePickerContext } from '../../context/TimePickerContext.js';
 import type { TimePickerContextValue, TimePickerFormat } from '../../context/TimePickerContext.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
+import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
 import { SR_ONLY } from '../../internal/srOnly.js';
 
@@ -278,8 +279,10 @@ export function DateTimePickerRoot({
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
     setViewMonth(calendarTarget);
-    setFocusedDate(calendarTarget);
-  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone]);
+    setFocusedDate(
+      resolveEnabledCalendarFocus(calendarTarget, disabledRules, adapter, displayTimezone),
+    );
+  }, [isDisabled, readOnly, currentValue, adapter, displayTimezone, disabledRules]);
 
   const close = useCallback(() => {
     setIsOpen(false);

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import {
   getCalendarDays,
+  calendarDayFromInstant,
+  civilMidnightFromUtcDay,
   getISOWeekNumber,
   isDateDisabled,
   getWeekdayNames,
@@ -113,7 +115,10 @@ export function RangePickerCalendar({
     () =>
       getCalendarDays(viewMonth, adapter, {
         weekStartsOn,
-        focusedDate,
+        focusedDate:
+          displayTimezone && focusedDate
+            ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+            : focusedDate,
         disabled,
         range: value,
         rangeHover: hoverDate,
@@ -180,28 +185,38 @@ export function RangePickerCalendar({
           weekStart = adapter.startOfWeek(iso, weekStartsOn);
           weekEnd = adapter.startOfDay(adapter.endOfWeek(iso, weekStartsOn));
         }
-        const range: DateRange = { start: weekStart, end: weekEnd };
-        ctx.setRange(range);
-        ctx.close();
-        ctx.announce(
-          `${ctx.labels.rangeSelected}: ${safeFormatFullDate(weekStart, locale)} – ${safeFormatFullDate(weekEnd, locale)}`,
-        );
+        const range: DateRange = {
+          start: displayTimezone ? civilMidnightFromUtcDay(weekStart, displayTimezone) : weekStart,
+          end: displayTimezone ? civilMidnightFromUtcDay(weekEnd, displayTimezone) : weekEnd,
+        };
+        if (ctx.setRange(range)) {
+          ctx.close();
+          ctx.announce(
+            `${ctx.labels.rangeSelected}: ${safeFormatFullDate(weekStart, locale)} – ${safeFormatFullDate(weekEnd, locale)}`,
+          );
+        }
       } else {
         // Capture selectingTarget BEFORE selectDate flips it so we can announce
         // the right state. "start" click prompts for the end; "end" click closes
         // the range and announces the full span.
         const wasPickingStart = selectingTarget === 'start';
         const previousStart = value.start;
-        ctx.selectDate(iso);
+        if (!ctx.selectDate(iso)) return;
         const formatted = safeFormatFullDate(iso, locale);
         if (wasPickingStart) {
           ctx.announce(`${formatted}. ${ctx.labels.selectingEnd}`);
         } else if (previousStart) {
           // Mirror the swap-if-before logic from RangePickerRoot.selectDate so the
           // announcement matches what will be committed.
-          const [start, end] = adapter.isBefore(iso, previousStart)
-            ? [iso, previousStart]
-            : [previousStart, iso];
+          const selectedValue = displayTimezone
+            ? civilMidnightFromUtcDay(iso, displayTimezone)
+            : iso;
+          const previousStartCoordinate = displayTimezone
+            ? calendarDayFromInstant(previousStart, displayTimezone)
+            : previousStart;
+          const [start, end] = adapter.isBefore(selectedValue, previousStart)
+            ? [iso, previousStartCoordinate]
+            : [previousStartCoordinate, iso];
           ctx.announce(
             `${ctx.labels.rangeSelected}: ${safeFormatFullDate(start, locale)} – ${safeFormatFullDate(end, locale)}`,
           );
@@ -212,7 +227,17 @@ export function RangePickerCalendar({
         }
       }
     },
-    [selectionMode, weekAnchor, adapter, weekStartsOn, ctx, locale, selectingTarget, value.start],
+    [
+      selectionMode,
+      weekAnchor,
+      adapter,
+      weekStartsOn,
+      ctx,
+      locale,
+      selectingTarget,
+      value.start,
+      displayTimezone,
+    ],
   );
 
   const handleDayClick = useCallback(
@@ -274,7 +299,10 @@ export function RangePickerCalendar({
           case 'Enter':
           case ' ':
             e.preventDefault();
-            if (!isDateDisabled(focusedDate, disabled, adapter)) {
+            const focusedValue = displayTimezone
+              ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+              : focusedDate;
+            if (!isDateDisabled(focusedValue, disabled, adapter, displayTimezone)) {
               commitDay(focusedDate);
             }
             return;
@@ -296,7 +324,15 @@ export function RangePickerCalendar({
         // Step in the original direction up to one full grid (42 cells) before giving up.
         const skipStep = isBackwardKey(e.key, dir) ? -1 : 1;
         let attempts = 0;
-        while (isDateDisabled(newFocused, disabled, adapter) && attempts < 42) {
+        while (
+          isDateDisabled(
+            displayTimezone ? civilMidnightFromUtcDay(newFocused, displayTimezone) : newFocused,
+            disabled,
+            adapter,
+            displayTimezone,
+          ) &&
+          attempts < 42
+        ) {
           newFocused = adapter.addDays(newFocused, skipStep);
           attempts++;
         }
@@ -326,6 +362,7 @@ export function RangePickerCalendar({
       value.start,
       commitDay,
       dir,
+      displayTimezone,
     ],
   );
 

--- a/packages/react/src/components/RangePicker/Presets.tsx
+++ b/packages/react/src/components/RangePicker/Presets.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
+import { calendarDayFromInstant, civilMidnightFromUtcDay } from '@kalyx/core';
 import type { DateRange, ISODateString } from '@kalyx/core';
 import { useRangePickerContext } from '../../context/RangePickerContext.js';
 
@@ -144,8 +145,23 @@ export function RangePickerPreset({
   // row into 10 today() allocations per render.
   const resolved = useMemo<DateRange | null>(() => {
     if (directRange) return directRange;
-    if (presetKey)
-      return resolvePreset(presetKey, ctx.adapter.today(ctx.displayTimezone), ctx.adapter);
+    if (presetKey) {
+      const today = ctx.adapter.today(ctx.displayTimezone);
+      const coordinateToday = ctx.displayTimezone
+        ? calendarDayFromInstant(today, ctx.displayTimezone)
+        : ctx.adapter.startOfDay(today);
+      const coordinateRange = resolvePreset(presetKey, coordinateToday, ctx.adapter);
+      return {
+        start:
+          coordinateRange.start && ctx.displayTimezone
+            ? civilMidnightFromUtcDay(coordinateRange.start, ctx.displayTimezone)
+            : coordinateRange.start,
+        end:
+          coordinateRange.end && ctx.displayTimezone
+            ? civilMidnightFromUtcDay(coordinateRange.end, ctx.displayTimezone)
+            : coordinateRange.end,
+      };
+    }
     return null;
   }, [directRange, presetKey, ctx.adapter, ctx.displayTimezone]);
 
@@ -154,8 +170,9 @@ export function RangePickerPreset({
       if (ctx.isDisabled || ctx.isReadOnly) return;
       if (!resolved) return;
 
-      ctx.setRange(resolved);
-      ctx.close();
+      if (ctx.setRange(resolved)) {
+        ctx.close();
+      }
       onClick?.(e);
     },
     [ctx, resolved, onClick],
@@ -167,8 +184,8 @@ export function RangePickerPreset({
       return false;
     }
     return (
-      ctx.adapter.isSameDay(ctx.value.start, resolved.start) &&
-      ctx.adapter.isSameDay(ctx.value.end, resolved.end)
+      ctx.adapter.isSameDay(ctx.value.start, resolved.start, ctx.displayTimezone) &&
+      ctx.adapter.isSameDay(ctx.value.end, resolved.end, ctx.displayTimezone)
     );
   }, [ctx.value.start, ctx.value.end, ctx.adapter, resolved]);
 

--- a/packages/react/src/components/RangePicker/Presets.tsx
+++ b/packages/react/src/components/RangePicker/Presets.tsx
@@ -187,7 +187,7 @@ export function RangePickerPreset({
       ctx.adapter.isSameDay(ctx.value.start, resolved.start, ctx.displayTimezone) &&
       ctx.adapter.isSameDay(ctx.value.end, resolved.end, ctx.displayTimezone)
     );
-  }, [ctx.value.start, ctx.value.end, ctx.adapter, resolved]);
+  }, [ctx.value.start, ctx.value.end, ctx.adapter, ctx.displayTimezone, resolved]);
 
   // role="option" is invalid outside role="listbox"/role="combobox"; parent is
   // role="group". Use a regular toggle button with aria-pressed.

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
@@ -416,6 +416,44 @@ describe('RangePicker — keyboard navigation', () => {
       end: null,
     });
   });
+
+  it('skips a timezone-disabled civil day when navigating', async () => {
+    const user = userEvent.setup();
+    renderRangePicker({
+      value: { start: '2026-01-15T05:00:00.000Z', end: null },
+      displayTimezone: 'America/New_York',
+      disabled: [{ date: '2026-01-16T05:00:00.000Z' }],
+    });
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('button', { name: /January 17, 2026/ })).toHaveFocus();
+  });
+
+  it.each(['Enter', ' '])('uses the timezone civil instant for %s disabled checks', async (key) => {
+    const onChange = vi.fn();
+    const filter = vi.fn((iso: string) => iso === '2026-01-15T05:00:00.000Z');
+    render(
+      <RangePicker
+        value={{ start: '2026-01-15T05:00:00.000Z', end: null }}
+        displayTimezone="America/New_York"
+        disabled={[{ filter }]}
+        onChange={onChange}
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+    await userEvent.click(screen.getByLabelText('Start date'));
+    filter.mockClear();
+    fireEvent.keyDown(screen.getByRole('grid'), { key });
+
+    expect(filter.mock.calls).toEqual([['2026-01-15T05:00:00.000Z']]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });
 
 describe('RangePicker — range visualization', () => {
@@ -784,6 +822,29 @@ describe('RangePicker — Presets', () => {
     // The "Today" option should be active
     const todayOption = screen.getByRole('button', { name: 'Today' });
     expect(todayOption).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('recomputes direct-range active state when displayTimezone changes', () => {
+    const value = {
+      start: '2026-01-15T00:00:00.000Z',
+      end: '2026-01-15T00:00:00.000Z',
+    };
+    const directRange = {
+      start: '2026-01-15T05:00:00.000Z',
+      end: '2026-01-15T05:00:00.000Z',
+    };
+    const renderPicker = (displayTimezone?: string) => (
+      <RangePicker value={value} displayTimezone={displayTimezone} onChange={vi.fn()}>
+        <RangePicker.Preset range={directRange}>Direct range</RangePicker.Preset>
+      </RangePicker>
+    );
+    const { rerender } = render(renderPicker());
+    const preset = screen.getByRole('button', { name: 'Direct range' });
+    expect(preset).toHaveAttribute('aria-pressed', 'true');
+
+    rerender(renderPicker('America/New_York'));
+
+    expect(preset).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('sets the correct range for "Last 30 days"', async () => {

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -433,7 +433,8 @@ describe('RangePicker — keyboard navigation', () => {
 
   it.each(['Enter', ' '])('uses the timezone civil instant for %s disabled checks', async (key) => {
     const onChange = vi.fn();
-    const filter = vi.fn((iso: string) => iso === '2026-01-15T05:00:00.000Z');
+    let reject = false;
+    const filter = vi.fn((iso: string) => reject && iso === '2026-01-15T05:00:00.000Z');
     render(
       <RangePicker
         value={{ start: '2026-01-15T05:00:00.000Z', end: null }}
@@ -448,6 +449,7 @@ describe('RangePicker — keyboard navigation', () => {
       </RangePicker>,
     );
     await userEvent.click(screen.getByLabelText('Start date'));
+    reject = true;
     filter.mockClear();
     fireEvent.keyDown(screen.getByRole('grid'), { key });
 
@@ -731,6 +733,29 @@ describe('RangePicker — date rules and edge cases (CLAUDE.md §7)', () => {
     // Focus on Jan 12 (Mon). ArrowLeft → skip Sun → Fri Jan 9.
     await user.keyboard('{ArrowLeft}');
     expect(screen.getByRole('button', { name: /January 9, 2026/ })).toHaveFocus();
+  });
+
+  it('moves the first Arrow from the enabled DOM fallback when the controlled start is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <RangePicker
+        value={{ start: '2026-01-17T00:00:00.000Z', end: null }}
+        disabled={[{ dayOfWeek: [0, 6] }]}
+        onChange={vi.fn()}
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Popover>
+          <RangePicker.Calendar />
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+
+    await user.click(screen.getByLabelText('Start date'));
+    expect(screen.getByRole('button', { name: /January 1, 2026/ })).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('button', { name: /January 2, 2026/ })).toHaveFocus();
   });
 });
 

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -3,7 +3,9 @@ import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
 import { RangePicker } from './index.js';
+import { useRangePickerContext } from '../../context/RangePickerContext.js';
 import type { DateRange, DisabledRule } from '@kalyx/core';
 
 const EMPTY: DateRange = { start: null, end: null };
@@ -39,7 +41,8 @@ function renderRangePicker(
     value?: DateRange;
     defaultValue?: DateRange;
     onChange?: (r: DateRange) => void;
-    disabled?: boolean;
+    disabled?: DisabledRule[] | boolean;
+    displayTimezone?: string;
   } = {},
 ) {
   const onChange = props.onChange ?? vi.fn();
@@ -49,6 +52,7 @@ function renderRangePicker(
       defaultValue={props.defaultValue}
       onChange={onChange}
       disabled={props.disabled}
+      displayTimezone={props.displayTimezone}
     >
       <RangePicker.Input part="start" />
       <RangePicker.Input part="end" />
@@ -284,6 +288,80 @@ describe('RangePicker — basic interactions', () => {
     renderRangePicker({ value: EMPTY });
     expect(screen.getByLabelText('Start date')).toHaveValue('');
     expect(screen.getByLabelText('End date')).toHaveValue('');
+  });
+});
+
+describe('RangePicker — timezone calendar coordinates', () => {
+  it.each([
+    {
+      name: 'a positive-offset range',
+      timezone: 'Asia/Seoul',
+      value: { start: '2025-12-31T15:00:00.000Z', end: '2026-01-02T15:00:00.000Z' },
+      startDay: 1,
+      endDay: 3,
+    },
+    {
+      name: 'a negative-offset range',
+      timezone: 'America/New_York',
+      value: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-17T05:00:00.000Z' },
+      startDay: 15,
+      endDay: 17,
+    },
+  ])(
+    'opens and highlights $name on its displayed civil days',
+    async ({ timezone, value, startDay, endDay }) => {
+      const user = userEvent.setup();
+      renderRangePicker({ value, displayTimezone: timezone });
+
+      await user.click(screen.getByLabelText('Start date'));
+
+      expect(screen.getByRole('grid')).toHaveAttribute('aria-label', 'January 2026');
+      const start = screen.getByRole('button', { name: new RegExp(`January ${startDay}, 2026`) });
+      const end = screen.getByRole('button', { name: new RegExp(`January ${endDay}, 2026`) });
+      expect(start).toHaveAttribute('data-range-start', 'true');
+      expect(start).toHaveFocus();
+      expect(end).toHaveAttribute('data-range-end', 'true');
+    },
+  );
+});
+
+function DirectRangeCommit() {
+  const { setRange } = useRangePickerContext('DirectRangeCommit');
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        setRange({
+          start: '2026-01-14T15:00:00.000Z',
+          end: '2026-01-15T15:00:00.000Z',
+        })
+      }
+    >
+      Commit disabled range
+    </button>
+  );
+}
+
+describe('RangePicker — shared range constraints', () => {
+  it('rejects a direct context range with a disabled endpoint', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <RangePicker
+        defaultValue={{ start: '2026-01-09T15:00:00.000Z', end: '2026-01-09T15:00:00.000Z' }}
+        displayTimezone="Asia/Seoul"
+        disabled={[{ date: '2026-01-14T15:00:00.000Z' }]}
+        onChange={onChange}
+      >
+        <RangePicker.Input part="start" />
+        <DirectRangeCommit />
+      </RangePicker>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Commit disabled range' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Start date')).toHaveValue('2026-01-10');
   });
 });
 
@@ -738,6 +816,41 @@ describe('RangePicker — Presets', () => {
     expect(call.start).toMatch(/-01T/);
   });
 
+  it.each([
+    {
+      label: 'This week',
+      expected: { start: '2026-03-28T15:00:00.000Z', end: '2026-04-03T15:00:00.000Z' },
+    },
+    {
+      label: 'This month',
+      expected: { start: '2026-03-31T15:00:00.000Z', end: '2026-04-29T15:00:00.000Z' },
+    },
+    {
+      label: 'This year',
+      expected: { start: '2025-12-31T15:00:00.000Z', end: '2026-03-31T15:00:00.000Z' },
+    },
+  ])(
+    'computes $label in the display timezone at UTC date boundaries',
+    async ({ label, expected }) => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      const adapter = { ...DateFnsAdapter, today: () => '2026-03-31T15:00:00.000Z' };
+      render(
+        <RangePicker adapter={adapter} displayTimezone="Asia/Seoul" onChange={onChange}>
+          <RangePicker.Presets>
+            <RangePicker.Preset value="thisWeek">This week</RangePicker.Preset>
+            <RangePicker.Preset value="thisMonth">This month</RangePicker.Preset>
+            <RangePicker.Preset value="thisYear">This year</RangePicker.Preset>
+          </RangePicker.Presets>
+        </RangePicker>,
+      );
+
+      await user.click(screen.getByRole('button', { name: label }));
+
+      expect(onChange).toHaveBeenLastCalledWith(expected);
+    },
+  );
+
   it('supports explicit ranges via the custom range prop', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
@@ -762,6 +875,36 @@ describe('RangePicker — Presets', () => {
       start: '2026-01-01T00:00:00.000Z',
       end: '2026-03-31T00:00:00.000Z',
     });
+  });
+
+  it('rejects a direct preset whose endpoint is disabled without closing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <RangePicker
+        defaultValue={{ start: '2026-01-09T15:00:00.000Z', end: '2026-01-09T15:00:00.000Z' }}
+        displayTimezone="Asia/Seoul"
+        disabled={[{ date: '2026-01-14T15:00:00.000Z' }]}
+        onChange={onChange}
+      >
+        <RangePicker.Input part="start" />
+        <RangePicker.Popover>
+          <RangePicker.Presets>
+            <RangePicker.Preset
+              range={{ start: '2026-01-14T15:00:00.000Z', end: '2026-01-15T15:00:00.000Z' }}
+            >
+              Disabled range
+            </RangePicker.Preset>
+          </RangePicker.Presets>
+        </RangePicker.Popover>
+      </RangePicker>,
+    );
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: 'Disabled range' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });
 

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
+  calendarDayFromInstant,
   DEFAULT_RANGEPICKER_LABELS,
   civilMidnightFromUtcDay,
   getWeekStartForLocale,
+  isDateDisabled,
 } from '@kalyx/core';
 import type {
   DateAdapter,
@@ -123,13 +125,19 @@ export function RangePickerRoot({
   const announce = useCallback((message: string) => setAnnouncement(message), []);
 
   // Lazy initializers — see DatePicker/Root.tsx for the SSR/hydration rationale.
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    () => currentValue.start ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
 
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    () => currentValue.start ?? adapter.today(displayTimezone),
-  );
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
 
   useChangeEffect(isOpen, onOpenChange);
   const viewMonthStart = useMemo(() => adapter.startOfMonth(viewMonth), [viewMonth, adapter]);
@@ -151,13 +159,20 @@ export function RangePickerRoot({
 
   const setRange = useCallback(
     (range: DateRange) => {
-      if (isDisabled || readOnly) return;
+      if (isDisabled || readOnly) return false;
+      if (
+        (range.start && isDateDisabled(range.start, disabledRules, adapter, displayTimezone)) ||
+        (range.end && isDateDisabled(range.end, disabledRules, adapter, displayTimezone))
+      ) {
+        return false;
+      }
       if (!isControlled) {
         setUncontrolledValue(range);
       }
       onChange?.(range);
+      return true;
     },
-    [isControlled, isDisabled, readOnly, onChange],
+    [isControlled, isDisabled, readOnly, onChange, disabledRules, adapter, displayTimezone],
   );
 
   /**
@@ -167,23 +182,24 @@ export function RangePickerRoot({
    */
   const selectDate = useCallback(
     (iso: ISODateString) => {
-      if (isDisabled || readOnly) return;
+      if (isDisabled || readOnly) return false;
 
       // Normalize UTC-grid ISOs to civil-midnight-in-tz before storing (see DatePicker.Root).
       const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
 
       if (selectingTarget === 'start') {
         const newRange: DateRange = { start: normalized, end: null };
-        setRange(newRange);
+        if (!setRange(newRange)) return false;
         setSelectingTarget('end');
         setHoverDate(null);
+        return true;
       } else {
         const start = currentValue.start;
         if (!start) {
           // Safety: if start is missing, treat this click as start
-          setRange({ start: normalized, end: null });
+          if (!setRange({ start: normalized, end: null })) return false;
           setSelectingTarget('end');
-          return;
+          return true;
         }
 
         let newRange: DateRange;
@@ -194,10 +210,11 @@ export function RangePickerRoot({
           newRange = { start, end: normalized };
         }
 
-        setRange(newRange);
+        if (!setRange(newRange)) return false;
         setSelectingTarget('start');
         setHoverDate(null);
         setIsOpen(false);
+        return true;
       }
     },
     [isDisabled, readOnly, selectingTarget, currentValue.start, adapter, setRange, displayTimezone],
@@ -207,7 +224,10 @@ export function RangePickerRoot({
     (target?: RangeSelectingTarget) => {
       if (isDisabled || readOnly) return;
       setIsOpen(true);
-      const focus = currentValue.start ?? adapter.today(displayTimezone);
+      const targetValue = currentValue.start ?? adapter.today(displayTimezone);
+      const focus = displayTimezone
+        ? calendarDayFromInstant(targetValue, displayTimezone)
+        : adapter.startOfDay(targetValue);
       setViewMonth(focus);
       setFocusedDate(focus);
       // An explicit target (from clicking the start/end input) wins. Otherwise, if

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -22,6 +22,7 @@ import type {
 } from '../../context/RangePickerContext.js';
 import type { Direction } from '../_shared/rtl.js';
 import { useChangeEffect } from '../../hooks/useChangeEffect.js';
+import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
 import { getDefaultAdapter, resolveAdapter } from '../../internal/defaultAdapter.js';
 import { SR_ONLY } from '../../internal/srOnly.js';
 
@@ -229,7 +230,7 @@ export function RangePickerRoot({
         ? calendarDayFromInstant(targetValue, displayTimezone)
         : adapter.startOfDay(targetValue);
       setViewMonth(focus);
-      setFocusedDate(focus);
+      setFocusedDate(resolveEnabledCalendarFocus(focus, disabledRules, adapter, displayTimezone));
       // An explicit target (from clicking the start/end input) wins. Otherwise, if
       // the range is complete, restart the two-click flow from 'start'.
       if (target) {
@@ -238,7 +239,7 @@ export function RangePickerRoot({
         setSelectingTarget('start');
       }
     },
-    [isDisabled, readOnly, currentValue, adapter, displayTimezone],
+    [isDisabled, readOnly, currentValue, adapter, displayTimezone, disabledRules],
   );
 
   const close = useCallback(() => {

--- a/packages/react/src/components/RangePicker/Root.tsx
+++ b/packages/react/src/components/RangePicker/Root.tsx
@@ -229,8 +229,14 @@ export function RangePickerRoot({
       const focus = displayTimezone
         ? calendarDayFromInstant(targetValue, displayTimezone)
         : adapter.startOfDay(targetValue);
-      setViewMonth(focus);
-      setFocusedDate(resolveEnabledCalendarFocus(focus, disabledRules, adapter, displayTimezone));
+      const enabledFocus = resolveEnabledCalendarFocus(
+        focus,
+        disabledRules,
+        adapter,
+        displayTimezone,
+      );
+      setViewMonth(enabledFocus);
+      setFocusedDate(enabledFocus);
       // An explicit target (from clicking the start/end input) wins. Otherwise, if
       // the range is complete, restart the two-click flow from 'start'.
       if (target) {

--- a/packages/react/src/components/TimePicker/Root.tsx
+++ b/packages/react/src/components/TimePicker/Root.tsx
@@ -137,12 +137,25 @@ export function TimePickerRoot({
       const newIso = displayTimezone
         ? setTimeInTimezone(base, partial, displayTimezone)
         : setTimeOnIso(base, partial);
+      const finalTime = displayTimezone
+        ? getTimeInTimezone(newIso, displayTimezone)
+        : getTime(newIso);
+      if (filterTime?.(finalTime.hours, finalTime.minutes)) return;
       if (!isControlled) {
         setUncontrolledValue(newIso);
       }
       onChange?.(newIso);
     },
-    [disabled, readOnly, currentValue, displayTimezone, isControlled, onChange, adapter],
+    [
+      disabled,
+      readOnly,
+      currentValue,
+      displayTimezone,
+      filterTime,
+      isControlled,
+      onChange,
+      adapter,
+    ],
   );
 
   const contextValue: TimePickerContextValue = useMemo(

--- a/packages/react/src/components/TimePicker/TimePicker.test.tsx
+++ b/packages/react/src/components/TimePicker/TimePicker.test.tsx
@@ -4,6 +4,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { TimePicker } from './index.js';
+import { useTimePickerContext } from '../../context/TimePickerContext.js';
+
+function TimeMutationProbe({ hours }: { hours: number }) {
+  const ctx = useTimePickerContext('TimeMutationProbe');
+  return <button onClick={() => ctx.setTime({ hours })}>set-context-hour-{hours}</button>;
+}
 
 function renderTimePicker(
   props: {
@@ -528,6 +534,48 @@ describe('TimePicker — disabled state', () => {
 });
 
 describe('TimePicker — filterTime', () => {
+  it('rejects a filtered time typed into the input at the Root boundary', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TimePicker
+        value="2026-01-15T10:30:00.000Z"
+        onChange={onChange}
+        filterTime={(hours, minutes) => hours === 15 && minutes === 45}
+      >
+        <TimePicker.Input />
+      </TimePicker>,
+    );
+
+    const input = screen.getByLabelText('Time');
+    await user.clear(input);
+    await user.type(input, '15:45');
+    await user.tab();
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue('10:30');
+  });
+
+  it('rejects a filtered context mutation using the final merged time', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TimePicker
+        value="2026-01-15T10:30:00.000Z"
+        onChange={onChange}
+        filterTime={(hours, minutes) => hours === 12 && minutes === 30}
+      >
+        <TimePicker.Input />
+        <TimeMutationProbe hours={12} />
+      </TimePicker>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'set-context-hour-12' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Time')).toHaveValue('10:30');
+  });
+
   it('marks aria-disabled on minutes rejected by filterTime', () => {
     // Disable minute 30 only — visible per-minute disable
     render(

--- a/packages/react/src/components/WeekPicker/WeekPicker.test.tsx
+++ b/packages/react/src/components/WeekPicker/WeekPicker.test.tsx
@@ -14,6 +14,7 @@ function renderWeekPicker(
     disabled?: boolean;
     weekStartsOn?: 0 | 1;
     weekAnchor?: 'calendar' | 'clicked';
+    displayTimezone?: string;
   } = {},
 ) {
   const onChange = props.onChange ?? vi.fn();
@@ -24,6 +25,7 @@ function renderWeekPicker(
       onChange={onChange}
       disabled={props.disabled}
       weekStartsOn={props.weekStartsOn}
+      displayTimezone={props.displayTimezone}
     >
       <WeekPicker.Input part="start" />
       <WeekPicker.Input part="end" />
@@ -42,6 +44,49 @@ const JAN_ANCHOR: DateRange = {
 };
 
 describe('WeekPicker — single-click commits the full week', () => {
+  it('emits calendar-week endpoints as civil-midnight instants in the display timezone', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderWeekPicker({
+      value: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-15T05:00:00.000Z' },
+      displayTimezone: 'America/New_York',
+      weekStartsOn: 0,
+    });
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: /January 14, 2026/ }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      start: '2026-01-11T05:00:00.000Z',
+      end: '2026-01-17T05:00:00.000Z',
+    });
+  });
+
+  it.each([
+    {
+      target: 'Start date',
+      expected: { start: '2026-01-14T05:00:00.000Z', end: '2026-01-20T05:00:00.000Z' },
+    },
+    {
+      target: 'End date',
+      expected: { start: '2026-01-08T05:00:00.000Z', end: '2026-01-14T05:00:00.000Z' },
+    },
+  ])(
+    'keeps a clicked anchor directional when opened from the $target',
+    async ({ target, expected }) => {
+      const user = userEvent.setup();
+      const { onChange } = renderWeekPicker({
+        value: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-15T05:00:00.000Z' },
+        displayTimezone: 'America/New_York',
+        weekAnchor: 'clicked',
+      });
+
+      await user.click(screen.getByLabelText(target));
+      await user.click(screen.getByRole('button', { name: /January 14, 2026/ }));
+
+      expect(onChange).toHaveBeenCalledWith(expected);
+    },
+  );
+
   it('selects Sunday–Saturday when weekStartsOn=0', async () => {
     const user = userEvent.setup();
     const { onChange } = renderWeekPicker({ value: JAN_ANCHOR, weekStartsOn: 0 });
@@ -320,12 +365,11 @@ describe('WeekPicker — date rules and edge cases (CLAUDE.md §7)', () => {
     await user.click(sat);
     expect(onChange).not.toHaveBeenCalled();
 
-    // Sanity check: an enabled weekday IS selectable. Wed Jan 14 → week Sun
-    // Jan 11 – Sat Jan 17, but Sun and Sat are themselves disabled days.
-    // The week-mode commits regardless of weekday filtering on endpoints, so
-    // verify the call still fires for the chosen day.
+    // Wed Jan 14 itself is enabled, but its calendar-week endpoints (Sun Jan 11
+    // and Sat Jan 17) are disabled. The shared range commit gate rejects the
+    // entire week, so week mode cannot bypass endpoint constraints.
     await user.click(screen.getByRole('button', { name: /January 14, 2026/ }));
-    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('keyboard ArrowLeft skips disabled days', async () => {

--- a/packages/react/src/context/DatePickerContext.ts
+++ b/packages/react/src/context/DatePickerContext.ts
@@ -21,8 +21,10 @@ export interface DatePickerContextValue {
    * DateTimePicker.Root — undefined for plain DatePicker. Used by
    * DateTimePicker.Presets so a preset like "today 09:00" commits both portions
    * atomically instead of racing `selectDate` (time-preserving) with `setTime`.
+   * Returns whether the Root accepted the commit so callers only apply follow-up
+   * effects such as closing the popover after a successful transition.
    */
-  selectDateTime?: (iso: ISODateString | null) => void;
+  selectDateTime?: (iso: ISODateString | null) => boolean;
   /** Popover open state */
   isOpen: boolean;
   /** Open the popover */

--- a/packages/react/src/context/RangePickerContext.ts
+++ b/packages/react/src/context/RangePickerContext.ts
@@ -19,9 +19,9 @@ export interface RangePickerContextValue {
   /** Currently selected range */
   value: DateRange;
   /** Update the entire range object */
-  setRange: (range: DateRange) => void;
+  setRange: (range: DateRange) => boolean;
   /** Single-date click; automatically decides start/end */
-  selectDate: (iso: ISODateString) => void;
+  selectDate: (iso: ISODateString) => boolean;
   /** Which part gets selected next (start first, then end) */
   selectingTarget: RangeSelectingTarget;
   /**

--- a/packages/react/src/hooks/useDatePicker.test.tsx
+++ b/packages/react/src/hooks/useDatePicker.test.tsx
@@ -189,3 +189,61 @@ describe('useDatePicker — stable IDs', () => {
     expect(result.current.pickerId).toBe(firstId);
   });
 });
+
+describe('useDatePicker — timezone and constraint parity', () => {
+  it.each([
+    {
+      name: 'Seoul',
+      timezone: 'Asia/Seoul',
+      value: '2025-12-31T15:00:00.000Z',
+      coordinate: '2026-01-01T00:00:00.000Z',
+    },
+    {
+      name: 'New York',
+      timezone: 'America/New_York',
+      value: '2026-01-15T05:00:00.000Z',
+      coordinate: '2026-01-15T00:00:00.000Z',
+    },
+  ])(
+    'uses $name civil-day coordinates for initial and opened view/focus',
+    ({ timezone, value, coordinate }) => {
+      const { result } = renderHook(() =>
+        useDatePicker({ defaultValue: value, displayTimezone: timezone }),
+      );
+
+      expect(result.current.viewMonth).toBe(coordinate);
+      expect(result.current.focusedDate).toBe(coordinate);
+
+      act(() => result.current.open());
+
+      expect(result.current.viewMonth).toBe(coordinate);
+      expect(result.current.focusedDate).toBe(coordinate);
+    },
+  );
+
+  it.each([
+    { name: 'exact date', rule: { date: '2026-01-15T05:00:00.000Z' } },
+    { name: 'day of week', rule: { dayOfWeek: [4] } },
+    { name: 'before instant', rule: { before: '2026-01-15T06:00:00.000Z' } },
+    { name: 'after instant', rule: { after: '2026-01-15T04:00:00.000Z' } },
+    { name: 'filter', rule: { filter: (iso: string) => iso === '2026-01-15T05:00:00.000Z' } },
+  ])('rejects a $name rule at the final mutation boundary', ({ rule }) => {
+    const onChange = vi.fn();
+    const initial = '2026-01-14T05:00:00.000Z';
+    const { result } = renderHook(() =>
+      useDatePicker({
+        defaultValue: initial,
+        displayTimezone: 'America/New_York',
+        disabled: [rule],
+        onChange,
+      }),
+    );
+
+    act(() => result.current.open());
+    act(() => result.current.selectDate('2026-01-15T00:00:00.000Z'));
+
+    expect(result.current.value).toBe(initial);
+    expect(result.current.isOpen).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useDatePicker.test.tsx
+++ b/packages/react/src/hooks/useDatePicker.test.tsx
@@ -204,6 +204,20 @@ describe('useDatePicker — timezone and constraint parity', () => {
     expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
   });
 
+  it('moves view and focus beyond a fully disabled month', () => {
+    const { result } = renderHook(() =>
+      useDatePicker({
+        value: '2026-01-17T00:00:00.000Z',
+        disabled: [{ before: '2026-02-01T00:00:00.000Z' }],
+      }),
+    );
+
+    act(() => result.current.open());
+
+    expect(result.current.viewMonth).toBe('2026-02-01T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-02-01T00:00:00.000Z');
+  });
+
   it.each([
     {
       name: 'Seoul',

--- a/packages/react/src/hooks/useDatePicker.test.tsx
+++ b/packages/react/src/hooks/useDatePicker.test.tsx
@@ -191,6 +191,19 @@ describe('useDatePicker — stable IDs', () => {
 });
 
 describe('useDatePicker — timezone and constraint parity', () => {
+  it('opens with an enabled focus coordinate when the controlled value is disabled', () => {
+    const { result } = renderHook(() =>
+      useDatePicker({
+        value: '2026-01-17T00:00:00.000Z',
+        disabled: [{ dayOfWeek: [0, 6] }],
+      }),
+    );
+
+    act(() => result.current.open());
+
+    expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
+  });
+
   it.each([
     {
       name: 'Seoul',

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -13,6 +13,7 @@ import type {
   WeekStartsOn,
 } from '@kalyx/core';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
+import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
 
 export interface UseDatePickerOptions {
   /** Selected date (controlled mode) */
@@ -134,8 +135,8 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
     setViewMonth(coordinate);
-    setFocusedDate(coordinate);
-  }, [currentValue, adapter, displayTimezone]);
+    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+  }, [currentValue, adapter, displayTimezone, disabled]);
 
   const close = useCallback(() => {
     setIsOpen(false);

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -1,5 +1,10 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import {
+  calendarDayFromInstant,
+  civilMidnightFromUtcDay,
+  getCalendarDays,
+  isDateDisabled,
+} from '@kalyx/core';
 import type {
   CalendarGrid,
   DateAdapter,
@@ -95,31 +100,41 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue ?? adapter.today(displayTimezone),
-  );
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
 
   const selectDate = useCallback(
     (iso: ISODateString | null) => {
       const normalized =
         iso && displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
+      if (normalized && isDateDisabled(normalized, disabled, adapter, displayTimezone)) return;
       if (!isControlled) {
         setUncontrolledValue(normalized);
       }
       onChange?.(normalized);
       setIsOpen(false);
     },
-    [isControlled, onChange, displayTimezone],
+    [isControlled, onChange, displayTimezone, disabled, adapter],
   );
 
   const open = useCallback(() => {
     setIsOpen(true);
     const target = currentValue ?? adapter.today(displayTimezone);
-    setViewMonth(target);
-    setFocusedDate(target);
+    const coordinate = displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+    setViewMonth(coordinate);
+    setFocusedDate(coordinate);
   }, [currentValue, adapter, displayTimezone]);
 
   const close = useCallback(() => {
@@ -146,7 +161,9 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,
     selected: currentValue,
-    focusedDate,
+    focusedDate: displayTimezone
+      ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+      : focusedDate,
     disabled,
     timezone: displayTimezone,
   });

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -134,8 +134,9 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
     const coordinate = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
-    setViewMonth(coordinate);
-    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+    const focus = resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone);
+    setViewMonth(focus);
+    setFocusedDate(focus);
   }, [currentValue, adapter, displayTimezone, disabled]);
 
   const close = useCallback(() => {

--- a/packages/react/src/hooks/useDateTimePicker.test.tsx
+++ b/packages/react/src/hooks/useDateTimePicker.test.tsx
@@ -88,4 +88,18 @@ describe('useDateTimePicker — timezone and constraint parity', () => {
     expect(result.current.value).toBe(initial);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('recenters zoned view and focus when toggle opens after navigation and a controlled value change', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDateTimePicker({ value, displayTimezone: 'Asia/Seoul' }),
+      { initialProps: { value: '2025-12-31T15:30:00.000Z' } },
+    );
+
+    act(() => result.current.nextMonth());
+    rerender({ value: '2026-03-15T15:30:00.000Z' });
+    act(() => result.current.toggle());
+
+    expect(result.current.viewMonth).toBe('2026-03-16T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-03-16T00:00:00.000Z');
+  });
 });

--- a/packages/react/src/hooks/useDateTimePicker.test.tsx
+++ b/packages/react/src/hooks/useDateTimePicker.test.tsx
@@ -48,3 +48,44 @@ describe('useDateTimePicker', () => {
     expect(result.current.calendar[0]).toHaveLength(7);
   });
 });
+
+describe('useDateTimePicker — timezone and constraint parity', () => {
+  it('uses Seoul civil-day coordinates for initial and opened view/focus', () => {
+    const { result } = renderHook(() =>
+      useDateTimePicker({
+        defaultValue: '2025-12-31T15:30:00.000Z',
+        displayTimezone: 'Asia/Seoul',
+      }),
+    );
+
+    expect(result.current.viewMonth).toBe('2026-01-01T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
+
+    act(() => result.current.open());
+
+    expect(result.current.viewMonth).toBe('2026-01-01T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('rejects disabled date and filtered time mutations at the final boundary', () => {
+    const onChange = vi.fn();
+    const initial = '2026-01-14T05:30:00.000Z';
+    const { result } = renderHook(() =>
+      useDateTimePicker({
+        defaultValue: initial,
+        displayTimezone: 'America/New_York',
+        disabled: [{ date: '2026-01-15T05:00:00.000Z' }],
+        filterTime: (hours, minutes) => hours === 10 && minutes === 30,
+        onChange,
+      }),
+    );
+
+    act(() => result.current.selectDate('2026-01-15T00:00:00.000Z'));
+    expect(result.current.value).toBe(initial);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => result.current.setTime({ hours: 10 }));
+    expect(result.current.value).toBe(initial);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useDateTimePicker.test.tsx
+++ b/packages/react/src/hooks/useDateTimePicker.test.tsx
@@ -50,6 +50,19 @@ describe('useDateTimePicker', () => {
 });
 
 describe('useDateTimePicker — timezone and constraint parity', () => {
+  it('opens with an enabled focus coordinate when the controlled date is disabled', () => {
+    const { result } = renderHook(() =>
+      useDateTimePicker({
+        value: '2026-01-17T10:00:00.000Z',
+        disabled: [{ dayOfWeek: [0, 6] }],
+      }),
+    );
+
+    act(() => result.current.open());
+
+    expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
+  });
+
   it('uses Seoul civil-day coordinates for initial and opened view/focus', () => {
     const { result } = renderHook(() =>
       useDateTimePicker({

--- a/packages/react/src/hooks/useDateTimePicker.ts
+++ b/packages/react/src/hooks/useDateTimePicker.ts
@@ -174,7 +174,10 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
     setFocusedDate(coordinate);
   }, [currentValue, adapter, displayTimezone]);
   const close = useCallback(() => setIsOpen(false), []);
-  const toggle = useCallback(() => setIsOpen((o) => !o), []);
+  const toggle = useCallback(() => {
+    if (isOpen) close();
+    else open();
+  }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
     setViewMonth((m) => {

--- a/packages/react/src/hooks/useDateTimePicker.ts
+++ b/packages/react/src/hooks/useDateTimePicker.ts
@@ -18,6 +18,7 @@ import type {
   WeekStartsOn,
 } from '@kalyx/core';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
+import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
 
 export interface UseDateTimePickerOptions {
   /** Selected datetime (controlled, ISO 8601 UTC — date and time) */
@@ -171,8 +172,8 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
     setViewMonth(coordinate);
-    setFocusedDate(coordinate);
-  }, [currentValue, adapter, displayTimezone]);
+    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+  }, [currentValue, adapter, displayTimezone, disabled]);
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => {
     if (isOpen) close();

--- a/packages/react/src/hooks/useDateTimePicker.ts
+++ b/packages/react/src/hooks/useDateTimePicker.ts
@@ -1,11 +1,13 @@
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import {
   civilMidnightFromUtcDay,
+  calendarDayFromInstant,
   getCalendarDays,
   getTime,
   getTimeInTimezone,
   setTime as setTimeOnIso,
   setTimeInTimezone,
+  isDateDisabled,
 } from '@kalyx/core';
 import type {
   CalendarGrid,
@@ -32,6 +34,8 @@ export interface UseDateTimePickerOptions {
   adapter?: DateAdapter;
   /** IANA timezone for display (see DateTimePickerRoot#displayTimezone) */
   displayTimezone?: string;
+  /** Returns true when the final displayed time should be rejected. */
+  filterTime?: (hours: number, minutes: number) => boolean;
 }
 
 export interface UseDateTimePickerReturn {
@@ -79,6 +83,7 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
     weekStartsOn = 0,
     adapter: adapterProp,
     displayTimezone,
+    filterTime,
   } = options;
 
   const adapter = resolveAdapter(adapterProp, getDefaultAdapter(), 'useDateTimePicker');
@@ -91,12 +96,18 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    () => currentValue ?? adapter.today(displayTimezone),
-  );
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    () => currentValue ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
 
   // Stable {0,0,0} fallback when null keeps SSR/hydration output deterministic.
   const currentTime: TimeValue = useMemo(() => {
@@ -108,10 +119,18 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
 
   const updateValue = useCallback(
     (next: ISODateString | null) => {
+      if (next && isDateDisabled(next, disabled, adapter, displayTimezone)) return false;
+      if (next) {
+        const finalTime = displayTimezone
+          ? getTimeInTimezone(next, displayTimezone)
+          : getTime(next);
+        if (filterTime?.(finalTime.hours, finalTime.minutes)) return false;
+      }
       if (!isControlled) setUncontrolledValue(next);
       onChange?.(next);
+      return true;
     },
-    [isControlled, onChange],
+    [isControlled, onChange, disabled, adapter, displayTimezone, filterTime],
   );
 
   const selectDate = useCallback(
@@ -148,8 +167,11 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
   const open = useCallback(() => {
     setIsOpen(true);
     const target = currentValue ?? adapter.today(displayTimezone);
-    setViewMonth(target);
-    setFocusedDate(target);
+    const coordinate = displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+    setViewMonth(coordinate);
+    setFocusedDate(coordinate);
   }, [currentValue, adapter, displayTimezone]);
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => setIsOpen((o) => !o), []);
@@ -172,7 +194,9 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,
     selected: currentValue,
-    focusedDate,
+    focusedDate: displayTimezone
+      ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+      : focusedDate,
     disabled,
     timezone: displayTimezone,
   });

--- a/packages/react/src/hooks/useDateTimePicker.ts
+++ b/packages/react/src/hooks/useDateTimePicker.ts
@@ -171,8 +171,9 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
     const coordinate = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
-    setViewMonth(coordinate);
-    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+    const focus = resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone);
+    setViewMonth(focus);
+    setFocusedDate(focus);
   }, [currentValue, adapter, displayTimezone, disabled]);
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => {

--- a/packages/react/src/hooks/useRangePicker.test.tsx
+++ b/packages/react/src/hooks/useRangePicker.test.tsx
@@ -193,3 +193,66 @@ describe('useRangePicker — navigation', () => {
     ).toBe(true);
   });
 });
+
+describe('useRangePicker — timezone and constraint parity', () => {
+  it.each([
+    {
+      name: 'Seoul',
+      timezone: 'Asia/Seoul',
+      value: { start: '2025-12-31T15:00:00.000Z', end: '2026-01-01T15:00:00.000Z' },
+      coordinate: '2026-01-01T00:00:00.000Z',
+    },
+    {
+      name: 'New York',
+      timezone: 'America/New_York',
+      value: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-16T05:00:00.000Z' },
+      coordinate: '2026-01-15T00:00:00.000Z',
+    },
+  ])(
+    'uses $name civil-day coordinates for initial and opened view/focus',
+    ({ timezone, value, coordinate }) => {
+      const { result } = renderHook(() =>
+        useRangePicker({ defaultValue: value, displayTimezone: timezone }),
+      );
+
+      expect(result.current.viewMonth).toBe(coordinate);
+      expect(result.current.focusedDate).toBe(coordinate);
+
+      act(() => result.current.open());
+
+      expect(result.current.viewMonth).toBe(coordinate);
+      expect(result.current.focusedDate).toBe(coordinate);
+    },
+  );
+
+  it.each([
+    { name: 'a disabled start endpoint', rule: { date: '2026-01-15T05:00:00.000Z' } },
+    {
+      name: 'a disabled end endpoint',
+      rule: { filter: (iso: string) => iso === '2026-01-16T05:00:00.000Z' },
+    },
+  ])('rejects a direct range with $name without updating uncontrolled state', ({ rule }) => {
+    const onChange = vi.fn();
+    const initial = { start: '2026-01-14T05:00:00.000Z', end: '2026-01-14T05:00:00.000Z' };
+    const { result } = renderHook(() =>
+      useRangePicker({
+        defaultValue: initial,
+        displayTimezone: 'America/New_York',
+        disabled: [rule],
+        onChange,
+      }),
+    );
+
+    act(() => result.current.open());
+    act(() =>
+      result.current.setRange({
+        start: '2026-01-15T05:00:00.000Z',
+        end: '2026-01-16T05:00:00.000Z',
+      }),
+    );
+
+    expect(result.current.value).toEqual(initial);
+    expect(result.current.isOpen).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useRangePicker.test.tsx
+++ b/packages/react/src/hooks/useRangePicker.test.tsx
@@ -195,6 +195,19 @@ describe('useRangePicker — navigation', () => {
 });
 
 describe('useRangePicker — timezone and constraint parity', () => {
+  it('opens with an enabled focus coordinate when the controlled start is disabled', () => {
+    const { result } = renderHook(() =>
+      useRangePicker({
+        value: { start: '2026-01-17T00:00:00.000Z', end: null },
+        disabled: [{ dayOfWeek: [0, 6] }],
+      }),
+    );
+
+    act(() => result.current.open());
+
+    expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
+  });
+
   it.each([
     {
       name: 'Seoul',

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -43,7 +43,7 @@ export interface UseRangePickerReturn {
   /** Handler for clicking a single date */
   selectDate: (iso: ISODateString) => void;
   /** Set the range directly */
-  setRange: (range: DateRange) => boolean;
+  setRange: (range: DateRange) => void;
   /** Whether the popover is open */
   isOpen: boolean;
   open: () => void;

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -1,5 +1,10 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import {
+  calendarDayFromInstant,
+  civilMidnightFromUtcDay,
+  getCalendarDays,
+  isDateDisabled,
+} from '@kalyx/core';
 import type {
   CalendarGrid,
   DateAdapter,
@@ -38,7 +43,7 @@ export interface UseRangePickerReturn {
   /** Handler for clicking a single date */
   selectDate: (iso: ISODateString) => void;
   /** Set the range directly */
-  setRange: (range: DateRange) => void;
+  setRange: (range: DateRange) => boolean;
   /** Whether the popover is open */
   isOpen: boolean;
   open: () => void;
@@ -104,34 +109,47 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
   const [isOpen, setIsOpen] = useState(false);
   const [selectingTarget, setSelectingTarget] = useState<RangeSelectingTarget>('start');
   const [hoverDate, setHoverDate] = useState<ISODateString | null>(null);
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(displayTimezone),
-  );
-  const [focusedDate, setFocusedDate] = useState<ISODateString>(
-    currentValue.start ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
 
   const setRange = useCallback(
     (range: DateRange) => {
+      if (
+        (range.start && isDateDisabled(range.start, disabled, adapter, displayTimezone)) ||
+        (range.end && isDateDisabled(range.end, disabled, adapter, displayTimezone))
+      ) {
+        return false;
+      }
       if (!isControlled) {
         setUncontrolledValue(range);
       }
       onChange?.(range);
+      return true;
     },
-    [isControlled, onChange],
+    [isControlled, onChange, disabled, adapter, displayTimezone],
   );
 
   const selectDate = useCallback(
     (iso: ISODateString) => {
       const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (selectingTarget === 'start') {
-        setRange({ start: normalized, end: null });
+        if (!setRange({ start: normalized, end: null })) return;
         setSelectingTarget('end');
         setHoverDate(null);
       } else {
         const start = currentValue.start;
         if (!start) {
-          setRange({ start: normalized, end: null });
+          if (!setRange({ start: normalized, end: null })) return;
           setSelectingTarget('end');
           return;
         }
@@ -140,7 +158,7 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
           ? { start: normalized, end: start }
           : { start, end: normalized };
 
-        setRange(newRange);
+        if (!setRange(newRange)) return;
         setSelectingTarget('start');
         setHoverDate(null);
         setIsOpen(false);
@@ -152,8 +170,11 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
   const open = useCallback(() => {
     setIsOpen(true);
     const target = currentValue.start ?? adapter.today(displayTimezone);
-    setViewMonth(target);
-    setFocusedDate(target);
+    const coordinate = displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+    setViewMonth(coordinate);
+    setFocusedDate(coordinate);
     if (currentValue.start && currentValue.end) {
       setSelectingTarget('start');
     }
@@ -183,7 +204,9 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,
-    focusedDate,
+    focusedDate: displayTimezone
+      ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+      : focusedDate,
     disabled,
     range: currentValue,
     rangeHover: hoverDate,

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -15,6 +15,7 @@ import type {
 } from '@kalyx/core';
 import type { RangeSelectingTarget } from '../context/RangePickerContext.js';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
+import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
 
 const EMPTY_RANGE: DateRange = { start: null, end: null };
 
@@ -174,11 +175,11 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
     setViewMonth(coordinate);
-    setFocusedDate(coordinate);
+    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
     if (currentValue.start && currentValue.end) {
       setSelectingTarget('start');
     }
-  }, [currentValue, adapter, displayTimezone]);
+  }, [currentValue, adapter, displayTimezone, disabled]);
 
   const close = useCallback(() => {
     setIsOpen(false);

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -174,8 +174,9 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
     const coordinate = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
-    setViewMonth(coordinate);
-    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+    const focus = resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone);
+    setViewMonth(focus);
+    setFocusedDate(focus);
     if (currentValue.start && currentValue.end) {
       setSelectingTarget('start');
     }

--- a/packages/react/src/hooks/useTimePicker.test.tsx
+++ b/packages/react/src/hooks/useTimePicker.test.tsx
@@ -153,3 +153,23 @@ describe('useTimePicker — format behavior', () => {
     expect(result.current.displayHour).toBe(13);
   });
 });
+
+describe('useTimePicker — filterTime parity', () => {
+  it('rejects a filtered final time without mutating uncontrolled state or calling onChange', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useTimePicker({
+        defaultValue: '2026-01-15T05:30:00.000Z',
+        displayTimezone: 'America/New_York',
+        filterTime: (hours, minutes) => hours === 10 && minutes === 30,
+        onChange,
+      }),
+    );
+
+    act(() => result.current.setHour(10));
+
+    expect(result.current.value).toBe('2026-01-15T05:30:00.000Z');
+    expect(result.current.currentTime).toEqual({ hours: 0, minutes: 30, seconds: 0 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useTimePicker.ts
+++ b/packages/react/src/hooks/useTimePicker.ts
@@ -28,6 +28,8 @@ export interface UseTimePickerOptions {
   withSeconds?: boolean;
   /** IANA timezone for time interpretation (see TimePickerRoot#displayTimezone) */
   displayTimezone?: string;
+  /** Returns true when the final displayed time should be rejected. */
+  filterTime?: (hours: number, minutes: number) => boolean;
   /**
    * Date adapter. Only used when the controlled `value` is `null` to derive
    * "today" as the base for the first time edit. The main `@kalyx/react` entry
@@ -90,6 +92,7 @@ export function useTimePicker(options: UseTimePickerOptions = {}): UseTimePicker
     format = '24h',
     step = 1,
     displayTimezone,
+    filterTime,
     adapter: adapterProp,
   } = options;
 
@@ -102,7 +105,7 @@ export function useTimePicker(options: UseTimePickerOptions = {}): UseTimePicker
   );
 
   const currentValue = isControlled ? (controlledValue ?? null) : uncontrolledValue;
-  const baseIso = currentValue ?? adapter.today();
+  const baseIso = currentValue ?? adapter.today(displayTimezone);
   const currentTime = useMemo(
     () => (displayTimezone ? getTimeInTimezone(baseIso, displayTimezone) : getTime(baseIso)),
     [baseIso, displayTimezone],
@@ -113,12 +116,16 @@ export function useTimePicker(options: UseTimePickerOptions = {}): UseTimePicker
       const newIso = displayTimezone
         ? setTimeInTimezone(baseIso, partial, displayTimezone)
         : setTimeOnIso(baseIso, partial);
+      const finalTime = displayTimezone
+        ? getTimeInTimezone(newIso, displayTimezone)
+        : getTime(newIso);
+      if (filterTime?.(finalTime.hours, finalTime.minutes)) return;
       if (!isControlled) {
         setUncontrolledValue(newIso);
       }
       onChange?.(newIso);
     },
-    [baseIso, isControlled, onChange, displayTimezone],
+    [baseIso, isControlled, onChange, displayTimezone, filterTime],
   );
 
   const period = format === '12h' ? to12Hour(currentTime.hours).period : null;

--- a/packages/react/src/hooks/useWeekPicker.test.tsx
+++ b/packages/react/src/hooks/useWeekPicker.test.tsx
@@ -112,4 +112,37 @@ describe('useWeekPicker — timezone and constraint parity', () => {
     expect(result.current.isOpen).toBe(true);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('recenters zoned view and focus when toggle opens after navigation and a controlled value change', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useWeekPicker({ value, displayTimezone: 'America/New_York' }),
+      {
+        initialProps: {
+          value: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-17T05:00:00.000Z' },
+        },
+      },
+    );
+
+    act(() => result.current.nextMonth());
+    rerender({ value: { start: '2026-03-15T05:00:00.000Z', end: '2026-03-21T04:00:00.000Z' } });
+    act(() => result.current.toggle());
+
+    expect(result.current.viewMonth).toBe('2026-03-15T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-03-15T00:00:00.000Z');
+  });
+
+  it('moves focusedDate into the month reached by navigation', () => {
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        defaultValue: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-17T05:00:00.000Z' },
+        displayTimezone: 'America/New_York',
+      }),
+    );
+
+    act(() => result.current.nextMonth());
+
+    expect(
+      result.current.adapter.isSameMonth(result.current.focusedDate, result.current.viewMonth),
+    ).toBe(true);
+  });
 });

--- a/packages/react/src/hooks/useWeekPicker.test.tsx
+++ b/packages/react/src/hooks/useWeekPicker.test.tsx
@@ -51,6 +51,19 @@ describe('useWeekPicker', () => {
 });
 
 describe('useWeekPicker — timezone and constraint parity', () => {
+  it('opens with an enabled focus coordinate when the controlled start is disabled', () => {
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        value: { start: '2026-01-17T00:00:00.000Z', end: null },
+        disabled: [{ dayOfWeek: [0, 6] }],
+      }),
+    );
+
+    act(() => result.current.open());
+
+    expect(result.current.focusedDate).toBe('2026-01-01T00:00:00.000Z');
+  });
+
   it('uses New York civil-day coordinates and emits civil-midnight week endpoints', () => {
     const onChange = vi.fn();
     const { result } = renderHook(() =>

--- a/packages/react/src/hooks/useWeekPicker.test.tsx
+++ b/packages/react/src/hooks/useWeekPicker.test.tsx
@@ -49,3 +49,67 @@ describe('useWeekPicker', () => {
     expect(result.current.viewMonth).not.toBe(before);
   });
 });
+
+describe('useWeekPicker — timezone and constraint parity', () => {
+  it('uses New York civil-day coordinates and emits civil-midnight week endpoints', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        defaultValue: { start: '2026-01-15T05:00:00.000Z', end: '2026-01-15T05:00:00.000Z' },
+        displayTimezone: 'America/New_York',
+        weekStartsOn: 0,
+        onChange,
+      }),
+    );
+
+    expect(result.current.viewMonth).toBe('2026-01-15T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-01-15T00:00:00.000Z');
+
+    act(() => result.current.open());
+    act(() => result.current.selectWeek('2026-01-14T00:00:00.000Z'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      start: '2026-01-11T05:00:00.000Z',
+      end: '2026-01-17T05:00:00.000Z',
+    });
+  });
+
+  it('preserves clicked-anchor direction after converting week endpoints', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        displayTimezone: 'America/New_York',
+        weekAnchor: 'clicked',
+        selectingTarget: 'end',
+        onChange,
+      }),
+    );
+
+    act(() => result.current.selectWeek('2026-01-14T00:00:00.000Z'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      start: '2026-01-08T05:00:00.000Z',
+      end: '2026-01-14T05:00:00.000Z',
+    });
+  });
+
+  it('rejects a week when either final endpoint is disabled', () => {
+    const onChange = vi.fn();
+    const initial = { start: '2026-01-04T05:00:00.000Z', end: '2026-01-10T05:00:00.000Z' };
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        defaultValue: initial,
+        displayTimezone: 'America/New_York',
+        disabled: [{ date: '2026-01-11T05:00:00.000Z' }],
+        onChange,
+      }),
+    );
+
+    act(() => result.current.open());
+    act(() => result.current.selectWeek('2026-01-14T00:00:00.000Z'));
+
+    expect(result.current.value).toEqual(initial);
+    expect(result.current.isOpen).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useWeekPicker.ts
+++ b/packages/react/src/hooks/useWeekPicker.ts
@@ -14,6 +14,7 @@ import type {
   WeekStartsOn,
 } from '@kalyx/core';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
+import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
 
 const EMPTY_RANGE: DateRange = { start: null, end: null };
 
@@ -153,8 +154,8 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
     setViewMonth(coordinate);
-    setFocusedDate(coordinate);
-  }, [currentValue.start, adapter, displayTimezone]);
+    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+  }, [currentValue.start, adapter, displayTimezone, disabled]);
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => {
     if (isOpen) close();

--- a/packages/react/src/hooks/useWeekPicker.ts
+++ b/packages/react/src/hooks/useWeekPicker.ts
@@ -1,5 +1,10 @@
 import { useCallback, useId, useRef, useState } from 'react';
-import { civilMidnightFromUtcDay, getCalendarDays } from '@kalyx/core';
+import {
+  calendarDayFromInstant,
+  civilMidnightFromUtcDay,
+  getCalendarDays,
+  isDateDisabled,
+} from '@kalyx/core';
 import type {
   CalendarGrid,
   DateAdapter,
@@ -27,6 +32,10 @@ export interface UseWeekPickerOptions {
   adapter?: DateAdapter;
   /** IANA timezone for display (see WeekPickerRoot#displayTimezone) */
   displayTimezone?: string;
+  /** Whether a clicked week follows calendar boundaries or the clicked day. */
+  weekAnchor?: 'calendar' | 'clicked';
+  /** Which endpoint a clicked anchored week represents. */
+  selectingTarget?: 'start' | 'end';
 }
 
 export interface UseWeekPickerReturn {
@@ -41,6 +50,9 @@ export interface UseWeekPickerReturn {
   /** Month currently displayed */
   viewMonth: ISODateString;
   setViewMonth: (iso: ISODateString) => void;
+  /** Currently focused calendar coordinate */
+  focusedDate: ISODateString;
+  setFocusedDate: (iso: ISODateString) => void;
   /** Calendar grid with the selected week highlighted as a range */
   calendar: CalendarGrid;
   previousMonth: () => void;
@@ -68,6 +80,8 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
     weekStartsOn = 0,
     adapter: adapterProp,
     displayTimezone,
+    weekAnchor = 'calendar',
+    selectingTarget = 'start',
   } = options;
 
   const adapter = resolveAdapter(adapterProp, getDefaultAdapter(), 'useWeekPicker');
@@ -80,27 +94,66 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
   const currentValue = isControlled ? (controlledValue ?? EMPTY_RANGE) : uncontrolledValue;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [viewMonth, setViewMonth] = useState<ISODateString>(
-    () => currentValue.start ?? adapter.today(displayTimezone),
-  );
+  const [viewMonth, setViewMonth] = useState<ISODateString>(() => {
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
+  const [focusedDate, setFocusedDate] = useState<ISODateString>(() => {
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    return displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+  });
 
   const selectWeek = useCallback(
     (iso: ISODateString) => {
-      const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
+      const coordinate = displayTimezone ? iso : adapter.startOfDay(iso);
+      let weekStart: ISODateString;
+      let weekEnd: ISODateString;
+      if (weekAnchor === 'clicked') {
+        weekStart = selectingTarget === 'end' ? adapter.addDays(coordinate, -6) : coordinate;
+        weekEnd = selectingTarget === 'end' ? coordinate : adapter.addDays(coordinate, 6);
+      } else {
+        weekStart = adapter.startOfWeek(coordinate, weekStartsOn);
+        const calendarWeekEnd = adapter.endOfWeek(coordinate, weekStartsOn);
+        weekEnd = displayTimezone ? adapter.startOfDay(calendarWeekEnd) : calendarWeekEnd;
+      }
       const week: DateRange = {
-        start: adapter.startOfWeek(normalized, weekStartsOn),
-        end: adapter.endOfWeek(normalized, weekStartsOn),
+        start: displayTimezone ? civilMidnightFromUtcDay(weekStart, displayTimezone) : weekStart,
+        end: displayTimezone ? civilMidnightFromUtcDay(weekEnd, displayTimezone) : weekEnd,
       };
+      if (
+        (week.start && isDateDisabled(week.start, disabled, adapter, displayTimezone)) ||
+        (week.end && isDateDisabled(week.end, disabled, adapter, displayTimezone))
+      ) {
+        return;
+      }
       if (!isControlled) setUncontrolledValue(week);
       onChange?.(week);
       setIsOpen(false);
     },
-    [isControlled, onChange, displayTimezone, adapter, weekStartsOn],
+    [
+      isControlled,
+      onChange,
+      displayTimezone,
+      adapter,
+      weekStartsOn,
+      weekAnchor,
+      selectingTarget,
+      disabled,
+    ],
   );
 
   const open = useCallback(() => {
     setIsOpen(true);
-    setViewMonth(currentValue.start ?? adapter.today(displayTimezone));
+    const target = currentValue.start ?? adapter.today(displayTimezone);
+    const coordinate = displayTimezone
+      ? calendarDayFromInstant(target, displayTimezone)
+      : adapter.startOfDay(target);
+    setViewMonth(coordinate);
+    setFocusedDate(coordinate);
   }, [currentValue.start, adapter, displayTimezone]);
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => setIsOpen((o) => !o), []);
@@ -110,6 +163,9 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,
+    focusedDate: displayTimezone
+      ? civilMidnightFromUtcDay(focusedDate, displayTimezone)
+      : focusedDate,
     disabled,
     range: currentValue,
     timezone: displayTimezone,
@@ -124,6 +180,8 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
     selectWeek,
     viewMonth,
     setViewMonth,
+    focusedDate,
+    setFocusedDate,
     calendar,
     previousMonth,
     nextMonth,

--- a/packages/react/src/hooks/useWeekPicker.ts
+++ b/packages/react/src/hooks/useWeekPicker.ts
@@ -153,8 +153,9 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
     const coordinate = displayTimezone
       ? calendarDayFromInstant(target, displayTimezone)
       : adapter.startOfDay(target);
-    setViewMonth(coordinate);
-    setFocusedDate(resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone));
+    const focus = resolveEnabledCalendarFocus(coordinate, disabled, adapter, displayTimezone);
+    setViewMonth(focus);
+    setFocusedDate(focus);
   }, [currentValue.start, adapter, displayTimezone, disabled]);
   const close = useCallback(() => setIsOpen(false), []);
   const toggle = useCallback(() => {

--- a/packages/react/src/hooks/useWeekPicker.ts
+++ b/packages/react/src/hooks/useWeekPicker.ts
@@ -156,10 +156,25 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
     setFocusedDate(coordinate);
   }, [currentValue.start, adapter, displayTimezone]);
   const close = useCallback(() => setIsOpen(false), []);
-  const toggle = useCallback(() => setIsOpen((o) => !o), []);
+  const toggle = useCallback(() => {
+    if (isOpen) close();
+    else open();
+  }, [isOpen, open, close]);
 
-  const previousMonth = useCallback(() => setViewMonth((m) => adapter.addMonths(m, -1)), [adapter]);
-  const nextMonth = useCallback(() => setViewMonth((m) => adapter.addMonths(m, 1)), [adapter]);
+  const previousMonth = useCallback(() => {
+    setViewMonth((month) => {
+      const previous = adapter.addMonths(month, -1);
+      setFocusedDate(adapter.startOfMonth(previous));
+      return previous;
+    });
+  }, [adapter]);
+  const nextMonth = useCallback(() => {
+    setViewMonth((month) => {
+      const next = adapter.addMonths(month, 1);
+      setFocusedDate(adapter.startOfMonth(next));
+      return next;
+    });
+  }, [adapter]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/internal/calendarFocus.ts
+++ b/packages/react/src/internal/calendarFocus.ts
@@ -17,10 +17,14 @@ export function resolveEnabledCalendarFocus(
 
   if (!isDisabled(coordinate)) return coordinate;
 
-  let candidate = adapter.startOfMonth(coordinate);
-  for (let day = 0; day < 31; day++) {
-    if (!isDisabled(candidate)) return candidate;
-    candidate = adapter.addDays(candidate, 1);
+  const monthStart = adapter.startOfMonth(coordinate);
+  for (let offset = 0; offset < 366; offset++) {
+    const next = adapter.addDays(monthStart, offset);
+    if (!isDisabled(next)) return next;
+    if (offset > 0) {
+      const previous = adapter.addDays(monthStart, -offset);
+      if (!isDisabled(previous)) return previous;
+    }
   }
   return coordinate;
 }

--- a/packages/react/src/internal/calendarFocus.ts
+++ b/packages/react/src/internal/calendarFocus.ts
@@ -1,0 +1,26 @@
+import { civilMidnightFromUtcDay, isDateDisabled } from '@kalyx/core';
+import type { DateAdapter, DisabledRule, ISODateString } from '@kalyx/core';
+
+export function resolveEnabledCalendarFocus(
+  coordinate: ISODateString,
+  disabled: DisabledRule[],
+  adapter: DateAdapter,
+  timezone?: string,
+): ISODateString {
+  const isDisabled = (day: ISODateString) =>
+    isDateDisabled(
+      timezone ? civilMidnightFromUtcDay(day, timezone) : day,
+      disabled,
+      adapter,
+      timezone,
+    );
+
+  if (!isDisabled(coordinate)) return coordinate;
+
+  let candidate = adapter.startOfMonth(coordinate);
+  for (let day = 0; day < 31; day++) {
+    if (!isDisabled(candidate)) return candidate;
+    candidate = adapter.addDays(candidate, 1);
+  }
+  return coordinate;
+}


### PR DESCRIPTION
## Summary

- normalize picker calendar coordinates against `displayTimezone` while preserving `before`/`after` instant semantics
- enforce disabled/filter constraints at final mutation boundaries across rendered pickers, presets, context setters, and five headless hooks
- align disabled focus state with DOM focus and keyboard navigation, including fully disabled months
- add timezone, constraint-path, focus, and regression coverage plus a patch changeset
- document an outcome-based comparison with Claude PRs #176, #178, #179, and #180

## Validation

- `pnpm build` — PASS (bundle warning: ESM 18.30KB, CJS 18.43KB)
- `pnpm test:run` — PASS (45 files, 852 tests)
- `pnpm test:coverage` — PASS (89.75% statements, 86.17% branches, 94.02% functions, 92.12% lines)
- `pnpm typecheck` — PASS
- `pnpm lint` — PASS
- `pnpm format:check` — PASS
- `pnpm check-bundle` — **FAIL** (17KB gate; no budget/config change)
- `pnpm check-tree-shaking` — PASS (single picker 23.78KB, hook 24.10KB, all 24.80KB gzip)
- `node scripts/verify-entry-split.mjs` — **FAIL** (headless is 1.2% smaller than default; gate requires >=2%)
- `pnpm test:e2e` — PASS (93/93 Chromium, Firefox, WebKit)
- `pnpm --filter docs-site typecheck` — **FAIL** on baseline issue `src/pages/index.tsx(11,33): Cannot find namespace 'JSX'`

## Merge status

Draft only. Do not merge until the 17KB React index budget and headless entry-split decisions are resolved. The final independent correctness review found no remaining Critical or Important finding in the implemented scope; bundle packaging was excluded from that approval.

Detailed evidence: `docs/reviews/2026-08-03-claude-codex-correctness-comparison.md`
