### PR TITLE
docs(core): document isDateDisabled timezone param + instant contract

### DIFF
--- a/apps/docs-site/docs/api/core.md
+++ b/apps/docs-site/docs/api/core.md
@@ -94,7 +94,7 @@ const grid = getCalendarDays(
 
 Returns `CalendarGrid` (6×7 `CalendarDay`s). Leading and trailing days belong to neighboring months (`isCurrentMonth: false`).
 
-### `isDateDisabled(iso, rules, adapter)`
+### `isDateDisabled(iso, rules, adapter, timezone?)`
 
 ```ts
 import { isDateDisabled, DateFnsAdapter } from '@kalyx/core';
@@ -104,7 +104,24 @@ isDateDisabled(
   [{ dayOfWeek: [0, 6] }],
   DateFnsAdapter,
 ); // → true (Saturday)
+
+// With `timezone`, `{ date }` / `{ dayOfWeek }` rules match by the civil day in
+// that zone. Pass the civil-midnight-in-timezone instant the pickers emit — the
+// same value `onChange` gives you — not a raw `…T00:00:00Z` grid coordinate:
+isDateDisabled(
+  '2026-01-15T05:00:00.000Z',            // civil Jan 15 in America/New_York
+  [{ date: '2026-01-15T05:00:00.000Z' }],
+  DateFnsAdapter,
+  'America/New_York',
+); // → true
 ```
+
+`iso` is the point-in-time value being tested, not a hand-built UTC-midnight grid
+coordinate: under a negative UTC offset, `2026-01-15T00:00:00.000Z` is still the
+14th locally. `{ before }` / `{ after }` are instant comparisons and ignore
+`timezone`. When you just need per-cell disabled state for a calendar, read the
+precomputed `isDisabled` flag from `getCalendarDays(...)` instead — it normalizes
+each cell for you.
 
 ### `minDate(dates)` / `maxDate(dates)`
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/core.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/core.md
@@ -94,7 +94,7 @@ const grid = getCalendarDays(
 
 Returns `CalendarGrid` (6×7 `CalendarDay`s). Leading and trailing days belong to neighboring months (`isCurrentMonth: false`).
 
-### `isDateDisabled(iso, rules, adapter)`
+### `isDateDisabled(iso, rules, adapter, timezone?)`
 
 ```ts
 import { isDateDisabled, DateFnsAdapter } from '@kalyx/core';
@@ -104,7 +104,24 @@ isDateDisabled(
   [{ dayOfWeek: [0, 6] }],
   DateFnsAdapter,
 ); // → true (Saturday)
+
+// With `timezone`, `{ date }` / `{ dayOfWeek }` rules match by the civil day in
+// that zone. Pass the civil-midnight-in-timezone instant the pickers emit — the
+// same value `onChange` gives you — not a raw `…T00:00:00Z` grid coordinate:
+isDateDisabled(
+  '2026-01-15T05:00:00.000Z',            // civil Jan 15 in America/New_York
+  [{ date: '2026-01-15T05:00:00.000Z' }],
+  DateFnsAdapter,
+  'America/New_York',
+); // → true
 ```
+
+`iso` is the point-in-time value being tested, not a hand-built UTC-midnight grid
+coordinate: under a negative UTC offset, `2026-01-15T00:00:00.000Z` is still the
+14th locally. `{ before }` / `{ after }` are instant comparisons and ignore
+`timezone`. When you just need per-cell disabled state for a calendar, read the
+precomputed `isDisabled` flag from `getCalendarDays(...)` instead — it normalizes
+each cell for you.
 
 ### `minDate(dates)` / `maxDate(dates)`
 

--- a/packages/core/src/utils/calendar.ts
+++ b/packages/core/src/utils/calendar.ts
@@ -195,6 +195,19 @@ function computeRangeFlags(
 
 /**
  * Checks whether the given date matches any disable rule.
+ *
+ * `iso` is a point-in-time value (the date being tested) — not a hand-built
+ * UTC-midnight grid coordinate. When `timezone` is set, the day-granular rules
+ * (`{ date }` and `{ dayOfWeek }`) are evaluated by the *civil day in that zone*,
+ * so pass the same civil-midnight-in-timezone instants the pickers emit (via
+ * `onChange` / {@link civilMidnightFromUtcDay}) rather than a raw `…T00:00:00Z`
+ * coordinate — under a negative UTC offset the latter resolves to the previous
+ * civil day. `{ before }` / `{ after }` are plain instant comparisons and are
+ * timezone-independent. For rendering a calendar, prefer the precomputed
+ * {@link getCalendarDays} `isDisabled` flag, which already normalizes each cell.
+ *
+ * @param timezone - Optional IANA timezone governing the civil-day evaluation of
+ *   `{ date }` / `{ dayOfWeek }` rules. Omit for UTC-day semantics.
  */
 export function isDateDisabled(
   iso: string,


### PR DESCRIPTION
## What

Document `isDateDisabled`'s `timezone` parameter and its instant contract. **Docs + JSDoc only — no behavior change.**

## Why

The `timezone` 4th param (added in #180/#181 so `getCalendarDays` evaluates `{date}`/`dayOfWeek` rules by civil day) was **undocumented publicly** — `api/core.md` only showed the 3-arg form. The cross-eval synthesis flagged this as a follow-up, phrased as "normalize the grid coordinate inside `isDateDisabled`."

**I verified empirically that internal normalization is the wrong fix** — it breaks positive-offset stored values:

| tz | picker-stored value for "Jan 15" | current (instant contract) | normalize `iso` inside |
|---|---|---|---|
| Asia/Seoul (+9) | `2026-01-14T15:00:00.000Z` | ✅ `true` | ❌ `false` — **breaks** |
| America/New_York (−5) | `2026-01-15T05:00:00.000Z` | ✅ `true` | `true` |

`civilMidnightFromUtcDay` reads the input's **UTC calendar date**, so normalizing the Seoul stored value (`…T15:00Z`, whose UTC date is the 14th) resolves it to the previous civil day. No single internal normalization serves both real instants and hand-built UTC-midnight coordinates — it's the same civil-vs-UTC ambiguity that caused the original P0, now at the public boundary. The current behavior is already correct for the values pickers actually emit; the real gap was documentation.

## Changes

- **JSDoc** on `isDateDisabled` (`packages/core/src/utils/calendar.ts`).
- **`api/core.md`** (en + ko): signature → `isDateDisabled(iso, rules, adapter, timezone?)`, a timezone example, and a note.

Contract, now documented: `iso` is the point-in-time value being tested (not a hand-built `…T00:00:00Z` grid coordinate); with `timezone`, `{date}`/`{dayOfWeek}` match by civil day in that zone — pass the picker's civil-midnight-in-tz value (what `onChange` gives you); `{before}`/`{after}` are instant comparisons and ignore `timezone`; for grid rendering, read `getCalendarDays(...).isDisabled`.

## Verification

typecheck · build · docs-site **en + ko** build — all pass. No changeset (comment/docs only, no API or behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
