### PR TITLE
build: centralize correctness-first bundle policy

### DIFF
--- a/.claude/skills/ci-cd.md
+++ b/.claude/skills/ci-cd.md
@@ -149,7 +149,7 @@ jobs:
         with:
           name: dist-${{ github.run_id }}
           path: packages/react/dist/
-      # 측정·게이팅은 scripts/check-bundle-size.js 단일 소스 (TARGET_KB=17, B-R1).
+      # 측정·게이팅은 scripts/bundle-policy.js의 20KB 정책을 공유 (B-R1).
       # 스크립트가 kb_esm/kb_cjs 를 $GITHUB_OUTPUT 에 기록하고, 20KB 초과 시 exit 1.
       - name: 크기 측정 및 판정
         id: check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,8 @@ kalyx/
 │   ├── docs/                         ← 데모 사이트 (Next.js, 정적 빌드)
 │   └── docs-site/                    ← 문서 사이트 (Docusaurus, i18n)
 ├── scripts/
-│   ├── check-bundle-size.js          ← 번들 크기 측정 (20KB 제한, TARGET_KB 단일 소스 — tsup.config.ts에도 동일 상수 복제)
+│   ├── bundle-policy.js              ← React gzip 제한 단일 소스 (20KB, checker·tsup이 공유)
+│   ├── check-bundle-size.js          ← 공유 정책 기반 번들 크기 측정·게이팅
 │   └── check-tree-shaking.js         ← tree-shaking 검증
 ├── test/
 │   └── setup.ts                      ← Vitest 전역 설정
@@ -757,7 +758,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 □ 접근성 기준을 만족하는가? (axe 통과)
 □ 테스트가 작성됐는가? (커버리지 기준 충족)
 □ JSDoc 주석이 있는가? (공개 API)
-□ 번들에 불필요한 의존성을 추가하지 않았는가? (16KB 목표)
+□ 번들에 불필요한 의존성을 추가하지 않았는가? (20KB gzip ceiling)
 □ 내부 구현이 index.ts에 실수로 export되지 않았는가?
 □ changeset 파일을 추가했는가? (공개 API 변경 시 필수)
 ```

--- a/apps/docs-site/i18n/ko/code.json
+++ b/apps/docs-site/i18n/ko/code.json
@@ -60,7 +60,7 @@
     "description": "FeatureGrid: 번들 카드 제목"
   },
   "home.featureGrid.bundle.body": {
-    "message": "7종 picker + hook + date-fns 어댑터 전부 포함. react-datepicker의 1/4 크기. tree-shakable — 쓰는 것만 비용 부담.",
+    "message": "7종 picker + hook + date-fns 어댑터 전부 포함. CI 한계 20 KB. tree-shakable — 쓰는 것만 비용 부담.",
     "description": "FeatureGrid: 번들 카드 본문"
   },
   "home.sameJsx.eyebrow": {

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/adapters.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/adapters.md
@@ -121,9 +121,12 @@ Day.js 지원은 *예시*이지 공식 지원 어댑터가 아닙니다. 모든 
 
 ## 의존성 관련 참고
 
-현재 `date-fns`와 `date-fns-tz`는 `@kalyx/react`의 **런타임 의존성**입니다. 향후 릴리즈에서 이를 별도의 `@kalyx/adapter-date-fns` 패키지로 분리해, 어댑터 없는 번들은 무게를 완전히 뺄 수 있게 됩니다.
+`@kalyx/core`는 이제 날짜 라이브러리에 독립적이며 자체 `date-fns` 의존성이 없습니다. 기본 어댑터는 `@kalyx/adapter-date-fns`에 있고, 기본 `@kalyx/react` 엔트리가 이를 자동으로 주입하므로 `@kalyx/react`만 설치해도 바로 동작합니다.
+
+이미 `dayjs`, `luxon`, 또는 `Temporal`을 사용한다면 `@kalyx/react/headless`에서 import하여 어댑터를 교체하고 번들에서 `date-fns`를 완전히 제외할 수 있습니다. Kalyx는 `@kalyx/adapter-dayjs`와 `@kalyx/adapter-luxon` 공식 drop-in 어댑터를 제공하므로 직접 작성할 필요가 없습니다. 전체 사용법은 [어댑터 가이드](../guides/adapters.md)를 참고하세요.
 
 ## 다음
 
+- [어댑터 가이드 (커스텀 어댑터, `/headless` 엔트리) →](../guides/adapters.md)
 - [ISO 문자열 →](./iso-string.md)
 - [API 레퍼런스 — core →](../api/core.md)

--- a/apps/docs-site/src/components/FeatureGrid/__tests__/FeatureGrid.test.tsx
+++ b/apps/docs-site/src/components/FeatureGrid/__tests__/FeatureGrid.test.tsx
@@ -27,6 +27,14 @@ describe('<FeatureGrid>', () => {
     ]);
   });
 
+  it('describes the bundle using the enforced ceiling, not a stale competitor ratio', () => {
+    const bundle = FEATURES.find(feature => feature.id === 'bundle');
+
+    expect(bundle?.titleDefault).toBe('≤20 KB gzipped');
+    expect(bundle?.bodyDefault).toContain('CI ceiling: 20 KB');
+    expect(bundle?.bodyDefault).not.toContain('quarter of react-datepicker');
+  });
+
   it('passes axe', async () => {
     const { container } = render(<FeatureGrid />);
     expect(await axe(container)).toHaveNoViolations();

--- a/apps/docs-site/src/components/FeatureGrid/data.ts
+++ b/apps/docs-site/src/components/FeatureGrid/data.ts
@@ -40,6 +40,6 @@ export const FEATURES: readonly Feature[] = [
     titleId: 'home.featureGrid.bundle.title',
     titleDefault: '≤20 KB gzipped',
     bodyId: 'home.featureGrid.bundle.body',
-    bodyDefault: 'All seven pickers + hooks + the date-fns adapter. A quarter of react-datepicker. Tree-shakable — pay only for what you import.',
+    bodyDefault: 'All seven pickers + hooks + the date-fns adapter. CI ceiling: 20 KB. Tree-shakable — pay only for what you import.',
   },
 ] as const;

--- a/apps/docs-site/src/pages/index.tsx
+++ b/apps/docs-site/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import Layout from '@theme/Layout';
 import Hero from '../components/Hero';
 import StatStrip from '../components/StatStrip';

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import { REACT_GZIP_CEILING_KB } from "../../scripts/bundle-policy.js";
 
 const USE_CLIENT_DIRECTIVE = '"use client";\n';
 
@@ -34,7 +35,6 @@ export default defineConfig({
 		// Only the default `index` entry is checked against the public size budget;
 		// the headless entry is intentionally smaller and measured separately by
 		// scripts/verify-entry-split.mjs.
-		const TARGET_KB = 20;
 		const outputs = [
 			["ESM index", "dist/index.js", true],
 			["CJS index", "dist/index.cjs", true],
@@ -49,8 +49,11 @@ export default defineConfig({
 				}
 				const content = readFileSync(file);
 				const kb = (gzipSync(content).length / 1024).toFixed(2);
-				const icon = !enforceBudget || parseFloat(kb) <= TARGET_KB ? "✅" : "⚠️";
-				const suffix = enforceBudget ? ` (목표: ≤${TARGET_KB}KB)` : "";
+				const icon =
+					!enforceBudget || parseFloat(kb) <= REACT_GZIP_CEILING_KB ? "✅" : "⚠️";
+				const suffix = enforceBudget
+					? ` (목표: ≤${REACT_GZIP_CEILING_KB}KB)`
+					: "";
 				console.log(`${icon} [${label}] gzip: ${kb}KB${suffix}`);
 			} catch {}
 		}

--- a/scripts/__tests__/bundle-policy.test.mjs
+++ b/scripts/__tests__/bundle-policy.test.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { REACT_GZIP_CEILING_KB } from '../bundle-policy.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../..');
+
+describe('React bundle policy', () => {
+  it('keeps the approved ceiling at 20KB', () => {
+    expect(REACT_GZIP_CEILING_KB).toBe(20);
+  });
+
+  it('is shared by both the CLI gate and the build report', () => {
+    const checker = readFileSync(resolve(repoRoot, 'scripts/check-bundle-size.js'), 'utf8');
+    const buildConfig = readFileSync(resolve(repoRoot, 'packages/react/tsup.config.ts'), 'utf8');
+
+    expect(checker).toMatch(/from ["']\.\/bundle-policy\.js["']/);
+    expect(buildConfig).toMatch(/from ["']\.\.\/\.\.\/scripts\/bundle-policy\.js["']/);
+    expect(checker).not.toMatch(/TARGET_KB\s*=\s*\d/);
+    expect(buildConfig).not.toMatch(/TARGET_KB\s*=\s*\d/);
+    expect(checker.match(/REACT_GZIP_CEILING_KB/g)).toHaveLength(2);
+    expect(buildConfig.match(/REACT_GZIP_CEILING_KB/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/scripts/bundle-diff.mjs
+++ b/scripts/bundle-diff.mjs
@@ -2,10 +2,9 @@
 // scripts/bundle-diff.mjs
 //
 // Surfaces the *byte-level* bundle delta and remaining ceiling margin so a PR
-// author sees, before merge, exactly how much of the 17KB budget a change
-// consumes. The working headroom is CJS-bound (~901 B CJS / ~1033 B
-// ESM as of v1.2.0, ceiling 17KB), so a feature that costs "only a few hundred
-// bytes" can silently break the CI gate — this script makes that cost visible per PR.
+// author sees, before merge, exactly how much of the configured budget a
+// change consumes. Even a small feature can silently break the CI gate when
+// headroom is tight, so this script makes that cost visible per PR.
 //
 // Measurement reuses getGzipBytes() from check-bundle-size.js, so base-vs-head
 // numbers share the exact same zlib defaults as the CI gate and the tsup

--- a/scripts/bundle-policy.js
+++ b/scripts/bundle-policy.js
@@ -1,0 +1,1 @@
+export const REACT_GZIP_CEILING_KB = 20;

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -8,8 +8,8 @@
 //    primitive on the same payload.
 // 3. CI (`.github/workflows/pr-check.yml` `bundle-size` job) invokes this
 //    script directly instead of running its own `gzip -c | wc -c` pipeline,
-//    so shell-gzip vs. Node-zlib defaults can't drift apart inside the
-//    17KB margin (currently ~901 B on CJS / ~1033 B on ESM — CJS binds).
+//    so shell-gzip vs. Node-zlib defaults can't drift apart near the
+//    configured ceiling.
 //
 // When `$GITHUB_OUTPUT` is set, the script appends per-bundle gzip KB values
 // (kb_esm, kb_cjs) so the workflow can read them back for the PR comment
@@ -17,6 +17,7 @@
 
 import { gzipSync } from "zlib";
 import { readFileSync, statSync, appendFileSync } from "fs";
+import { REACT_GZIP_CEILING_KB } from "./bundle-policy.js";
 
 // Bundle target. 12KB → 13KB after the v1.0-rc audit added user-facing
 // features (IME composition handling, popover focus-out, `name`/hidden-input
@@ -35,7 +36,7 @@ import { readFileSync, statSync, appendFileSync } from "fs";
 // DatePicker/DateTimePicker (audit A-G1), so month-nav and date selection are
 // announced from a region that survives Calendar unmount, matching RangePicker.
 // Still ~3.5× smaller than react-datepicker (~40KB).
-export const TARGET_KB = 20;
+export const TARGET_KB = REACT_GZIP_CEILING_KB;
 export const TARGET_BYTES = TARGET_KB * 1024;
 
 export const BUNDLES = [
@@ -46,7 +47,7 @@ export const BUNDLES = [
 // Single source of truth for the gzip primitive. bundle-diff.mjs imports this
 // so base-vs-head deltas are measured with the exact same zlib defaults as the
 // CI gate and tsup post-build hook — no shell-gzip drift inside the
-// 17KB margin (~901 B CJS / ~1033 B ESM).
+// configured margin.
 export function getGzipBytes(filePath) {
 	return gzipSync(readFileSync(filePath)).length;
 }


### PR DESCRIPTION
## Summary
- keep the approved React gzip ceiling at 20 KB and centralize it in one policy module
- preserve date-fns absence from the headless entry as the semantic hard gate; keep the 2% size delta informational
- align active bundle and adapter documentation, and remove the unsupported competitor ratio
- restore docs-site typechecking with React 19 JSX types

## Verification
- pnpm build
- pnpm test:run (855 passed)
- pnpm test:coverage
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm check-bundle (ESM 18.30 KB, CJS 18.43 KB; ceiling 20 KB)
- pnpm check-tree-shaking
- pnpm test:e2e (93 passed across Chromium, Firefox, WebKit)
- pnpm --filter docs-site typecheck
- node scripts/verify-entry-split.mjs (date-fns absent; 1.2% delta informational)

## Review
Independent review completed with no remaining Critical or Important findings.

This is a follow-up to merged PRs #181 and #182. No merge is requested in this step.