### PR TITLE
fix: harden timezone conversion and calendar focus

### DIFF
--- a/.changeset/fix-calendar-coordinate-roundtrips.md
+++ b/.changeset/fix-calendar-coordinate-roundtrips.md
@@ -4,3 +4,5 @@
 ---
 
 Preserve calendar dates in UTC+12 through UTC+14 display timezones and keep month navigation focus on enabled, rendered days.
+
+Month navigation now follows the direction you travelled, so a fully disabled month no longer traps the calendar: stepping back past it continues into earlier months instead of returning to the month you came from. `useRangePicker`, `useWeekPicker`, and `useDateTimePicker` resolve their focus target the same way as the components and no longer focus a disabled day after navigating.

--- a/.changeset/fix-calendar-coordinate-roundtrips.md
+++ b/.changeset/fix-calendar-coordinate-roundtrips.md
@@ -1,0 +1,6 @@
+---
+"@kalyx/core": patch
+"@kalyx/react": patch
+---
+
+Preserve calendar dates in UTC+12 through UTC+14 display timezones and keep month navigation focus on enabled, rendered days.

--- a/docs/superpowers/plans/2026-08-04-codex-correctness-hotfix.md
+++ b/docs/superpowers/plans/2026-08-04-codex-correctness-hotfix.md
@@ -1,0 +1,428 @@
+# Codex Correctness Hotfix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve UTC calendar coordinates across the complete IANA offset range and prevent partially disabled calendars from stranding focus after month navigation.
+
+**Architecture:** Extract the proven two-pass civil-time resolution inside `setTimeInTimezone` into one private helper that accepts explicit civil fields, then route `civilMidnightFromUtcDay` through it. Reuse the existing `resolveEnabledCalendarFocus` at the three month-navigation boundaries instead of creating another focus algorithm.
+
+**Tech Stack:** TypeScript 5, React 19, Vitest 4, Testing Library, fast-check, tsup, Playwright.
+
+## Global Constraints
+
+- Baseline is immutable commit `a71c43a`.
+- No public API additions or signature changes.
+- Preserve spring-gap snap-forward and fall-ambiguity earlier-instant behavior.
+- Do not mix documentation, release, supply-chain, prop-precedence, or feature work into this PR.
+- Every production change must be preceded by a focused test observed failing for the expected reason.
+- Default `@kalyx/react` ESM and CJS artifacts must stay below the approved 20 KB gzip ceiling.
+
+---
+
+### Task 1: Extreme-positive timezone coordinate preservation
+
+**Files:**
+- Modify: `packages/core/src/__tests__/timezone.test.ts`
+- Modify: `packages/core/src/__tests__/timezone.property.test.ts`
+- Modify: `packages/core/src/utils/timezone.ts`
+
+**Interfaces:**
+- Consumes: existing public `civilMidnightFromUtcDay(gridUtcIso, timeZone)`, `calendarDayFromInstant(iso, timeZone)`, and `setTimeInTimezone(iso, partial, timeZone)`.
+- Produces: private `resolveCivilDateTime(parts, timeZone): ISODateString`; public signatures and exports remain unchanged.
+
+- [ ] **Step 1: Add literal extreme-positive regression fixtures**
+
+Append to the existing `civilMidnightFromUtcDay — calendar-grid cell bridge` describe block:
+
+```ts
+it.each([
+  ['Pacific/Auckland', '2026-01-14T11:00:00.000Z'],
+  ['Pacific/Chatham', '2026-01-14T10:15:00.000Z'],
+  ['Pacific/Kiritimati', '2026-01-14T10:00:00.000Z'],
+] as const)('preserves January 15 in %s', (timeZone, expected) => {
+  const coordinate = '2026-01-15T00:00:00.000Z';
+  const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+
+  expect(instant).toBe(expected);
+  expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+});
+```
+
+These hand-derived literals catch the noon-probe mutation: Auckland/Chatham/Kiritimati must not round-trip as January 16.
+
+- [ ] **Step 2: Add the missing coordinate round-trip property**
+
+Add `Pacific/Auckland` and `Pacific/Chatham` to `ZONES`. Define a UTC-midnight coordinate generator independently from the production helper:
+
+```ts
+const utcCalendarCoordinate = () =>
+  fc
+    .date({
+      min: new Date('2020-01-01T00:00:00.000Z'),
+      max: new Date('2045-01-01T00:00:00.000Z'),
+      noInvalidDate: true,
+    })
+    .map(
+      (date) =>
+        new Date(
+          Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+        ).toISOString(),
+    );
+```
+
+Add this invariant to `timezone invariants (property-based)`:
+
+```ts
+it('round-trips every UTC calendar coordinate through civil midnight', () => {
+  fc.assert(
+    fc.property(utcCalendarCoordinate(), zone(), (coordinate, timeZone) => {
+      const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+      expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+    }),
+    RUNS,
+  );
+});
+```
+
+- [ ] **Step 3: Verify RED for the timezone tests**
+
+Run:
+
+```bash
+pnpm exec vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+```
+
+Expected: FAIL because the current noon probe maps at least Auckland, Chatham, and Kiritimati to January 16. Existing unrelated timezone tests must remain green.
+
+- [ ] **Step 4: Extract an explicit civil-date-time resolver**
+
+In `packages/core/src/utils/timezone.ts`, add a private type and helper immediately before `setTimeInTimezone`:
+
+```ts
+type CivilDateTime = {
+  year: number;
+  month: number;
+  day: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+};
+
+function resolveCivilDateTime(target: CivilDateTime, timeZone: string): ISODateString {
+  const civilEpoch = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hours,
+    target.minutes,
+    target.seconds,
+  );
+  const probe1 = new Date(civilEpoch).toISOString();
+  const offset1 = getTimezoneOffsetMinutes(probe1, timeZone);
+  const realEpoch1 = civilEpoch - offset1 * 60_000;
+  const probe2 = new Date(realEpoch1).toISOString();
+  const offset2 = getTimezoneOffsetMinutes(probe2, timeZone);
+  const realEpoch2 = civilEpoch - offset2 * 60_000;
+
+  const civilMatches = (epoch: number) => {
+    const actual = partsInTimezone(new Date(epoch), timeZone);
+    return (
+      actual.year === target.year &&
+      actual.month === target.month &&
+      actual.day === target.day &&
+      actual.hour === target.hours &&
+      actual.minute === target.minutes &&
+      actual.second === target.seconds
+    );
+  };
+  const match1 = civilMatches(realEpoch1);
+  const match2 = civilMatches(realEpoch2);
+
+  if (match1 && match2) return new Date(Math.min(realEpoch1, realEpoch2)).toISOString();
+  if (match1) return new Date(realEpoch1).toISOString();
+  if (match2) return new Date(realEpoch2).toISOString();
+  return new Date(Math.max(realEpoch1, realEpoch2)).toISOString();
+}
+```
+
+Move the existing explanatory two-pass comment above this helper. Do not change its gap/ambiguity selection rules.
+
+- [ ] **Step 5: Route both public functions through the resolver**
+
+Replace the noon-probe body of `civilMidnightFromUtcDay` with:
+
+```ts
+const coordinate = new Date(gridUtcIso);
+return resolveCivilDateTime(
+  {
+    year: coordinate.getUTCFullYear(),
+    month: coordinate.getUTCMonth() + 1,
+    day: coordinate.getUTCDate(),
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+  },
+  timeZone,
+);
+```
+
+Replace the duplicated two-pass implementation in `setTimeInTimezone` with:
+
+```ts
+return resolveCivilDateTime(
+  {
+    year: p.year,
+    month: p.month,
+    day: p.day,
+    hours: partial.hours ?? p.hour,
+    minutes: partial.minutes ?? p.minute,
+    seconds: partial.seconds ?? p.second,
+  },
+  timeZone,
+);
+```
+
+- [ ] **Step 6: Verify GREEN and unchanged DST behavior**
+
+Run:
+
+```bash
+pnpm exec vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+```
+
+Expected: both files pass, including existing Sydney start-of-day, New York spring gap, and fall ambiguity tests.
+
+- [ ] **Step 7: Commit the timezone fix**
+
+```bash
+git add packages/core/src/utils/timezone.ts packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+git commit -m "fix(core): preserve extreme-positive timezone dates"
+```
+
+---
+
+### Task 2: Enabled focus after calendar month navigation
+
+**Files:**
+- Modify: `packages/react/src/components/DatePicker/DatePicker.test.tsx`
+- Modify: `packages/react/src/components/RangePicker/RangePicker.test.tsx`
+- Modify: `packages/react/src/hooks/useDatePicker.test.tsx`
+- Modify: `packages/react/src/components/DatePicker/Calendar.tsx`
+- Modify: `packages/react/src/components/RangePicker/Calendar.tsx`
+- Modify: `packages/react/src/hooks/useDatePicker.ts`
+
+**Interfaces:**
+- Consumes: existing internal `resolveEnabledCalendarFocus(coordinate, disabled, adapter, timezone?)`.
+- Produces: no new interface; existing navigation methods and buttons now store an enabled focus coordinate.
+
+- [ ] **Step 1: Add a DatePicker DOM regression**
+
+Add a test beside the existing disabled-focus keyboard tests:
+
+```tsx
+it('retargets focus after next-month navigation when the first day is disabled', async () => {
+  const user = userEvent.setup();
+  render(
+    <DatePicker
+      defaultValue="2026-06-15T00:00:00.000Z"
+      disabled={[{ dayOfWeek: [3] }]}
+    >
+      <DatePicker.Input />
+      <DatePicker.Popover>
+        <DatePicker.Calendar />
+      </DatePicker.Popover>
+    </DatePicker>,
+  );
+
+  await user.click(screen.getByRole('combobox'));
+  await user.click(screen.getByRole('button', { name: /next month/i }));
+
+  const focused = document.querySelector<HTMLButtonElement>('[data-focused="true"]');
+  expect(focused).toHaveAccessibleName('Thursday, July 2, 2026');
+  expect(focused).toBeEnabled();
+  expect(focused).toHaveFocus();
+
+  await user.keyboard('{ArrowRight}');
+  expect(document.activeElement).toHaveAccessibleName('Friday, July 3, 2026');
+});
+```
+
+This catches direct assignment of disabled July 1 and proves the keyboard can recover.
+
+- [ ] **Step 2: Add RangePicker and hook regressions**
+
+Add a RangePicker test near calendar navigation callbacks:
+
+```tsx
+it('keeps an enabled focus anchor when the target month starts disabled', async () => {
+  const user = userEvent.setup();
+  renderRangePicker({
+    defaultValue: { start: '2026-06-15T00:00:00.000Z', end: null },
+    disabled: [{ dayOfWeek: [3] }],
+  });
+
+  await user.click(screen.getByLabelText('Start date'));
+  await user.click(screen.getByRole('button', { name: 'Next month' }));
+
+  const focused = document.querySelector<HTMLButtonElement>('[data-focused="true"]');
+  expect(focused).toHaveAccessibleName('Thursday, July 2, 2026');
+  expect(focused).toBeEnabled();
+  expect(focused).toHaveFocus();
+});
+```
+
+Add hook tests to `useDatePicker — navigation`:
+
+```ts
+it.each([
+  ['nextMonth', '2026-06-15T00:00:00.000Z', '2026-07-02T00:00:00.000Z'],
+  ['previousMonth', '2026-08-15T00:00:00.000Z', '2026-07-02T00:00:00.000Z'],
+] as const)('%s skips a disabled first day', (method, initial, expected) => {
+  const { result } = renderHook(() =>
+    useDatePicker({
+      defaultValue: initial,
+      disabled: [{ dayOfWeek: [3] }],
+    }),
+  );
+
+  act(() => result.current[method]());
+
+  expect(result.current.focusedDate).toBe(expected);
+});
+```
+
+- [ ] **Step 3: Verify RED for focus navigation**
+
+Run:
+
+```bash
+pnpm exec vitest run packages/react/src/components/DatePicker/DatePicker.test.tsx packages/react/src/components/RangePicker/RangePicker.test.tsx packages/react/src/hooks/useDatePicker.test.tsx
+```
+
+Expected: new tests fail because focused state remains July 1, which is disabled. Existing tests remain green.
+
+- [ ] **Step 4: Reuse the enabled-focus resolver in component calendars**
+
+Import `resolveEnabledCalendarFocus` into both calendar files. In each `navigateMonth` callback, replace the direct focused-date assignment with:
+
+```ts
+const monthStart = adapter.startOfMonth(newMonth);
+ctx.setFocusedDate(
+  resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone),
+);
+```
+
+Add `disabled` and `displayTimezone` to the callback dependency array. Keep `ctx.setViewMonth(newMonth)` and the month announcement unchanged.
+
+- [ ] **Step 5: Reuse the resolver in the standalone hook**
+
+In both `previousMonth` and `nextMonth`:
+
+```ts
+const monthStart = adapter.startOfMonth(newMonth);
+setViewMonth(newMonth);
+setFocusedDate(
+  resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone),
+);
+```
+
+Add `disabled` and `displayTimezone` to both dependency arrays.
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+pnpm exec vitest run packages/react/src/components/DatePicker/DatePicker.test.tsx packages/react/src/components/RangePicker/RangePicker.test.tsx packages/react/src/hooks/useDatePicker.test.tsx
+```
+
+Expected: all three files pass and new focused elements are enabled.
+
+- [ ] **Step 7: Commit the focus fix**
+
+```bash
+git add packages/react/src/components/DatePicker/Calendar.tsx packages/react/src/components/DatePicker/DatePicker.test.tsx packages/react/src/components/RangePicker/Calendar.tsx packages/react/src/components/RangePicker/RangePicker.test.tsx packages/react/src/hooks/useDatePicker.ts packages/react/src/hooks/useDatePicker.test.tsx
+git commit -m "fix(react): retarget disabled focus after month navigation"
+```
+
+---
+
+### Task 3: Full verification and Claude handoff
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-04-codex-correctness-hotfix.md` only to check completed boxes if desired; no production changes.
+
+**Interfaces:**
+- Consumes: committed Task 1 and Task 2 behavior.
+- Produces: immutable verification evidence and a PR description Claude can reproduce.
+
+- [ ] **Step 1: Run static and focused verification**
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm exec vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts packages/react/src/components/DatePicker/DatePicker.test.tsx packages/react/src/components/RangePicker/RangePicker.test.tsx packages/react/src/hooks/useDatePicker.test.tsx
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Run the complete test and coverage suites**
+
+```bash
+pnpm test:run
+pnpm test:coverage
+```
+
+Expected: all test files and tests pass; record exact counts and coverage percentages from output.
+
+- [ ] **Step 3: Build and verify package boundaries**
+
+```bash
+pnpm build
+pnpm check-bundle
+node scripts/verify-entry-split.mjs
+pnpm --filter docs-site build
+```
+
+Expected: builds exit 0; ESM/CJS default bundles remain ≤20 KB; headless contains no date-fns; EN and KO docs build.
+
+- [ ] **Step 4: Run cross-browser E2E**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: Chromium, Firefox, and WebKit all pass. Record the total count.
+
+- [ ] **Step 5: Inspect the final diff and immutable state**
+
+```bash
+git diff --check
+git status --short
+git log --oneline --decorate -5
+git diff a71c43a...HEAD --stat
+```
+
+Expected: no unstaged production changes, no whitespace errors, and only the design, plan, tests, and two scoped implementations differ from baseline.
+
+- [ ] **Step 6: Push and open the Codex PR**
+
+```bash
+git push -u origin fix/codex-correctness-2026-08
+gh pr create --base main --head fix/codex-correctness-2026-08 --title "fix: close timezone and disabled-focus correctness gaps" --body-file /tmp/kalyx-codex-correctness-pr.md
+```
+
+The PR body must contain:
+
+- baseline and head SHAs;
+- root causes and affected zones/flows;
+- RED and GREEN commands with observed outcomes;
+- full verification counts and bundle values;
+- explicit non-goals;
+- a link to the design document;
+- the eight-item Claude adversarial checklist from the design.
+
+- [ ] **Step 7: Hand the PR to Claude**
+
+Provide Claude the PR URL and instruct it to review from the immutable head SHA, independently rerun the listed commands, perform implementation-revert RED checks, and report any disagreement without modifying the Codex branch.

--- a/docs/superpowers/plans/2026-08-04-codex-correctness-release-prep.md
+++ b/docs/superpowers/plans/2026-08-04-codex-correctness-release-prep.md
@@ -1,0 +1,201 @@
+# Codex Correctness Release Preparation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete PR #187 with guaranteed all-IANA timezone coverage and a core/react patch changeset, without versioning, merging, or publishing.
+
+**Architecture:** Keep the runtime fix unchanged. Extend the existing core property suite so every timezone returned by the supported Node runtime receives its own deterministic fast-check run, then encode release intent in one changeset. Validate the inherited implementation with a deliberate temporary noon-probe mutation because the production fix predates this test-completeness task.
+
+**Tech Stack:** TypeScript, Vitest 4, fast-check 3, Intl, pnpm, Changesets, GitHub Actions Node 20/22 matrix
+
+## Global Constraints
+
+- Exercise every timezone returned by `Intl.supportedValuesOf('timeZone')`; random zone sampling is insufficient.
+- Normalize generated values to UTC-midnight calendar coordinates from 2020-01-01 through 2045-01-01.
+- Use deterministic per-zone seeds and at least 12 runs per zone.
+- Keep the focused timezone property test below 10 seconds locally.
+- Request patch releases for `@kalyx/core` and `@kalyx/react` only.
+- Do not run `changeset version`, publish packages, merge PR #187, or change public APIs.
+
+---
+
+### Task 1: Guarantee all-IANA calendar-coordinate round trips
+
+**Files:**
+- Modify: `packages/core/src/__tests__/timezone.property.test.ts`
+
+**Interfaces:**
+- Consumes: `Intl.supportedValuesOf('timeZone')`, `civilMidnightFromUtcDay`, `calendarDayFromInstant`, and the existing `utcCalendarCoordinate()` arbitrary.
+- Produces: one deterministic property that guarantees every runtime-supported IANA timezone is exercised.
+
+- [ ] **Step 1: Add the all-zone property**
+
+Add constants near the existing property configuration:
+
+```ts
+const IANA_ZONES = Intl.supportedValuesOf('timeZone');
+const IANA_RUNS_PER_ZONE = 12;
+const IANA_SEED = 0x4b414c59;
+```
+
+Add a test that first checks the enumerated list and then property-checks every zone:
+
+```ts
+it('round-trips calendar coordinates in every supported IANA timezone', () => {
+  expect(IANA_ZONES.length).toBeGreaterThan(0);
+  expect(IANA_ZONES).toEqual(
+    expect.arrayContaining(['Pacific/Auckland', 'Pacific/Chatham', 'Pacific/Kiritimati']),
+  );
+
+  IANA_ZONES.forEach((timeZone, index) => {
+    try {
+      fc.assert(
+        fc.property(utcCalendarCoordinate(), (coordinate) => {
+          const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+          expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+        }),
+        { numRuns: IANA_RUNS_PER_ZONE, seed: IANA_SEED + index },
+      );
+    } catch (error) {
+      throw new Error(
+        `Calendar-coordinate round trip failed in ${timeZone}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused suite and record its runtime**
+
+Run:
+
+```bash
+time pnpm exec vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+```
+
+Expected: PASS because the correctness implementation already exists; total wall-clock time remains below 10 seconds.
+
+- [ ] **Step 3: Prove the property catches the original regression**
+
+Temporarily replace `civilMidnightFromUtcDay` with the former noon-probe implementation, without staging it:
+
+```ts
+const utc = new Date(gridUtcIso);
+const probe = new Date(
+  Date.UTC(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate(), 12, 0, 0),
+).toISOString();
+return startOfDayInTimezone(probe, timeZone);
+```
+
+Run the focused property test. Expected: FAIL with an extreme-positive timezone counterexample. Restore the direct `resolveCivilDateTime` implementation using `apply_patch`, then rerun and expect PASS.
+
+- [ ] **Step 4: Run static checks for the test change**
+
+Run:
+
+```bash
+pnpm exec prettier --check packages/core/src/__tests__/timezone.property.test.ts
+pnpm lint
+pnpm typecheck
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+---
+
+### Task 2: Encode the patch release intent
+
+**Files:**
+- Create: `.changeset/fix-calendar-coordinate-roundtrips.md`
+
+**Interfaces:**
+- Consumes: linked core/react release policy from `.changeset/config.json`.
+- Produces: one valid Changesets patch declaration for core and react.
+
+- [ ] **Step 1: Add the changeset**
+
+Create:
+
+```md
+---
+"@kalyx/core": patch
+"@kalyx/react": patch
+---
+
+Preserve calendar dates in UTC+12 through UTC+14 display timezones and keep month navigation focus on enabled, rendered days.
+```
+
+- [ ] **Step 2: Validate changeset parsing and status**
+
+Run:
+
+```bash
+node scripts/verify-changesets.mjs
+pnpm changeset status
+```
+
+Expected: no ignored/publishable mixing error; status lists patch bumps for core and react and no other package.
+
+- [ ] **Step 3: Commit the executable coverage and release intent**
+
+```bash
+git add packages/core/src/__tests__/timezone.property.test.ts .changeset/fix-calendar-coordinate-roundtrips.md
+git commit -m "test(core): verify all IANA calendar round trips"
+```
+
+---
+
+### Task 3: Verify and update PR #187
+
+**Files:**
+- Modify externally: PR #187 body only
+
+**Interfaces:**
+- Consumes: the final immutable branch HEAD and local verification evidence.
+- Produces: an updated remote branch and PR body with Claude verification instructions.
+
+- [ ] **Step 1: Run focused and complete verification**
+
+Run:
+
+```bash
+pnpm exec vitest run packages/core/src/__tests__/timezone.test.ts packages/core/src/__tests__/timezone.property.test.ts
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm test:run
+pnpm test:coverage
+pnpm build
+pnpm check-bundle
+pnpm check-tree-shaking
+pnpm --filter docs-site build
+pnpm docs:build
+pnpm test:e2e
+node scripts/verify-changesets.mjs
+git diff --check a71c43a..HEAD
+git status --short
+```
+
+Expected: every command passes and the worktree is clean after reverting any generated `next-env.d.ts` change with `apply_patch`.
+
+- [ ] **Step 2: Request independent read-only review**
+
+Review the final range `a71c43a..HEAD`, focusing on guaranteed zone enumeration, property determinism, runtime cost, changeset scope, and absence of publish/version side effects. Resolve every Critical or Important finding before pushing.
+
+- [ ] **Step 3: Push and update the PR**
+
+```bash
+git push origin fix/codex-correctness-2026-08
+gh pr edit 187 --body-file /private/tmp/kalyx-codex-correctness-pr.md
+```
+
+Update the body first so it includes the final SHA, all-zone count/runtime, changeset scope, verification results, and Claude checklist.
+
+- [ ] **Step 4: Monitor remote checks**
+
+```bash
+gh pr checks 187 --watch --interval 10
+```
+
+Expected: `All Checks Pass` and every required job succeeds.

--- a/docs/superpowers/specs/2026-08-04-codex-correctness-hotfix-design.md
+++ b/docs/superpowers/specs/2026-08-04-codex-correctness-hotfix-design.md
@@ -1,7 +1,7 @@
 # Codex Correctness Hotfix Design
 
-> **Date:** 2026-08-04  
-> **Baseline:** `a71c43a` (`@kalyx/core@1.4.1`, `@kalyx/react@1.4.1`)  
+> **Date:** 2026-08-04
+> **Baseline:** `a71c43a` (`@kalyx/core@1.4.1`, `@kalyx/react@1.4.1`)
 > **Branch:** `fix/codex-correctness-2026-08`
 
 ## Goal

--- a/docs/superpowers/specs/2026-08-04-codex-correctness-hotfix-design.md
+++ b/docs/superpowers/specs/2026-08-04-codex-correctness-hotfix-design.md
@@ -1,0 +1,166 @@
+# Codex Correctness Hotfix Design
+
+> **Date:** 2026-08-04  
+> **Baseline:** `a71c43a` (`@kalyx/core@1.4.1`, `@kalyx/react@1.4.1`)  
+> **Branch:** `fix/codex-correctness-2026-08`
+
+## Goal
+
+Fix the two remaining correctness blockers found by the post-1.4.1 dual-model audit:
+
+1. UTC+12 through UTC+14 display timezones can map a UTC calendar coordinate to the next civil day.
+2. Calendar month-button navigation can anchor focus on a disabled first day and strand keyboard navigation.
+
+The pull request must contain executable regressions that fail on `a71c43a`, pass after the fixes, and give Claude a compact adversarial verification surface.
+
+## Scope
+
+### Included
+
+- Correct `civilMidnightFromUtcDay` for the full IANA offset range, including fractional positive offsets.
+- Preserve the existing DST disambiguation contract used by `setTimeInTimezone`:
+  - spring-forward gaps snap forward;
+  - fall-back ambiguity chooses the earlier instant.
+- Retarget month-button focus through the existing enabled-focus resolver in:
+  - `DatePicker.Calendar`;
+  - `RangePicker.Calendar`, which is also used by WeekPicker;
+  - standalone `useDatePicker` previous/next month methods.
+- Add focused unit, property, component, and hook regressions.
+- Run the repository's full correctness and packaging verification suite.
+
+### Excluded
+
+- Documentation/API-reference corrections.
+- Release workflow, action pinning, alternate-adapter packaging, and supply-chain hardening.
+- `disabled`/`readOnly` child-prop precedence changes.
+- New picker features or public APIs.
+- Broad refactors unrelated to the two root causes.
+
+Those excluded areas will be handled in separate PRs after Claude verifies this correctness PR.
+
+## Root Cause 1: UTC+12 and Greater Civil-Day Drift
+
+Calendar cells use UTC-midnight coordinates such as `2026-01-15T00:00:00.000Z`. `civilMidnightFromUtcDay` must interpret the coordinate's UTC year/month/day as an explicit civil date in the requested display timezone.
+
+The current implementation changes the coordinate to noon UTC and asks `startOfDayInTimezone` for the probe's observed civil day. This is not valid over the global offset range. At UTC+12 or greater, noon UTC is already the next civil day. For example, the January 15 coordinate round-trips as January 16 in Auckland, Chatham, and Kiritimati.
+
+No single UTC probe hour can cover the complete −12 through +14 range, so changing noon to another constant only moves the failure boundary.
+
+## Timezone Design
+
+Extract the existing two-pass offset resolution from `setTimeInTimezone` into a private helper that accepts explicit civil date-time parts:
+
+```ts
+resolveCivilDateTime(
+  { year, month, day, hours, minutes, seconds },
+  timeZone,
+): ISODateString
+```
+
+The helper will:
+
+1. Treat the requested civil fields as a provisional UTC epoch.
+2. Probe the timezone offset at that epoch.
+3. Re-probe at the first resolved candidate to cross DST boundaries correctly.
+4. Compare both candidates by civil round-trip.
+5. Select the matching candidate, the earlier candidate for ambiguity, or the later candidate for a gap.
+
+`setTimeInTimezone` will continue deriving its target date and unspecified time fields from the input instant, then delegate to this helper. This preserves its public behavior while avoiding duplicated DST logic.
+
+`civilMidnightFromUtcDay` will read the grid coordinate with UTC getters and call the helper with those exact year/month/day fields and zero time. It will no longer infer the target date through a timezone-observed probe.
+
+## Timezone Tests
+
+Tests are written and observed RED before production changes:
+
+- Concrete UTC+12/+13/+13:45/+14 cases, including Auckland, Chatham, and Kiritimati.
+- Round-trip invariant:
+
+```ts
+calendarDayFromInstant(civilMidnightFromUtcDay(coordinate, zone), zone)
+  === coordinate
+```
+
+- Property coverage across representative negative, zero, fractional, DST, and extreme-positive zones and generated calendar coordinates.
+- Existing New York, Seoul, leap-day, Sydney DST, spring-gap, and fall-ambiguity tests remain green.
+
+The production change that makes these tests pass is the explicit-civil-field resolver. A test that passes while the noon probe is present is invalid and must be corrected before implementation.
+
+## Root Cause 2: Disabled Focus After Month Navigation
+
+Opening a picker already routes its initial coordinate through `resolveEnabledCalendarFocus`. Month-button navigation does not. It writes `startOfMonth(newMonth)` directly into focused state.
+
+If day 1 is disabled, the only cell with `data-focused=true` and `tabIndex=0` is a disabled button. The focus effect targets that button, and ArrowRight continues from the stale disabled coordinate without recovery.
+
+## Focus Design
+
+For each month-button or standalone-hook transition:
+
+1. Compute `newMonth` with the adapter.
+2. Compute `monthStart` with `adapter.startOfMonth(newMonth)`.
+3. Pass `monthStart`, disabled rules, adapter, and optional display timezone to `resolveEnabledCalendarFocus`.
+4. Store the resolved coordinate as focused state.
+5. Keep `newMonth` as the visible month and preserve the existing announcement.
+
+This reuses the same rule evaluation as the open path and avoids a second focus-selection algorithm. It does not change the public API.
+
+## Focus Tests
+
+Tests are written and observed RED before production changes:
+
+- DatePicker: next-month button where day 1 is disabled focuses an enabled day; ArrowRight continues moving.
+- RangePicker: the same transition does not leave a disabled focused cell.
+- `useDatePicker`: `nextMonth` and `previousMonth` return an enabled focused coordinate when the target month starts disabled.
+- At least one test uses `displayTimezone` so rule normalization is exercised.
+
+The tests assert observable state or DOM behavior rather than the helper's implementation.
+
+## Error and Edge Handling
+
+- Invalid IANA timezone handling remains delegated to `Intl.DateTimeFormat`, matching current behavior.
+- If no enabled day can be found within the resolver's bounded search, focus remains on the supplied coordinate, matching the existing fallback contract.
+- Fully disabled calendars therefore remain non-navigable by definition, but partially disabled calendars must not strand focus on month transition.
+- Timezone conversion continues returning ISO UTC strings and does not mutate inputs.
+
+## Verification
+
+Required before the PR is opened:
+
+```text
+targeted RED evidence for timezone tests
+targeted RED evidence for DatePicker/RangePicker/hook tests
+targeted GREEN tests
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm test:run
+pnpm test:coverage
+pnpm build
+pnpm check-bundle
+node scripts/verify-entry-split.mjs
+pnpm --filter docs-site build
+pnpm test:e2e
+```
+
+The final verification must record the immutable commit SHA, exact pass counts, bundle values, and any non-blocking warnings.
+
+## Claude Adversarial Verification Checklist
+
+Claude should independently verify:
+
+1. Revert only the timezone implementation while retaining tests; extreme-positive tests must fail.
+2. Revert only each focus call-site change while retaining tests; the corresponding component/hook test must fail.
+3. Test both positive and negative offset extremes rather than Seoul-only fixtures.
+4. Check fractional zones (`Pacific/Chatham`) and DST (`Pacific/Auckland`) as separate classes.
+5. Confirm `setTimeInTimezone` gap and ambiguity behavior is unchanged after helper extraction.
+6. Reproduce month-button navigation with multiple leading disabled days, not only day 1.
+7. Confirm DateTimePicker and WeekPicker inherit the corrected shared calendar paths.
+8. Re-measure default and headless bundles from a clean install.
+
+## Success Criteria
+
+- UTC calendar coordinates preserve their civil date across the tested IANA offset classes.
+- Partially disabled target months always receive an enabled focus anchor after month-button or standalone-hook navigation.
+- Every new regression is proven RED before implementation and GREEN after implementation.
+- No public API is added or changed.
+- Full verification passes and the default bundle remains below the approved 20 KB gzip ceiling.

--- a/docs/superpowers/specs/2026-08-04-codex-correctness-release-prep-design.md
+++ b/docs/superpowers/specs/2026-08-04-codex-correctness-release-prep-design.md
@@ -1,0 +1,89 @@
+# Codex Correctness Release Preparation Design
+
+> **Date:** 2026-08-04
+> **PR:** #187 (`fix/codex-correctness-2026-08`)
+> **Reviewed implementation head:** `360259961a991b39034d74f18ba9c1932ba10210`
+
+## Goal
+
+Complete the release-preparation portion of the UTC+12 through UTC+14 correctness fix without merging the pull request or publishing packages. The pull request must prove the calendar-coordinate round trip across every IANA timezone exposed by the supported Node runtimes and must carry the patch release intent for both linked public packages.
+
+## Scope
+
+### Included
+
+- Enumerate all IANA timezone identifiers exposed by `Intl.supportedValuesOf('timeZone')`.
+- Exercise every enumerated timezone, rather than sampling zones from one global arbitrary.
+- Property-check UTC calendar coordinates from 2020-01-01 through 2045-01-01 for each timezone.
+- Use a fixed fast-check seed and a bounded number of runs per timezone so a CI failure is reproducible and the Node 20/22 matrix stays practical.
+- Keep the existing exact Auckland, Chatham, and Kiritimati regression expectations.
+- Add one changeset that declares patch releases for both `@kalyx/core` and `@kalyx/react`.
+- Re-run the complete local quality gates and update PR #187 at an immutable head SHA.
+
+### Excluded
+
+- Merging PR #187.
+- Running `changeset version`, changing package versions, creating tags, or publishing to npm.
+- Documentation corrections, publish-tarball smoke tests, adapter provenance changes, and validation-tool changes. Those remain separate follow-up pull requests.
+
+## IANA Property-Test Design
+
+The test obtains the zone list at runtime:
+
+```ts
+const IANA_ZONES = Intl.supportedValuesOf('timeZone');
+```
+
+The suite first asserts that the list is non-empty and includes the three named regression zones. It then iterates over every zone. Each zone receives its own deterministic fast-check property over normalized UTC-midnight calendar coordinates in the supported date window:
+
+```ts
+calendarDayFromInstant(civilMidnightFromUtcDay(coordinate, zone), zone) === coordinate
+```
+
+The seed is fixed and included in failure output. Runs are bounded per zone; the implementation will start with 12 runs per zone and may increase only if the measured focused-test runtime remains below 10 seconds on the development machine. This guarantees zone coverage while avoiding the ambiguity of `fc.constantFrom(...zones)`, which can miss individual identifiers.
+
+The property validates the public invariant. It does not duplicate the private offset algorithm or assert implementation details.
+
+## Release Intent
+
+The changeset contains both linked packages explicitly:
+
+```yaml
+"@kalyx/core": patch
+"@kalyx/react": patch
+```
+
+`@kalyx/core` owns the corrected timezone function. `@kalyx/react` is included because it consumes and exposes that behavior and the repository links core/react releases. This also prevents users of the exact published React dependency graph from missing the corrected core version.
+
+The changeset summary will mention both the extreme-positive timezone correction and disabled month-navigation focus correction already present in PR #187.
+
+## Verification
+
+The updated pull request must pass:
+
+- focused timezone unit and property tests;
+- `pnpm typecheck`;
+- `pnpm lint`;
+- `pnpm format:check`;
+- `pnpm test:run` and `pnpm test:coverage`;
+- `pnpm build`, `pnpm check-bundle`, and `pnpm check-tree-shaking`;
+- both documentation builds used by the repository;
+- `pnpm test:e2e` across Chromium, Firefox, and WebKit;
+- `node scripts/verify-changesets.mjs`;
+- `git diff --check` and a clean worktree.
+
+PR #187 will retain a Claude verification checklist calling out the all-zone property, the fixed seed, the changeset package list, and the prohibition on publishing.
+
+## Failure Handling
+
+- If a runtime lacks `Intl.supportedValuesOf`, the test fails with an explicit supported-runtime error; the project requires Node 20 or newer, so silently falling back to a partial hard-coded list would weaken the guarantee.
+- If a runtime exposes a zone that fails the invariant, fast-check reports the zone through the enclosing assertion context and reports the reproducible seed/counterexample.
+- If the all-zone test exceeds the runtime budget, reduce runs per zone while preserving at least one generated coordinate for every zone. Never replace guaranteed enumeration with random zone sampling.
+
+## Success Criteria
+
+1. Every timezone returned by Node's `Intl.supportedValuesOf('timeZone')` is exercised in CI on Node 20 and Node 22.
+2. Every exercised coordinate round-trips to the identical UTC calendar coordinate.
+3. Auckland, Chatham, and Kiritimati retain exact instant expectations.
+4. The changeset requests patch releases for core and react only.
+5. No version, tag, GitHub release, npm package, or public API is changed during this task.

--- a/packages/core/src/__tests__/timezone.property.test.ts
+++ b/packages/core/src/__tests__/timezone.property.test.ts
@@ -71,6 +71,9 @@ const timeOfDay = () =>
   });
 
 const RUNS = { numRuns: 300 };
+const IANA_ZONES = Intl.supportedValuesOf('timeZone');
+const IANA_RUNS_PER_ZONE = 12;
+const IANA_SEED = 0x4b414c59;
 
 describe('timezone invariants (property-based)', () => {
   it('round-trips every UTC calendar coordinate through civil midnight', () => {
@@ -81,6 +84,34 @@ describe('timezone invariants (property-based)', () => {
       }),
       RUNS,
     );
+  });
+
+  it('round-trips calendar coordinates in every supported IANA timezone', () => {
+    expect(IANA_ZONES.length).toBeGreaterThan(0);
+    expect(IANA_ZONES).toEqual(
+      expect.arrayContaining(['Pacific/Auckland', 'Pacific/Chatham', 'Pacific/Kiritimati']),
+    );
+
+    IANA_ZONES.forEach((timeZone, index) => {
+      try {
+        fc.assert(
+          fc.property(utcCalendarCoordinate(), (coordinate) => {
+            const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+            expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+          }),
+          {
+            numRuns: IANA_RUNS_PER_ZONE,
+            seed: IANA_SEED + index,
+          },
+        );
+      } catch (error) {
+        throw new Error(
+          `Calendar-coordinate round trip failed in ${timeZone}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    });
   });
 
   it('startOfDayInTimezone is idempotent', () => {

--- a/packages/core/src/__tests__/timezone.property.test.ts
+++ b/packages/core/src/__tests__/timezone.property.test.ts
@@ -33,6 +33,8 @@ const ZONES = [
   'Asia/Kolkata', // +5:30
   'Asia/Kathmandu', // +5:45
   'Australia/Eucla', // +8:45
+  'Pacific/Auckland', // +12/+13 DST
+  'Pacific/Chatham', // +12:45/+13:45 DST
   'Pacific/Niue', // -11
   'Pacific/Kiritimati', // +14
 ] as const;
@@ -48,6 +50,19 @@ const isoInstant = () =>
     })
     .map((d) => d.toISOString());
 
+const utcCalendarCoordinate = () =>
+  fc
+    .date({
+      min: new Date('2020-01-01T00:00:00.000Z'),
+      max: new Date('2045-01-01T00:00:00.000Z'),
+      noInvalidDate: true,
+    })
+    .map((date) =>
+      new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+      ).toISOString(),
+    );
+
 const timeOfDay = () =>
   fc.record({
     hours: fc.integer({ min: 0, max: 23 }),
@@ -58,6 +73,16 @@ const timeOfDay = () =>
 const RUNS = { numRuns: 300 };
 
 describe('timezone invariants (property-based)', () => {
+  it('round-trips every UTC calendar coordinate through civil midnight', () => {
+    fc.assert(
+      fc.property(utcCalendarCoordinate(), zone(), (coordinate, timeZone) => {
+        const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+        expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+      }),
+      RUNS,
+    );
+  });
+
   it('startOfDayInTimezone is idempotent', () => {
     fc.assert(
       fc.property(isoInstant(), zone(), (iso, tz) => {

--- a/packages/core/src/__tests__/timezone.property.test.ts
+++ b/packages/core/src/__tests__/timezone.property.test.ts
@@ -71,9 +71,16 @@ const timeOfDay = () =>
   });
 
 const RUNS = { numRuns: 300 };
-const IANA_ZONES = Intl.supportedValuesOf('timeZone');
+const supportedIanaZones = () => {
+  if (typeof Intl.supportedValuesOf !== 'function') {
+    throw new Error('All-IANA timezone tests require Intl.supportedValuesOf (Node 20+).');
+  }
+  return Intl.supportedValuesOf('timeZone');
+};
+const IANA_ZONES = supportedIanaZones();
 const IANA_RUNS_PER_ZONE = 12;
 const IANA_SEED = 0x4b414c59;
+const IANA_BOUNDARY_COORDINATES = ['2020-01-01T00:00:00.000Z', '2045-01-01T00:00:00.000Z'] as const;
 
 describe('timezone invariants (property-based)', () => {
   it('round-trips every UTC calendar coordinate through civil midnight', () => {
@@ -94,6 +101,11 @@ describe('timezone invariants (property-based)', () => {
 
     IANA_ZONES.forEach((timeZone, index) => {
       try {
+        IANA_BOUNDARY_COORDINATES.forEach((coordinate) => {
+          const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+          expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+        });
+
         fc.assert(
           fc.property(utcCalendarCoordinate(), (coordinate) => {
             const instant = civilMidnightFromUtcDay(coordinate, timeZone);
@@ -102,6 +114,7 @@ describe('timezone invariants (property-based)', () => {
           {
             numRuns: IANA_RUNS_PER_ZONE,
             seed: IANA_SEED + index,
+            unbiased: true,
           },
         );
       } catch (error) {

--- a/packages/core/src/__tests__/timezone.test.ts
+++ b/packages/core/src/__tests__/timezone.test.ts
@@ -216,6 +216,18 @@ describe('civilMidnightFromUtcDay — calendar-grid cell bridge', () => {
       '2026-06-15T00:00:00.000Z',
     );
   });
+
+  it.each([
+    ['Pacific/Auckland', '2026-01-14T11:00:00.000Z'],
+    ['Pacific/Chatham', '2026-01-14T10:15:00.000Z'],
+    ['Pacific/Kiritimati', '2026-01-14T10:00:00.000Z'],
+  ] as const)('preserves January 15 in %s', (timeZone, expected) => {
+    const coordinate = '2026-01-15T00:00:00.000Z';
+    const instant = civilMidnightFromUtcDay(coordinate, timeZone);
+
+    expect(instant).toBe(expected);
+    expect(calendarDayFromInstant(instant, timeZone)).toBe(coordinate);
+  });
 });
 
 describe('calendarDayFromInstant — civil-date calendar coordinate', () => {

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -158,11 +158,18 @@ export function civilMidnightFromUtcDay(
   gridUtcIso: ISODateString,
   timeZone: string,
 ): ISODateString {
-  const utc = new Date(gridUtcIso);
-  const probe = new Date(
-    Date.UTC(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate(), 12, 0, 0),
-  ).toISOString();
-  return startOfDayInTimezone(probe, timeZone);
+  const coordinate = new Date(gridUtcIso);
+  return resolveCivilDateTime(
+    {
+      year: coordinate.getUTCFullYear(),
+      month: coordinate.getUTCMonth() + 1,
+      day: coordinate.getUTCDate(),
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    },
+    timeZone,
+  );
 }
 
 /**
@@ -197,6 +204,56 @@ export function getTimeInTimezone(
   return { hours: p.hour, minutes: p.minute, seconds: p.second };
 }
 
+type CivilDateTime = {
+  year: number;
+  month: number;
+  day: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+};
+
+function resolveCivilDateTime(target: CivilDateTime, timeZone: string): ISODateString {
+  const civilEpoch = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hours,
+    target.minutes,
+    target.seconds,
+  );
+
+  // Two-pass offset resolution: probe at civil-as-UTC, then re-probe at the
+  // first-pass result so the second probe sees the offset that actually applies
+  // at the resolved instant. The two candidate UTC instants are then classified
+  // by whether their civil round-trip in the target zone matches the request.
+  const probe1 = new Date(civilEpoch).toISOString();
+  const offset1 = getTimezoneOffsetMinutes(probe1, timeZone);
+  const realEpoch1 = civilEpoch - offset1 * 60_000;
+  const probe2 = new Date(realEpoch1).toISOString();
+  const offset2 = getTimezoneOffsetMinutes(probe2, timeZone);
+  const realEpoch2 = civilEpoch - offset2 * 60_000;
+
+  const civilMatches = (epoch: number) => {
+    const actual = partsInTimezone(new Date(epoch), timeZone);
+    return (
+      actual.year === target.year &&
+      actual.month === target.month &&
+      actual.day === target.day &&
+      actual.hour === target.hours &&
+      actual.minute === target.minutes &&
+      actual.second === target.seconds
+    );
+  };
+  const match1 = civilMatches(realEpoch1);
+  const match2 = civilMatches(realEpoch2);
+
+  if (match1 && match2) return new Date(Math.min(realEpoch1, realEpoch2)).toISOString();
+  if (match1) return new Date(realEpoch1).toISOString();
+  if (match2) return new Date(realEpoch2).toISOString();
+  return new Date(Math.max(realEpoch1, realEpoch2)).toISOString();
+}
+
 /**
  * Returns a new ISO UTC string where the civil date in `timeZone` is preserved and the time
  * portion is replaced according to `partial` (as observed in that same timezone). Undefined
@@ -228,58 +285,15 @@ export function setTimeInTimezone(
   timeZone: string,
 ): ISODateString {
   const p = partsInTimezone(new Date(iso), timeZone);
-  const targetHours = partial.hours ?? p.hour;
-  const targetMinutes = partial.minutes ?? p.minute;
-  const targetSeconds = partial.seconds ?? p.second;
-  const civilEpoch = Date.UTC(
-    p.year,
-    p.month - 1,
-    p.day,
-    targetHours,
-    targetMinutes,
-    targetSeconds,
+  return resolveCivilDateTime(
+    {
+      year: p.year,
+      month: p.month,
+      day: p.day,
+      hours: partial.hours ?? p.hour,
+      minutes: partial.minutes ?? p.minute,
+      seconds: partial.seconds ?? p.second,
+    },
+    timeZone,
   );
-
-  // Two-pass offset resolution: probe at civil-as-UTC, then re-probe at the
-  // first-pass result so the second probe sees the offset that actually applies
-  // at the resolved instant. The two candidate UTC instants are then classified
-  // by whether their civil round-trip in the target zone matches the requested
-  // civil time:
-  //
-  //   match1 && match2  → fall-back ambiguity, both are valid wall-clock
-  //                       interpretations → pick the earlier instant (matches
-  //                       @internationalized/date and TC39 Temporal default).
-  //   match1 ^ match2   → the matching candidate is the correct one. (This is
-  //                       the common case near a DST boundary where one of the
-  //                       two probes picked the wrong-side offset.)
-  //   neither match     → spring-forward gap: the requested civil time does not
-  //                       exist → snap forward to the later instant.
-  const probe1 = new Date(civilEpoch).toISOString();
-  const offset1 = getTimezoneOffsetMinutes(probe1, timeZone);
-  const realEpoch1 = civilEpoch - offset1 * 60_000;
-  const probe2 = new Date(realEpoch1).toISOString();
-  const offset2 = getTimezoneOffsetMinutes(probe2, timeZone);
-  const realEpoch2 = civilEpoch - offset2 * 60_000;
-
-  const civilMatches = (epoch: number) => {
-    const rt = partsInTimezone(new Date(epoch), timeZone);
-    return (
-      rt.year === p.year &&
-      rt.month === p.month &&
-      rt.day === p.day &&
-      rt.hour === targetHours &&
-      rt.minute === targetMinutes &&
-      rt.second === targetSeconds
-    );
-  };
-  const match1 = civilMatches(realEpoch1);
-  const match2 = civilMatches(realEpoch2);
-
-  let chosen: number;
-  if (match1 && match2) chosen = Math.min(realEpoch1, realEpoch2);
-  else if (match1) chosen = realEpoch1;
-  else if (match2) chosen = realEpoch2;
-  else chosen = Math.max(realEpoch1, realEpoch2);
-
-  return new Date(chosen).toISOString();
 }

--- a/packages/core/src/utils/timezone.ts
+++ b/packages/core/src/utils/timezone.ts
@@ -148,7 +148,8 @@ export function todayInTimezone(timeZone: string): ISODateString {
  * This is the bridge used by DatePicker/RangePicker when `displayTimezone` is set: the grid
  * iterates in UTC, so a cell's `isoString` is `YYYY-MM-DDT00:00:00.000Z`. When the user clicks
  * that cell we want to emit an ISO representing the same civil day's midnight in the display
- * timezone. A probe at noon UTC is used so the target civil day is unambiguous across any zone.
+ * timezone. The coordinate's UTC date fields are resolved directly as midnight in the target
+ * timezone, preserving the date even in UTC+12 through UTC+14 zones.
  *
  * @example
  * civilMidnightFromUtcDay('2026-01-15T00:00:00.000Z', 'Asia/Seoul');

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@kalyx/core';
 import type { CalendarDay } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
+import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
 import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
 
 export interface DatePickerCalendarClassNames {
@@ -123,13 +124,16 @@ export function DatePickerCalendar({
   const navigateMonth = useCallback(
     (direction: number) => {
       const newMonth = adapter.addMonths(viewMonth, direction);
+      const monthStart = adapter.startOfMonth(newMonth);
       ctx.setViewMonth(newMonth);
-      ctx.setFocusedDate(adapter.startOfMonth(newMonth));
+      ctx.setFocusedDate(
+        resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone),
+      );
       const y = adapter.getYear(newMonth);
       const m = adapter.getMonth(newMonth);
       ctx.announce(formatMonthYear(y, m, locale));
     },
-    [adapter, viewMonth, ctx, locale],
+    [adapter, viewMonth, ctx, locale, disabled, displayTimezone],
   );
 
   const handleDayClick = useCallback(

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -125,12 +125,17 @@ export function DatePickerCalendar({
     (direction: number) => {
       const newMonth = adapter.addMonths(viewMonth, direction);
       const monthStart = adapter.startOfMonth(newMonth);
-      ctx.setViewMonth(newMonth);
-      ctx.setFocusedDate(
-        resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone),
+      const focus = resolveEnabledCalendarFocus(
+        monthStart,
+        disabled,
+        adapter,
+        displayTimezone,
+        'forward',
       );
-      const y = adapter.getYear(newMonth);
-      const m = adapter.getMonth(newMonth);
+      ctx.setViewMonth(adapter.startOfMonth(focus));
+      ctx.setFocusedDate(focus);
+      const y = adapter.getYear(focus);
+      const m = adapter.getMonth(focus);
       ctx.announce(formatMonthYear(y, m, locale));
     },
     [adapter, viewMonth, ctx, locale, disabled, displayTimezone],

--- a/packages/react/src/components/DatePicker/Calendar.tsx
+++ b/packages/react/src/components/DatePicker/Calendar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@kalyx/core';
 import type { CalendarDay } from '@kalyx/core';
 import { useDatePickerContext } from '../../context/DatePickerContext.js';
-import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
+import { resolveMonthNavigation } from '../../internal/calendarFocus.js';
 import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
 
 export interface DatePickerCalendarClassNames {
@@ -123,19 +123,11 @@ export function DatePickerCalendar({
 
   const navigateMonth = useCallback(
     (direction: number) => {
-      const newMonth = adapter.addMonths(viewMonth, direction);
-      const monthStart = adapter.startOfMonth(newMonth);
-      const focus = resolveEnabledCalendarFocus(
-        monthStart,
-        disabled,
-        adapter,
-        displayTimezone,
-        'forward',
-      );
-      ctx.setViewMonth(adapter.startOfMonth(focus));
-      ctx.setFocusedDate(focus);
-      const y = adapter.getYear(focus);
-      const m = adapter.getMonth(focus);
+      const next = resolveMonthNavigation(viewMonth, direction, disabled, adapter, displayTimezone);
+      ctx.setViewMonth(next.viewMonth);
+      ctx.setFocusedDate(next.focusedDate);
+      const y = adapter.getYear(next.focusedDate);
+      const m = adapter.getMonth(next.focusedDate);
       ctx.announce(formatMonthYear(y, m, locale));
     },
     [adapter, viewMonth, ctx, locale, disabled, displayTimezone],

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -1865,4 +1865,25 @@ describe('DatePicker — RTL (dir="rtl")', () => {
     await user.keyboard('{ArrowLeft}');
     expect(screen.getByRole('gridcell', { name: '2027' })).toHaveFocus();
   });
+
+  it('navigates past a fully disabled month instead of freezing on the current one', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        defaultValue="2026-03-10T00:00:00.000Z"
+        disabled={[{ filter: (iso) => iso.startsWith('2026-02-') }]}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Previous month' }));
+
+    // A 'forward' search lands back on March 1 and the button stops responding.
+    expect(screen.getByRole('button', { name: /January 31, 2026/ })).toHaveFocus();
+  });
 });

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -382,12 +382,13 @@ describe('DatePicker — keyboard navigation', () => {
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-16T/));
   });
 
-  it('focuses an enabled day after navigating to a month whose first day is disabled', async () => {
+  it('focuses a rendered enabled day after timezone-aware month navigation', async () => {
     const user = userEvent.setup();
     render(
       <DatePicker
-        value="2026-06-15T00:00:00.000Z"
-        disabled={[{ dayOfWeek: [3] }]}
+        value="2026-01-14T10:00:00.000Z"
+        displayTimezone="Pacific/Kiritimati"
+        disabled={[{ dayOfWeek: [0, 1] }]}
         onChange={vi.fn()}
       >
         <DatePicker.Input aria-label="날짜 선택" />
@@ -400,9 +401,9 @@ describe('DatePicker — keyboard navigation', () => {
     await user.click(screen.getByRole('combobox'));
     await user.click(screen.getByRole('button', { name: 'Next month' }));
 
-    expect(screen.getByRole('button', { name: /July 2, 2026/ })).toHaveFocus();
+    expect(screen.getByRole('button', { name: /February 3, 2026/ })).toHaveFocus();
     await user.keyboard('{ArrowRight}');
-    expect(screen.getByRole('button', { name: /July 3, 2026/ })).toHaveFocus();
+    expect(screen.getByRole('button', { name: /February 4, 2026/ })).toHaveFocus();
   });
 
   it('uses the civil instant for timezone-aware Enter disabled checks', async () => {

--- a/packages/react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.test.tsx
@@ -382,6 +382,29 @@ describe('DatePicker — keyboard navigation', () => {
     expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^2026-01-16T/));
   });
 
+  it('focuses an enabled day after navigating to a month whose first day is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <DatePicker
+        value="2026-06-15T00:00:00.000Z"
+        disabled={[{ dayOfWeek: [3] }]}
+        onChange={vi.fn()}
+      >
+        <DatePicker.Input aria-label="날짜 선택" />
+        <DatePicker.Popover>
+          <DatePicker.Calendar />
+        </DatePicker.Popover>
+      </DatePicker>,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('button', { name: 'Next month' }));
+
+    expect(screen.getByRole('button', { name: /July 2, 2026/ })).toHaveFocus();
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('button', { name: /July 3, 2026/ })).toHaveFocus();
+  });
+
   it('uses the civil instant for timezone-aware Enter disabled checks', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@kalyx/core';
 import type { CalendarDay, DateRange } from '@kalyx/core';
 import { useRangePickerContext } from '../../context/RangePickerContext.js';
+import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
 import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
 
 export interface RangePickerCalendarClassNames {
@@ -154,13 +155,16 @@ export function RangePickerCalendar({
   const navigateMonth = useCallback(
     (direction: number) => {
       const newMonth = adapter.addMonths(viewMonth, direction);
+      const monthStart = adapter.startOfMonth(newMonth);
       ctx.setViewMonth(newMonth);
-      ctx.setFocusedDate(adapter.startOfMonth(newMonth));
+      ctx.setFocusedDate(
+        resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone),
+      );
       const y = adapter.getYear(newMonth);
       const m = adapter.getMonth(newMonth);
       ctx.announce(formatMonthYear(y, m, locale));
     },
-    [adapter, viewMonth, ctx, locale],
+    [adapter, viewMonth, ctx, locale, disabled, displayTimezone],
   );
 
   const commitDay = useCallback(

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -12,7 +12,7 @@ import {
 } from '@kalyx/core';
 import type { CalendarDay, DateRange } from '@kalyx/core';
 import { useRangePickerContext } from '../../context/RangePickerContext.js';
-import { resolveEnabledCalendarFocus } from '../../internal/calendarFocus.js';
+import { resolveMonthNavigation } from '../../internal/calendarFocus.js';
 import { horizontalDayStep, isBackwardKey } from '../_shared/rtl.js';
 
 export interface RangePickerCalendarClassNames {
@@ -154,19 +154,11 @@ export function RangePickerCalendar({
 
   const navigateMonth = useCallback(
     (direction: number) => {
-      const newMonth = adapter.addMonths(viewMonth, direction);
-      const monthStart = adapter.startOfMonth(newMonth);
-      const focus = resolveEnabledCalendarFocus(
-        monthStart,
-        disabled,
-        adapter,
-        displayTimezone,
-        'forward',
-      );
-      ctx.setViewMonth(adapter.startOfMonth(focus));
-      ctx.setFocusedDate(focus);
-      const y = adapter.getYear(focus);
-      const m = adapter.getMonth(focus);
+      const next = resolveMonthNavigation(viewMonth, direction, disabled, adapter, displayTimezone);
+      ctx.setViewMonth(next.viewMonth);
+      ctx.setFocusedDate(next.focusedDate);
+      const y = adapter.getYear(next.focusedDate);
+      const m = adapter.getMonth(next.focusedDate);
       ctx.announce(formatMonthYear(y, m, locale));
     },
     [adapter, viewMonth, ctx, locale, disabled, displayTimezone],

--- a/packages/react/src/components/RangePicker/Calendar.tsx
+++ b/packages/react/src/components/RangePicker/Calendar.tsx
@@ -156,12 +156,17 @@ export function RangePickerCalendar({
     (direction: number) => {
       const newMonth = adapter.addMonths(viewMonth, direction);
       const monthStart = adapter.startOfMonth(newMonth);
-      ctx.setViewMonth(newMonth);
-      ctx.setFocusedDate(
-        resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone),
+      const focus = resolveEnabledCalendarFocus(
+        monthStart,
+        disabled,
+        adapter,
+        displayTimezone,
+        'forward',
       );
-      const y = adapter.getYear(newMonth);
-      const m = adapter.getMonth(newMonth);
+      ctx.setViewMonth(adapter.startOfMonth(focus));
+      ctx.setFocusedDate(focus);
+      const y = adapter.getYear(focus);
+      const m = adapter.getMonth(focus);
       ctx.announce(formatMonthYear(y, m, locale));
     },
     [adapter, viewMonth, ctx, locale, disabled, displayTimezone],

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -417,6 +417,21 @@ describe('RangePicker — keyboard navigation', () => {
     });
   });
 
+  it('focuses an enabled day after navigating to a month whose first day is disabled', async () => {
+    const user = userEvent.setup();
+    renderRangePicker({
+      value: { start: '2026-06-15T00:00:00.000Z', end: null },
+      disabled: [{ dayOfWeek: [3] }],
+    });
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: 'Next month' }));
+
+    expect(screen.getByRole('button', { name: /July 2, 2026/ })).toHaveFocus();
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('button', { name: /July 3, 2026/ })).toHaveFocus();
+  });
+
   it('skips a timezone-disabled civil day when navigating', async () => {
     const user = userEvent.setup();
     renderRangePicker({

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -1174,4 +1174,18 @@ describe('RangePicker — RTL (dir="rtl")', () => {
     await user.click(screen.getAllByRole('combobox')[0]);
     expect(screen.getByRole('grid')).toHaveAttribute('dir', 'ltr');
   });
+
+  it('navigates past a fully disabled month instead of freezing on the current one', async () => {
+    const user = userEvent.setup();
+    renderRangePicker({
+      value: { start: '2026-03-10T00:00:00.000Z', end: null },
+      disabled: [{ filter: (iso) => iso.startsWith('2026-02-') }],
+    });
+
+    await user.click(screen.getByLabelText('Start date'));
+    await user.click(screen.getByRole('button', { name: 'Previous month' }));
+
+    // A 'forward' search lands back on March 1 and the button stops responding.
+    expect(screen.getByRole('button', { name: /January 31, 2026/ })).toHaveFocus();
+  });
 });

--- a/packages/react/src/components/RangePicker/RangePicker.test.tsx
+++ b/packages/react/src/components/RangePicker/RangePicker.test.tsx
@@ -417,19 +417,19 @@ describe('RangePicker — keyboard navigation', () => {
     });
   });
 
-  it('focuses an enabled day after navigating to a month whose first day is disabled', async () => {
+  it('focuses a rendered enabled day when multiple leading days are disabled', async () => {
     const user = userEvent.setup();
     renderRangePicker({
-      value: { start: '2026-06-15T00:00:00.000Z', end: null },
-      disabled: [{ dayOfWeek: [3] }],
+      value: { start: '2026-01-15T00:00:00.000Z', end: null },
+      disabled: [{ dayOfWeek: [0, 1] }],
     });
 
     await user.click(screen.getByLabelText('Start date'));
     await user.click(screen.getByRole('button', { name: 'Next month' }));
 
-    expect(screen.getByRole('button', { name: /July 2, 2026/ })).toHaveFocus();
+    expect(screen.getByRole('button', { name: /February 3, 2026/ })).toHaveFocus();
     await user.keyboard('{ArrowRight}');
-    expect(screen.getByRole('button', { name: /July 3, 2026/ })).toHaveFocus();
+    expect(screen.getByRole('button', { name: /February 4, 2026/ })).toHaveFocus();
   });
 
   it('skips a timezone-disabled civil day when navigating', async () => {

--- a/packages/react/src/hooks/useDatePicker.test.tsx
+++ b/packages/react/src/hooks/useDatePicker.test.tsx
@@ -120,6 +120,22 @@ describe('useDatePicker — navigation', () => {
     expect(result.current.adapter.isSameMonth(result.current.viewMonth, next)).toBe(true);
   });
 
+  it.each([
+    ['nextMonth', '2026-06-15T00:00:00.000Z'],
+    ['previousMonth', '2026-08-15T00:00:00.000Z'],
+  ] as const)('%s focuses the first enabled day in the target month', (navigate, initialValue) => {
+    const { result } = renderHook(() =>
+      useDatePicker({
+        defaultValue: initialValue,
+        disabled: [{ dayOfWeek: [3] }],
+      }),
+    );
+
+    act(() => result.current[navigate]());
+
+    expect(result.current.focusedDate).toBe('2026-07-02T00:00:00.000Z');
+  });
+
   it('setViewMonth updates viewMonth directly', () => {
     const { result } = renderHook(() => useDatePicker());
 

--- a/packages/react/src/hooks/useDatePicker.test.tsx
+++ b/packages/react/src/hooks/useDatePicker.test.tsx
@@ -312,4 +312,21 @@ describe('useDatePicker — timezone and constraint parity', () => {
     expect(result.current.isOpen).toBe(true);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('reaches the earlier month when the whole previous month is disabled', () => {
+    const { result } = renderHook(() =>
+      useDatePicker({
+        defaultValue: '2026-03-10T00:00:00.000Z',
+        disabled: [{ filter: (iso: string) => iso.startsWith('2026-02-') }],
+      }),
+    );
+
+    act(() => result.current.previousMonth());
+
+    // A 'forward' search bounces back into March and freezes the button.
+    expect(result.current.focusedDate).toBe('2026-01-31T00:00:00.000Z');
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-01-01T00:00:00.000Z'),
+    ).toBe(true);
+  });
 });

--- a/packages/react/src/hooks/useDatePicker.test.tsx
+++ b/packages/react/src/hooks/useDatePicker.test.tsx
@@ -121,19 +121,42 @@ describe('useDatePicker — navigation', () => {
   });
 
   it.each([
-    ['nextMonth', '2026-06-15T00:00:00.000Z'],
-    ['previousMonth', '2026-08-15T00:00:00.000Z'],
+    ['nextMonth', '2026-01-15T00:00:00.000Z'],
+    ['previousMonth', '2026-03-15T00:00:00.000Z'],
   ] as const)('%s focuses the first enabled day in the target month', (navigate, initialValue) => {
     const { result } = renderHook(() =>
       useDatePicker({
         defaultValue: initialValue,
-        disabled: [{ dayOfWeek: [3] }],
+        disabled: [{ dayOfWeek: [0, 1] }],
       }),
     );
 
     act(() => result.current[navigate]());
 
-    expect(result.current.focusedDate).toBe('2026-07-02T00:00:00.000Z');
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-02-01T00:00:00.000Z'),
+    ).toBe(true);
+    expect(result.current.focusedDate).toBe('2026-02-03T00:00:00.000Z');
+  });
+
+  it('keeps view and focus synchronized when the target month is fully disabled', () => {
+    let disableFebruary = false;
+    const { result } = renderHook(() =>
+      useDatePicker({
+        defaultValue: '2026-01-15T00:00:00.000Z',
+        disabled: [
+          {
+            filter: (iso) => disableFebruary && iso.startsWith('2026-02-'),
+          },
+        ],
+      }),
+    );
+
+    disableFebruary = true;
+    act(() => result.current.nextMonth());
+
+    expect(result.current.viewMonth).toBe('2026-03-01T00:00:00.000Z');
+    expect(result.current.focusedDate).toBe('2026-03-01T00:00:00.000Z');
   });
 
   it('setViewMonth updates viewMonth directly', () => {

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -151,15 +151,29 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
   const previousMonth = useCallback(() => {
     const newMonth = adapter.addMonths(viewMonth, -1);
     const monthStart = adapter.startOfMonth(newMonth);
-    setViewMonth(newMonth);
-    setFocusedDate(resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone));
+    const focus = resolveEnabledCalendarFocus(
+      monthStart,
+      disabled,
+      adapter,
+      displayTimezone,
+      'forward',
+    );
+    setViewMonth(adapter.startOfMonth(focus));
+    setFocusedDate(focus);
   }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const nextMonth = useCallback(() => {
     const newMonth = adapter.addMonths(viewMonth, 1);
     const monthStart = adapter.startOfMonth(newMonth);
-    setViewMonth(newMonth);
-    setFocusedDate(resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone));
+    const focus = resolveEnabledCalendarFocus(
+      monthStart,
+      disabled,
+      adapter,
+      displayTimezone,
+      'forward',
+    );
+    setViewMonth(adapter.startOfMonth(focus));
+    setFocusedDate(focus);
   }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -13,7 +13,7 @@ import type {
   WeekStartsOn,
 } from '@kalyx/core';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
-import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
+import { resolveEnabledCalendarFocus, resolveMonthNavigation } from '../internal/calendarFocus.js';
 
 export interface UseDatePickerOptions {
   /** Selected date (controlled mode) */
@@ -149,31 +149,15 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
   }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
-    const newMonth = adapter.addMonths(viewMonth, -1);
-    const monthStart = adapter.startOfMonth(newMonth);
-    const focus = resolveEnabledCalendarFocus(
-      monthStart,
-      disabled,
-      adapter,
-      displayTimezone,
-      'forward',
-    );
-    setViewMonth(adapter.startOfMonth(focus));
-    setFocusedDate(focus);
+    const next = resolveMonthNavigation(viewMonth, -1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
   }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const nextMonth = useCallback(() => {
-    const newMonth = adapter.addMonths(viewMonth, 1);
-    const monthStart = adapter.startOfMonth(newMonth);
-    const focus = resolveEnabledCalendarFocus(
-      monthStart,
-      disabled,
-      adapter,
-      displayTimezone,
-      'forward',
-    );
-    setViewMonth(adapter.startOfMonth(focus));
-    setFocusedDate(focus);
+    const next = resolveMonthNavigation(viewMonth, 1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
   }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {

--- a/packages/react/src/hooks/useDatePicker.ts
+++ b/packages/react/src/hooks/useDatePicker.ts
@@ -150,15 +150,17 @@ export function useDatePicker(options: UseDatePickerOptions = {}): UseDatePicker
 
   const previousMonth = useCallback(() => {
     const newMonth = adapter.addMonths(viewMonth, -1);
+    const monthStart = adapter.startOfMonth(newMonth);
     setViewMonth(newMonth);
-    setFocusedDate(adapter.startOfMonth(newMonth));
-  }, [adapter, viewMonth]);
+    setFocusedDate(resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone));
+  }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const nextMonth = useCallback(() => {
     const newMonth = adapter.addMonths(viewMonth, 1);
+    const monthStart = adapter.startOfMonth(newMonth);
     setViewMonth(newMonth);
-    setFocusedDate(adapter.startOfMonth(newMonth));
-  }, [adapter, viewMonth]);
+    setFocusedDate(resolveEnabledCalendarFocus(monthStart, disabled, adapter, displayTimezone));
+  }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/hooks/useDateTimePicker.test.tsx
+++ b/packages/react/src/hooks/useDateTimePicker.test.tsx
@@ -115,4 +115,35 @@ describe('useDateTimePicker — timezone and constraint parity', () => {
     expect(result.current.viewMonth).toBe('2026-03-16T00:00:00.000Z');
     expect(result.current.focusedDate).toBe('2026-03-16T00:00:00.000Z');
   });
+
+  it('reaches the earlier month when the whole previous month is disabled', () => {
+    const { result } = renderHook(() =>
+      useDateTimePicker({
+        defaultValue: '2026-03-10T00:00:00.000Z',
+        disabled: [{ filter: (iso: string) => iso.startsWith('2026-02-') }],
+      }),
+    );
+
+    act(() => result.current.previousMonth());
+
+    // A 'forward' search bounces back into March and freezes the button.
+    expect(result.current.focusedDate).toBe('2026-01-31T00:00:00.000Z');
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-01-01T00:00:00.000Z'),
+    ).toBe(true);
+  });
+
+  it('never focuses a disabled day after month navigation', () => {
+    const { result } = renderHook(() =>
+      useDateTimePicker({
+        defaultValue: '2026-01-15T00:00:00.000Z',
+        disabled: [{ dayOfWeek: [0, 1] }],
+      }),
+    );
+
+    // February 2026 starts on a Sunday, so the raw month start is disabled.
+    act(() => result.current.nextMonth());
+
+    expect(result.current.focusedDate).toBe('2026-02-03T00:00:00.000Z');
+  });
 });

--- a/packages/react/src/hooks/useDateTimePicker.test.tsx
+++ b/packages/react/src/hooks/useDateTimePicker.test.tsx
@@ -133,6 +133,22 @@ describe('useDateTimePicker — timezone and constraint parity', () => {
     ).toBe(true);
   });
 
+  it('preserves repeated month navigation calls in the same React batch', () => {
+    const { result } = renderHook(() =>
+      useDateTimePicker({ defaultValue: '2026-01-15T12:30:00.000Z' }),
+    );
+
+    act(() => {
+      result.current.nextMonth();
+      result.current.nextMonth();
+    });
+
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-03-01T00:00:00.000Z'),
+    ).toBe(true);
+    expect(result.current.focusedDate).toBe('2026-03-01T00:00:00.000Z');
+  });
+
   it('never focuses a disabled day after month navigation', () => {
     const { result } = renderHook(() =>
       useDateTimePicker({

--- a/packages/react/src/hooks/useDateTimePicker.ts
+++ b/packages/react/src/hooks/useDateTimePicker.ts
@@ -182,15 +182,19 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
   }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
-    const next = resolveMonthNavigation(viewMonth, -1, disabled, adapter, displayTimezone);
-    setViewMonth(next.viewMonth);
-    setFocusedDate(next.focusedDate);
-  }, [adapter, viewMonth, disabled, displayTimezone]);
+    setViewMonth((current) => {
+      const next = resolveMonthNavigation(current, -1, disabled, adapter, displayTimezone);
+      setFocusedDate(next.focusedDate);
+      return next.viewMonth;
+    });
+  }, [adapter, disabled, displayTimezone]);
   const nextMonth = useCallback(() => {
-    const next = resolveMonthNavigation(viewMonth, 1, disabled, adapter, displayTimezone);
-    setViewMonth(next.viewMonth);
-    setFocusedDate(next.focusedDate);
-  }, [adapter, viewMonth, disabled, displayTimezone]);
+    setViewMonth((current) => {
+      const next = resolveMonthNavigation(current, 1, disabled, adapter, displayTimezone);
+      setFocusedDate(next.focusedDate);
+      return next.viewMonth;
+    });
+  }, [adapter, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/hooks/useDateTimePicker.ts
+++ b/packages/react/src/hooks/useDateTimePicker.ts
@@ -18,7 +18,7 @@ import type {
   WeekStartsOn,
 } from '@kalyx/core';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
-import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
+import { resolveEnabledCalendarFocus, resolveMonthNavigation } from '../internal/calendarFocus.js';
 
 export interface UseDateTimePickerOptions {
   /** Selected datetime (controlled, ISO 8601 UTC — date and time) */
@@ -182,19 +182,15 @@ export function useDateTimePicker(options: UseDateTimePickerOptions = {}): UseDa
   }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
-    setViewMonth((m) => {
-      const next = adapter.addMonths(m, -1);
-      setFocusedDate(adapter.startOfMonth(next));
-      return next;
-    });
-  }, [adapter]);
+    const next = resolveMonthNavigation(viewMonth, -1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
+  }, [adapter, viewMonth, disabled, displayTimezone]);
   const nextMonth = useCallback(() => {
-    setViewMonth((m) => {
-      const next = adapter.addMonths(m, 1);
-      setFocusedDate(adapter.startOfMonth(next));
-      return next;
-    });
-  }, [adapter]);
+    const next = resolveMonthNavigation(viewMonth, 1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
+  }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/hooks/useRangePicker.test.tsx
+++ b/packages/react/src/hooks/useRangePicker.test.tsx
@@ -268,4 +268,35 @@ describe('useRangePicker — timezone and constraint parity', () => {
     expect(result.current.isOpen).toBe(true);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('reaches the earlier month when the whole previous month is disabled', () => {
+    const { result } = renderHook(() =>
+      useRangePicker({
+        defaultValue: { start: '2026-03-10T00:00:00.000Z', end: '2026-03-10T00:00:00.000Z' },
+        disabled: [{ filter: (iso: string) => iso.startsWith('2026-02-') }],
+      }),
+    );
+
+    act(() => result.current.previousMonth());
+
+    // A 'forward' search bounces back into March and freezes the button.
+    expect(result.current.focusedDate).toBe('2026-01-31T00:00:00.000Z');
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-01-01T00:00:00.000Z'),
+    ).toBe(true);
+  });
+
+  it('never focuses a disabled day after month navigation', () => {
+    const { result } = renderHook(() =>
+      useRangePicker({
+        defaultValue: { start: '2026-01-15T00:00:00.000Z', end: '2026-01-15T00:00:00.000Z' },
+        disabled: [{ dayOfWeek: [0, 1] }],
+      }),
+    );
+
+    // February 2026 starts on a Sunday, so the raw month start is disabled.
+    act(() => result.current.nextMonth());
+
+    expect(result.current.focusedDate).toBe('2026-02-03T00:00:00.000Z');
+  });
 });

--- a/packages/react/src/hooks/useRangePicker.ts
+++ b/packages/react/src/hooks/useRangePicker.ts
@@ -15,7 +15,7 @@ import type {
 } from '@kalyx/core';
 import type { RangeSelectingTarget } from '../context/RangePickerContext.js';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
-import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
+import { resolveEnabledCalendarFocus, resolveMonthNavigation } from '../internal/calendarFocus.js';
 
 const EMPTY_RANGE: DateRange = { start: null, end: null };
 
@@ -193,16 +193,16 @@ export function useRangePicker(options: UseRangePickerOptions = {}): UseRangePic
   }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
-    const newMonth = adapter.addMonths(viewMonth, -1);
-    setViewMonth(newMonth);
-    setFocusedDate(adapter.startOfMonth(newMonth));
-  }, [adapter, viewMonth]);
+    const next = resolveMonthNavigation(viewMonth, -1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
+  }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const nextMonth = useCallback(() => {
-    const newMonth = adapter.addMonths(viewMonth, 1);
-    setViewMonth(newMonth);
-    setFocusedDate(adapter.startOfMonth(newMonth));
-  }, [adapter, viewMonth]);
+    const next = resolveMonthNavigation(viewMonth, 1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
+  }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/hooks/useWeekPicker.test.tsx
+++ b/packages/react/src/hooks/useWeekPicker.test.tsx
@@ -158,4 +158,35 @@ describe('useWeekPicker — timezone and constraint parity', () => {
       result.current.adapter.isSameMonth(result.current.focusedDate, result.current.viewMonth),
     ).toBe(true);
   });
+
+  it('reaches the earlier month when the whole previous month is disabled', () => {
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        defaultValue: { start: '2026-03-10T00:00:00.000Z', end: '2026-03-10T00:00:00.000Z' },
+        disabled: [{ filter: (iso: string) => iso.startsWith('2026-02-') }],
+      }),
+    );
+
+    act(() => result.current.previousMonth());
+
+    // A 'forward' search bounces back into March and freezes the button.
+    expect(result.current.focusedDate).toBe('2026-01-31T00:00:00.000Z');
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-01-01T00:00:00.000Z'),
+    ).toBe(true);
+  });
+
+  it('never focuses a disabled day after month navigation', () => {
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        defaultValue: { start: '2026-01-15T00:00:00.000Z', end: '2026-01-15T00:00:00.000Z' },
+        disabled: [{ dayOfWeek: [0, 1] }],
+      }),
+    );
+
+    // February 2026 starts on a Sunday, so the raw month start is disabled.
+    act(() => result.current.nextMonth());
+
+    expect(result.current.focusedDate).toBe('2026-02-03T00:00:00.000Z');
+  });
 });

--- a/packages/react/src/hooks/useWeekPicker.test.tsx
+++ b/packages/react/src/hooks/useWeekPicker.test.tsx
@@ -176,6 +176,24 @@ describe('useWeekPicker — timezone and constraint parity', () => {
     ).toBe(true);
   });
 
+  it('preserves repeated month navigation calls in the same React batch', () => {
+    const { result } = renderHook(() =>
+      useWeekPicker({
+        defaultValue: { start: '2026-01-15T00:00:00.000Z', end: '2026-01-15T00:00:00.000Z' },
+      }),
+    );
+
+    act(() => {
+      result.current.nextMonth();
+      result.current.nextMonth();
+    });
+
+    expect(
+      result.current.adapter.isSameMonth(result.current.viewMonth, '2026-03-01T00:00:00.000Z'),
+    ).toBe(true);
+    expect(result.current.focusedDate).toBe('2026-03-01T00:00:00.000Z');
+  });
+
   it('never focuses a disabled day after month navigation', () => {
     const { result } = renderHook(() =>
       useWeekPicker({

--- a/packages/react/src/hooks/useWeekPicker.ts
+++ b/packages/react/src/hooks/useWeekPicker.ts
@@ -164,15 +164,19 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
   }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
-    const next = resolveMonthNavigation(viewMonth, -1, disabled, adapter, displayTimezone);
-    setViewMonth(next.viewMonth);
-    setFocusedDate(next.focusedDate);
-  }, [adapter, viewMonth, disabled, displayTimezone]);
+    setViewMonth((current) => {
+      const next = resolveMonthNavigation(current, -1, disabled, adapter, displayTimezone);
+      setFocusedDate(next.focusedDate);
+      return next.viewMonth;
+    });
+  }, [adapter, disabled, displayTimezone]);
   const nextMonth = useCallback(() => {
-    const next = resolveMonthNavigation(viewMonth, 1, disabled, adapter, displayTimezone);
-    setViewMonth(next.viewMonth);
-    setFocusedDate(next.focusedDate);
-  }, [adapter, viewMonth, disabled, displayTimezone]);
+    setViewMonth((current) => {
+      const next = resolveMonthNavigation(current, 1, disabled, adapter, displayTimezone);
+      setFocusedDate(next.focusedDate);
+      return next.viewMonth;
+    });
+  }, [adapter, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/hooks/useWeekPicker.ts
+++ b/packages/react/src/hooks/useWeekPicker.ts
@@ -14,7 +14,7 @@ import type {
   WeekStartsOn,
 } from '@kalyx/core';
 import { getDefaultAdapter, resolveAdapter } from '../internal/defaultAdapter.js';
-import { resolveEnabledCalendarFocus } from '../internal/calendarFocus.js';
+import { resolveEnabledCalendarFocus, resolveMonthNavigation } from '../internal/calendarFocus.js';
 
 const EMPTY_RANGE: DateRange = { start: null, end: null };
 
@@ -164,19 +164,15 @@ export function useWeekPicker(options: UseWeekPickerOptions = {}): UseWeekPicker
   }, [isOpen, open, close]);
 
   const previousMonth = useCallback(() => {
-    setViewMonth((month) => {
-      const previous = adapter.addMonths(month, -1);
-      setFocusedDate(adapter.startOfMonth(previous));
-      return previous;
-    });
-  }, [adapter]);
+    const next = resolveMonthNavigation(viewMonth, -1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
+  }, [adapter, viewMonth, disabled, displayTimezone]);
   const nextMonth = useCallback(() => {
-    setViewMonth((month) => {
-      const next = adapter.addMonths(month, 1);
-      setFocusedDate(adapter.startOfMonth(next));
-      return next;
-    });
-  }, [adapter]);
+    const next = resolveMonthNavigation(viewMonth, 1, disabled, adapter, displayTimezone);
+    setViewMonth(next.viewMonth);
+    setFocusedDate(next.focusedDate);
+  }, [adapter, viewMonth, disabled, displayTimezone]);
 
   const calendar = getCalendarDays(viewMonth, adapter, {
     weekStartsOn,

--- a/packages/react/src/internal/calendarFocus.test.ts
+++ b/packages/react/src/internal/calendarFocus.test.ts
@@ -1,0 +1,86 @@
+import { DateFnsAdapter } from '@kalyx/adapter-date-fns';
+import type { DisabledRule } from '@kalyx/core';
+import { describe, expect, it } from 'vitest';
+import { resolveEnabledCalendarFocus } from './calendarFocus.js';
+
+const A = DateFnsAdapter;
+const day = (iso: string) => `${iso}T00:00:00.000Z`;
+
+/** Disables every day of February 2026 and nothing else. */
+const FEBRUARY_BLACKOUT: DisabledRule[] = [{ filter: (iso: string) => iso.startsWith('2026-02') }];
+/** Sundays and Mondays. February 2026 starts on a Sunday, so Feb 3 is the first enabled day. */
+const SUNDAYS_AND_MONDAYS: DisabledRule[] = [{ dayOfWeek: [0, 1] }];
+
+describe('resolveEnabledCalendarFocus', () => {
+  it('returns the coordinate untouched when it is already enabled', () => {
+    expect(resolveEnabledCalendarFocus(day('2026-02-10'), [], A)).toBe(day('2026-02-10'));
+  });
+
+  describe("searchDirection: 'backward'", () => {
+    it('picks the first enabled day inside the target month when the month is only partly disabled', () => {
+      // Same answer 'forward' gives: navigating in either direction should land on
+      // the same day when the month itself has an enabled day.
+      expect(
+        resolveEnabledCalendarFocus(
+          day('2026-02-01'),
+          SUNDAYS_AND_MONDAYS,
+          A,
+          undefined,
+          'backward',
+        ),
+      ).toBe(day('2026-02-03'));
+    });
+
+    it('walks into the earlier month when the whole target month is disabled', () => {
+      // Regression: 'forward' walked past the month the user came from, so the
+      // "previous month" button became a permanent dead end.
+      expect(
+        resolveEnabledCalendarFocus(day('2026-02-01'), FEBRUARY_BLACKOUT, A, undefined, 'backward'),
+      ).toBe(day('2026-01-31'));
+    });
+
+    it('keeps walking backward across several fully disabled months', () => {
+      const janAndFebBlackout: DisabledRule[] = [
+        { filter: (iso: string) => iso.startsWith('2026-01') || iso.startsWith('2026-02') },
+      ];
+      expect(
+        resolveEnabledCalendarFocus(day('2026-02-01'), janAndFebBlackout, A, undefined, 'backward'),
+      ).toBe(day('2025-12-31'));
+    });
+
+    it('falls back to the coordinate when nothing is enabled within a year', () => {
+      const everything: DisabledRule[] = [{ filter: () => true }];
+      expect(
+        resolveEnabledCalendarFocus(day('2026-02-01'), everything, A, undefined, 'backward'),
+      ).toBe(day('2026-02-01'));
+    });
+  });
+
+  describe("searchDirection: 'forward'", () => {
+    it('walks into the later month when the whole target month is disabled', () => {
+      expect(
+        resolveEnabledCalendarFocus(day('2026-02-01'), FEBRUARY_BLACKOUT, A, undefined, 'forward'),
+      ).toBe(day('2026-03-01'));
+    });
+
+    it('never walks backward out of the target month', () => {
+      expect(
+        resolveEnabledCalendarFocus(
+          day('2026-02-01'),
+          SUNDAYS_AND_MONDAYS,
+          A,
+          undefined,
+          'forward',
+        ),
+      ).toBe(day('2026-02-03'));
+    });
+  });
+
+  describe("searchDirection: 'nearest' (default, used when opening)", () => {
+    it('may reach backward for the closest enabled day', () => {
+      expect(resolveEnabledCalendarFocus(day('2026-02-01'), SUNDAYS_AND_MONDAYS, A)).toBe(
+        day('2026-01-31'),
+      );
+    });
+  });
+});

--- a/packages/react/src/internal/calendarFocus.ts
+++ b/packages/react/src/internal/calendarFocus.ts
@@ -6,6 +6,7 @@ export function resolveEnabledCalendarFocus(
   disabled: DisabledRule[],
   adapter: DateAdapter,
   timezone?: string,
+  searchDirection: 'nearest' | 'forward' = 'nearest',
 ): ISODateString {
   const isDisabled = (day: ISODateString) =>
     isDateDisabled(
@@ -21,7 +22,7 @@ export function resolveEnabledCalendarFocus(
   for (let offset = 0; offset < 366; offset++) {
     const next = adapter.addDays(monthStart, offset);
     if (!isDisabled(next)) return next;
-    if (offset > 0) {
+    if (searchDirection === 'nearest' && offset > 0) {
       const previous = adapter.addDays(monthStart, -offset);
       if (!isDisabled(previous)) return previous;
     }

--- a/packages/react/src/internal/calendarFocus.ts
+++ b/packages/react/src/internal/calendarFocus.ts
@@ -6,7 +6,7 @@ export function resolveEnabledCalendarFocus(
   disabled: DisabledRule[],
   adapter: DateAdapter,
   timezone?: string,
-  searchDirection: 'nearest' | 'forward' = 'nearest',
+  searchDirection: 'nearest' | 'forward' | 'backward' = 'nearest',
 ): ISODateString {
   const isDisabled = (day: ISODateString) =>
     isDateDisabled(
@@ -19,6 +19,25 @@ export function resolveEnabledCalendarFocus(
   if (!isDisabled(coordinate)) return coordinate;
 
   const monthStart = adapter.startOfMonth(coordinate);
+
+  if (searchDirection === 'backward') {
+    // Prefer an enabled day inside the target month, so a partially disabled
+    // month resolves to the same day 'forward' would pick.
+    for (let offset = 0; offset < 31; offset++) {
+      const inMonth = adapter.addDays(monthStart, offset);
+      if (!adapter.isSameMonth(inMonth, monthStart)) break;
+      if (!isDisabled(inMonth)) return inMonth;
+    }
+    // The whole month is disabled. Keep travelling the way the user asked
+    // instead of bouncing forward past the month they navigated away from —
+    // that turns the "previous month" button into a permanent dead end.
+    for (let offset = 1; offset <= 366; offset++) {
+      const earlier = adapter.addDays(monthStart, -offset);
+      if (!isDisabled(earlier)) return earlier;
+    }
+    return coordinate;
+  }
+
   for (let offset = 0; offset < 366; offset++) {
     const next = adapter.addDays(monthStart, offset);
     if (!isDisabled(next)) return next;
@@ -28,4 +47,30 @@ export function resolveEnabledCalendarFocus(
     }
   }
   return coordinate;
+}
+
+/**
+ * Resolves the view month and focus target for a month-navigation step.
+ *
+ * The focus search follows the direction the user travelled, so a fully
+ * disabled month never traps navigation: stepping back past it continues
+ * backward rather than bouncing forward into the month they came from.
+ * The view follows the resolved focus so the two can never disagree.
+ */
+export function resolveMonthNavigation(
+  viewMonth: ISODateString,
+  direction: number,
+  disabled: DisabledRule[],
+  adapter: DateAdapter,
+  timezone?: string,
+): { viewMonth: ISODateString; focusedDate: ISODateString } {
+  const monthStart = adapter.startOfMonth(adapter.addMonths(viewMonth, direction));
+  const focusedDate = resolveEnabledCalendarFocus(
+    monthStart,
+    disabled,
+    adapter,
+    timezone,
+    direction < 0 ? 'backward' : 'forward',
+  );
+  return { viewMonth: adapter.startOfMonth(focusedDate), focusedDate };
 }


### PR DESCRIPTION
## Summary

Fix two correctness blockers found in the post-1.4.1 dual-model audit:

- preserve UTC calendar coordinates when resolving civil midnight in UTC+12 through UTC+14 zones
- prevent DatePicker, RangePicker, and `useDatePicker` month navigation from focusing disabled or non-rendered dates
- keep `viewMonth` and `focusedDate` synchronized when an entire target month is disabled
- add literal, all-IANA property-based, timezone-aware, component, and headless regressions
- prepare linked patch releases for `@kalyx/core` and `@kalyx/react` without publishing
- document the design, non-goals, and Claude verification checklist

Immutable reviewed head: `79309692b023147cae15ff0af9890848b0500f20`

## Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, deps, or tooling

## Changes

- Replace the unsafe UTC-noon bridge in `civilMidnightFromUtcDay` with direct civil-date resolution through the existing DST-aware resolver.
- Cover Auckland, Chatham, and Kiritimati with exact expected instants and a 300-run curated-zone property.
- Enumerate every zone returned by `Intl.supportedValuesOf('timeZone')`, exercising explicit 2020/2045 boundaries plus 12 deterministic unbiased generated dates per zone.
- Add a forward search mode to the internal enabled-focus resolver for month navigation.
- Resolve and synchronize the actual displayed month for partially and fully disabled target months.
- Cover DatePicker, RangePicker, and headless hook behavior, including `Pacific/Kiritimati` and multiple leading disabled days.
- Add a core/react-only patch changeset; no versions, tags, releases, or npm packages are created by this PR.

## RED evidence

- Extreme-positive timezone regressions failed 4 cases before implementation: Auckland, Chatham, Kiritimati, and the property test.
- Month navigation regressions failed in DatePicker, RangePicker, and both hook directions by focusing disabled July 1.
- Independent review found a second counterexample: February 2026 with Sunday/Monday disabled resolved to non-rendered January 31. The strengthened regressions failed in all three paths before the follow-up fix.
- Reintroducing the former noon-probe against the all-IANA test failed immediately in `Antarctica/McMurdo` with a January 1 → January 2 counterexample; restoring the fix returned the suite to green.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] Focused timezone regressions: 2 files, 57 tests; 2.25s locally
- [x] All-IANA runtime coverage: Node 20.11 = 428 zones/1.11s; Node 22.22.3 = 418 zones/1.53s
- [x] `pnpm test:run`: 46 files, 865 tests
- [x] `pnpm test:coverage`: statements 89.82%, branches 86.20%, functions 94.03%, lines 92.13%
- [x] `pnpm build`
- [x] `pnpm check-bundle`: ESM 18.42KB gzip, CJS 18.55KB gzip, both under the current 20KB policy
- [x] `pnpm check-tree-shaking`
- [x] `pnpm --filter docs-site build` (EN/KO)
- [x] `pnpm docs:build`
- [x] `pnpm test:e2e`: 93 tests across Chromium, Firefox, and WebKit
- [x] `node scripts/verify-changesets.mjs` and `pnpm changeset status`: core/react patch only
- [x] `git diff --check`
- [x] Independent read-only review and re-review: no remaining Critical, Important, or Minor findings; Ready to merge: Yes

## Checklist

- [x] No public API changes; patch changeset prepared for linked core/react packages
- [x] No versioning, merge, tag, GitHub Release, or npm publish performed
- [x] Existing DST gap/overlap semantics preserved
- [x] Accessibility focus never intentionally anchors to a disabled/non-rendered target after month-button navigation
- [x] SSR behavior unchanged
- [x] `displayTimezone` behavior verified with UTC+12/+13:45/+14 and a timezone-aware focus regression

## Claude verification checklist

Please validate this exact head rather than relying only on the PR diff summary:

1. Reproduce calendar-coordinate round trips for `Pacific/Auckland`, `Pacific/Chatham`, and `Pacific/Kiritimati`.
2. Confirm every runtime-returned IANA zone receives the two boundary coordinates and 12 unbiased deterministic generated coordinates on Node 20 and 22.
3. Stress `civilMidnightFromUtcDay` around DST transitions and confirm gap/overlap behavior still matches `setTimeInTimezone`.
4. Navigate into February 2026 with Sunday/Monday disabled in DatePicker and RangePicker; confirm February 3 is the sole roving-tabindex target.
5. Disable an entire target month; confirm view and focus advance together to the next enabled month.
6. Repeat month navigation with `displayTimezone="Pacific/Kiritimati"` and keyboard navigation after the button click.
7. Confirm the changeset lists patch bumps for core/react only and that no version or publish side effect occurred.
8. Check public exports/types for accidental API changes and compare bundle output against the 20KB gzip gate.

## Non-goals

Release-workflow hardening, security metadata, competitor/documentation positioning, and broader feature work remain separate follow-up PRs.
