### PR TITLE
fix: guard headless month/year commits, split the headless bundle ceiling

### DIFF
--- a/.changeset/heavy-poems-smile.md
+++ b/.changeset/heavy-poems-smile.md
@@ -1,0 +1,21 @@
+---
+'@kalyx/react': patch
+---
+
+Stop `useMonthPicker` and `useYearPicker` from committing a disabled cell.
+
+Both hooks computed the grid's `isDisabled` flags but committed without checking
+them, so a month or year the grid renders as unselectable could still be passed
+to `selectMonth` / `selectYear` and would fire `onChange`. Only the `/headless`
+hooks were affected — the `MonthPicker` and `YearPicker` components are built on
+`DatePickerRoot`, which already guarded its commit path.
+
+The guard uses the same `isRangeFullyDisabled` predicate the grids use for their
+flags, so the commit and the rendered state agree: a month or year is refused
+only when a `before` / `after` bound excludes it *entirely*. Day-granular
+`{ date }` and `{ dayOfWeek }` rules never disable a whole month or year, and
+they do not block the commit either.
+
+If you were relying on `selectMonth` / `selectYear` emitting for out-of-range
+values, read the value back from `onChange` instead — it is now the same set of
+values the grid lets a user click.

--- a/.changeset/heavy-poems-smile.md
+++ b/.changeset/heavy-poems-smile.md
@@ -2,20 +2,36 @@
 '@kalyx/react': patch
 ---
 
-Stop `useMonthPicker` and `useYearPicker` from committing a disabled cell.
+Enforce month and year constraints correctly, including under `displayTimezone`.
 
-Both hooks computed the grid's `isDisabled` flags but committed without checking
-them, so a month or year the grid renders as unselectable could still be passed
-to `selectMonth` / `selectYear` and would fire `onChange`. Only the `/headless`
-hooks were affected — the `MonthPicker` and `YearPicker` components are built on
-`DatePickerRoot`, which already guarded its commit path.
+Two related defects in `MonthPicker` / `YearPicker` and their headless hooks:
 
-The guard uses the same `isRangeFullyDisabled` predicate the grids use for their
-flags, so the commit and the rendered state agree: a month or year is refused
-only when a `before` / `after` bound excludes it *entirely*. Day-granular
-`{ date }` and `{ dayOfWeek }` rules never disable a whole month or year, and
-they do not block the commit either.
+**Commits were unguarded.** `useMonthPicker.selectMonth` and
+`useYearPicker.selectYear` computed the grid's `isDisabled` flags but committed
+without consulting them, so a cell the grid renders as unselectable could still
+be committed programmatically and fire `onChange`. Only the `/headless` hooks
+were affected — the components are built on `DatePickerRoot`, which already
+guarded its commit path.
 
-If you were relying on `selectMonth` / `selectYear` emitting for out-of-range
-values, read the value back from `onChange` instead — it is now the same set of
-values the grid lets a user click.
+**The disabled calculation ignored `displayTimezone`.** `isRangeFullyDisabled`
+compared raw UTC coordinates against bounds that are civil-midnight instants. In
+a large positive-offset zone a period's civil range sits up to 14 hours earlier
+than its UTC coordinates suggest, so a month lying entirely before a `before`
+bound stayed **enabled** — visibly selectable in the grid, and committable. In
+`Pacific/Kiritimati` with `{ before: <civil 2026-01-01> }`, all of December 2025
+remained available. Negative-offset zones happened to compute correctly, which is
+why this survived earlier review.
+
+The range is now half-open — callers pass the start of the next period rather
+than its last millisecond — and both ends are mapped through the display zone
+before comparison. UTC behaviour (no `displayTimezone`) is unchanged and locked
+by boundary tests.
+
+**This changes rendering, not just commits:** under `displayTimezone`, months and
+years that previously appeared enabled may now correctly render as disabled. Both
+the grid flag and the commit guard call the same predicate, so they cannot
+disagree in either direction.
+
+The guard deliberately uses `isRangeFullyDisabled` rather than `isDateDisabled`:
+a month or year is disabled only when a bound excludes it *entirely*, so
+day-granular `{ date }` and `{ dayOfWeek }` rules must not block it.

--- a/.claude/commands/check-bundle.md
+++ b/.claude/commands/check-bundle.md
@@ -1,6 +1,6 @@
 ---
 name: check-bundle
-description: 현재 번들 크기를 분석하고 20KB 목표 달성 여부를 확인한다.
+description: 현재 번들 크기를 분석하고 목표(index 20KB / headless 22KB) 달성 여부를 확인한다.
 ---
 
 # /check-bundle
@@ -8,7 +8,7 @@ description: 현재 번들 크기를 분석하고 20KB 목표 달성 여부를 �
 ## 설명
 
 빌드 후 번들 크기를 분석한다.
-목표: `@kalyx/react` gzip 20KB 이하 (rc 단계에서 12 → 13KB 상향(commit e93d082); v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향; v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향; v1.0-rc.8 TimePicker `filterTime` 추가하면서 15 → 16KB 상향; v1.1 B10 a11y announce() 패리티 추가하면서 16 → 17KB 상향; 2026-08 timezone/constraint 정확성 전면 수정으로 17 → 20KB 상향)
+목표: 기본 엔트리 gzip **20KB** 이하, `/headless` 엔트리 **22KB** 이하 (rc 단계에서 12 → 13KB 상향(commit e93d082); v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향; v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향; v1.0-rc.8 TimePicker `filterTime` 추가하면서 15 → 16KB 상향; v1.1 B10 a11y announce() 패리티 추가하면서 16 → 17KB 상향; 2026-08 timezone/constraint 정확성 전면 수정으로 17 → 20KB 상향; 2026-08 headless 만 20 → 22KB 분리 상향 — 아래 판정 기준 참고)
 
 ## Claude가 수행할 작업
 
@@ -38,13 +38,15 @@ import('./packages/react/dist/index.js').then(m => {
 
 | 상태 | index (ESM/CJS) | headless (ESM/CJS) | 조치 |
 |---|---|---|---|
-| ✅ OK | ≤ 19KB | ≤ 19.5KB | 문제없음 |
-| ⚠️ 주의 | 19–20KB | 19.5–20KB | 최적화 검토 |
-| ❌ 초과 | > 20KB | > 20KB | 반드시 축소 필요 |
+| ✅ OK | ≤ 19KB | ≤ 21KB | 문제없음 |
+| ⚠️ 주의 | 19–20KB | 21–22KB | 최적화 검토 |
+| ❌ 초과 | > 20KB | > 22KB | 반드시 축소 필요 |
 
-밴드를 엔트리별로 나눈 이유: 천장은 넷 다 20KB 로 같지만 **남은 여유가 다르다.**
-index 는 1.4KB 이상 남는데 headless 는 수백 바이트 수준이라, 단일 밴드를 쓰면
-index 가 멀쩡한데도 매번 경고가 떠 표가 무시당한다. 실제로 막히는 건 항상 headless 다.
+**두 엔트리는 천장이 다르다** — index 20KB, headless 22KB. `scripts/bundle-policy.js` 가 단일 소스다.
+headless 는 index 와 같은 컴포넌트에 더해 훅 7종 전부와 `DateTimePicker.Presets` 를 싣는다.
+원래 둘이 같은 20KB 를 썼는데, 그러면 **코드를 더 많이 싣는 쪽이 여유가 더 적어져**
+index 가 1.4KB 씩 남는 동안 headless 가 200B 미만에서 먼저 막히는 상태가 됐다.
+2026-08 에 headless 만 22KB 로 올린 이유가 이것이다. 기본 엔트리 20KB 는 공개 수치라 그대로다.
 
 게이트 대상은 **네 아티팩트 전부**(`dist/index.js`·`index.cjs`·`headless.js`·`headless.cjs`)이며
 단일 소스는 `scripts/bundle-policy.js` 다. `tsup` 의 `onSuccess` 가 초과 시 **throw** 하므로

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -30,7 +30,7 @@ pnpm lint
 # 빌드 성공 확인
 pnpm build
 
-# 번들 크기 확인 (20KB 기준)
+# 번들 크기 확인 (index 20KB / headless 22KB 기준)
 # /check-bundle 커맨드 실행
 ```
 
@@ -77,7 +77,7 @@ git tag -a "v$(node -p "require('./packages/react/package.json').version")" \
 ### 4. 릴리즈 체크리스트
 
 - [ ] 모든 테스트 통과
-- [ ] 번들 크기 20KB 이하
+- [ ] 번들 크기: index 20KB 이하 / headless 22KB 이하
 - [ ] CHANGELOG.md 업데이트
 - [ ] package.json 버전 범프
 - [ ] 새 공개 API의 JSDoc 주석 있음

--- a/.claude/skills/ci-cd.md
+++ b/.claude/skills/ci-cd.md
@@ -25,7 +25,7 @@ Push to PR branch
   ├── lint
   ├── test (커버리지 포함)
   ├── build
-  └── bundle-size (20KB 게이팅)
+  └── bundle-size (index 20KB / headless 22KB 게이팅)
 
 PR merge to main
     ↓
@@ -149,8 +149,8 @@ jobs:
         with:
           name: dist-${{ github.run_id }}
           path: packages/react/dist/
-      # 측정·게이팅은 scripts/bundle-policy.js의 20KB 정책을 공유 (B-R1).
-      # 스크립트가 kb_esm/kb_cjs 를 $GITHUB_OUTPUT 에 기록하고, 20KB 초과 시 exit 1.
+      # 측정·게이팅은 scripts/bundle-policy.js의 정책을 공유 (B-R1, index 20KB / headless 22KB).
+      # 스크립트가 kb_esm/kb_cjs 를 $GITHUB_OUTPUT 에 기록하고, 천장 초과 시 exit 1.
       - name: 크기 측정 및 판정
         id: check
         run: node scripts/check-bundle-size.js
@@ -437,7 +437,7 @@ Branch name pattern: main
    - lint
    - test (Node 22)
    - build
-   - Bundle Size Check (≤20KB)
+   - Bundle Size Check (index ≤20KB / headless ≤22KB)
    - All Checks Pass
 
 ✅ Require branches to be up to date before merging

--- a/.claude/skills/oss-references.md
+++ b/.claude/skills/oss-references.md
@@ -19,7 +19,7 @@ triggers:
 |---|---|
 | `engineering/monorepo-navigator` | pnpm workspace 설정, 패키지 의존성 그래프, Turborepo 없이 모노레포 관리 |
 | `engineering/dependency-auditor` | `date-fns`, `@floating-ui` 등 의존성 감사, 라이선스 확인 |
-| `engineering/performance-profiler` | 번들 크기 분석, tree-shaking 검증, 20KB 목표 달성 확인 |
+| `engineering/performance-profiler` | 번들 크기 분석, tree-shaking 검증, 천장(index 20KB / headless 22KB) 달성 확인 |
 | `engineering/release-manager` | semantic version 결정, npm publish 워크플로우 |
 | `engineering/changelog-generator` | Conventional Commits → CHANGELOG 자동 생성 |
 
@@ -72,7 +72,7 @@ cp -r claude-skills/engineering/api-design-reviewer ~/.claude/skills/
 
 ## 주요 스킬 활용 시나리오
 
-### 시나리오 1: 번들 크기가 20KB를 초과했다
+### 시나리오 1: 번들 크기가 천장(index 20KB / headless 22KB)을 초과했다
 
 ```
 1. performance-profiler 스킬 활용

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] `pnpm lint` passes
 - [ ] `pnpm test:run` passes
 - [ ] `pnpm build` succeeds
-- [ ] Bundle size checked (`pnpm check-bundle` — all four artifacts ≤ 20 KB gzip)
+- [ ] Bundle size checked (`pnpm check-bundle` — default entry ≤ 20 KB, headless ≤ 22 KB gzip)
 - [ ] Changeset added (if public API changed)
 - [ ] New public APIs have JSDoc comments
 - [ ] Accessibility: axe passes, keyboard navigation works

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,9 @@ jobs:
       - name: 번들 크기 확인
         # Single source of truth for the gzip ceiling + measurement:
         # scripts/check-bundle-size.js + bundle-policy.js — the same default and
-        # headless gates pr-check.yml and tsup use. Avoids stale inline limits
-        # after the ceiling was raised to 20KB (2026-08 timezone/constraint correctness breadth).
+        # headless gates pr-check.yml and tsup use. Avoids stale inline limits —
+        # the two entries no longer share a number (default 20KB, headless 22KB),
+        # so anything hardcoded here would be wrong for half the artifacts.
         run: node scripts/check-bundle-size.js
 
       - name: Changeset 검증 (ignored/publishable 혼합 차단)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@
 - **React Aria**: 기능 완전하지만 복잡하고, `@internationalized/date` 의존 강제 (date-fns 비호환).
 - **Headless UI**: DatePicker 구현 거부 ("유지보수가 너무 큼").
 
-**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 20KB
+**우리가 채우는 공백:** Headless + Input·Calendar·TimePicker·RangePicker 통합 + date-fns 호환 + SSR 안전 + ≤ 20KB (기본 엔트리)
 
 ### 포지셔닝
 
@@ -69,7 +69,7 @@ Ark UI가 포기한 TimePicker 통합
 | 스타일링 | Zero CSS (Headless) | CSS 충돌 원천 차단 |
 | 날짜 코어 | Adapter 패턴 — `@kalyx/adapter-date-fns` 기본 (분리 완료), `@kalyx/adapter-dayjs`·`@kalyx/adapter-luxon` 공식 어댑터 npm 배포됨 | Temporal API 전환 대비, 사용자가 dayjs/luxon 선택 가능 |
 | 포지셔닝 | Floating UI | 3KB, SSR 안전, Popper.js 후계자 |
-| 번들 목표 | **≤ 20KB gzip** | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향, v1.0-rc.8 TimePicker `filterTime` 프로그래밍 콜백 추가하면서 15 → 16KB 상향, v1.1 B10 a11y announce() 패리티(A-G1 — DatePicker/DateTimePicker Root live-region) 추가하면서 16 → 17KB 상향, 2026-08 timezone/constraint 정확성 전면 수정(negative-offset 셀 배치 P0 + 전 mutation 경계 parity)으로 17 → 20KB 상향 — 정확성 우선 결정 |
+| 번들 목표 | **기본 엔트리 ≤ 20KB gzip · `/headless` ≤ 22KB** (단일 소스 `scripts/bundle-policy.js`) | react-datepicker 62KB 대비. RC 단계 12 → 13KB 상향(commit e93d082), v1.0-rc.3 grid 키보드 내비게이션 추가하면서 13 → 14KB 상향, v1.0-rc.4 MonthPicker/YearPicker disabled month/year 추가하면서 14 → 15KB 상향, v1.0-rc.8 TimePicker `filterTime` 프로그래밍 콜백 추가하면서 15 → 16KB 상향, v1.1 B10 a11y announce() 패리티(A-G1 — DatePicker/DateTimePicker Root live-region) 추가하면서 16 → 17KB 상향, 2026-08 timezone/constraint 정확성 전면 수정(negative-offset 셀 배치 P0 + 전 mutation 경계 parity)으로 17 → 20KB 상향 — 정확성 우선 결정. 2026-08 **`/headless` 만 20 → 22KB 분리** — headless 는 index 와 같은 컴포넌트에 훅 7종 전부 + `DateTimePicker.Presets` 를 더 싣는데 천장이 같아서, 코드를 더 많이 싣는 쪽의 여유가 더 적은 역전이 있었다(index 1.4KB 남을 때 headless 200B 미만). 기본 엔트리 20KB 는 공개 수치라 불변 |
 | 테스트 | Vitest + Testing Library + jest-axe | |
 | 빌드 | tsup (ESM + CJS 이중 출력) | |
 | 모노레포 | pnpm workspaces | |
@@ -140,22 +140,48 @@ useEffect(() => {                         // 클라이언트에서만
 }, []);
 ```
 
-### 원칙 3: 날짜 값 = ISO 8601 UTC string
+### 원칙 3: 날짜 값 = ISO 8601 UTC string (**instant**, 캘린더 좌표 아님)
 
 ```tsx
 // 모든 날짜의 입출력은 이 형식으로만
 type ISODateString = string; // "2026-01-15T00:00:00.000Z"
 
-// ✅ 올바른 props
+// ✅ displayTimezone 없음 — UTC 시맨틱, 문자열이 곧 그 날짜
 <DatePicker
-  value="2026-01-15T00:00:00.000Z"  // 항상 UTC ISO string
-  displayTimezone="Asia/Seoul"       // 표시 timezone 분리
+  value="2026-01-15T00:00:00.000Z"
   onChange={(iso: string | null) => save(iso)}  // 항상 UTC 반환
 />
 
 // ❌ 금지
 <DatePicker value={new Date()} />   // native Date 객체
 ```
+
+**`displayTimezone` 을 켜면 값은 "instant" 다.** ISO string 은 *시점*이지 캘린더 좌표가 아니다.
+`"2026-01-15T00:00:00.000Z"` 는 `America/New_York` 에서 **현지 1월 14일 19시**다 — 그래서 이 값을
+`value` 로 주면 캘린더가 14일을 하이라이트한다. **이건 버그가 아니라 정확한 동작이다.**
+
+```tsx
+// ❌ 손으로 만든 UTC 좌표 — displayTimezone 아래에서는 네가 타이핑한 날짜가 아니다
+<DatePicker value="2026-01-15T00:00:00.000Z" displayTimezone="America/New_York" />
+
+// ✅ 피커가 스스로 내보낼 수 있었던 값을 넘긴다
+<DatePicker
+  value={civilMidnightFromUtcDay('2026-01-15T00:00:00.000Z', 'America/New_York')}
+  displayTimezone="America/New_York"
+  onChange={save}   // 이후로는 onChange 가 준 값을 그대로 되돌려주면 된다
+/>
+```
+
+같은 규칙이 `disabled` 의 `{date}`·`{before}`·`{after}` 와 `isDateDisabled` 인자에도 적용된다.
+반대 방향 변환은 `calendarDayFromInstant(instant, zone)` 다.
+
+> **왜 라이브러리가 알아서 정규화해 주지 않는가 (2026-08 결정, 실측 근거):**
+> `"…T00:00:00.000Z"` 하나만 보고 그게 좌표인지 instant 인지 구분할 방법이 없다.
+> Root 에서 inbound 정규화를 하면 **양수 offset 존에서 controlled 값이 렌더마다 하루씩 뒤로 밀린다**
+> (`civilMidnightFromUtcDay` 가 멱등이 아니다 — Seoul: 1/15 → 1/14 → 1/13 → 1/12).
+> 멱등인 `startOfDayInTimezone` 은 반대로 결함을 못 고친다. 둘 다 만족하는 변환은 존재하지 않으므로
+> **계약을 instant 로 고정**했다. 사용자 문서는 `concepts/timezone.md`·`troubleshooting.md`·
+> `components/datepicker.md` 에 이미 노출돼 있다.
 
 ### 원칙 4: Dot Notation (Object.assign 패턴)
 
@@ -255,7 +281,7 @@ kalyx/
 │   ├── docs/                         ← 데모 사이트 (Next.js, 정적 빌드)
 │   └── docs-site/                    ← 문서 사이트 (Docusaurus, i18n)
 ├── scripts/
-│   ├── bundle-policy.js              ← React gzip 제한 단일 소스 (20KB, checker·tsup이 공유)
+│   ├── bundle-policy.js              ← React gzip 제한 단일 소스 (index 20KB / headless 22KB, checker·tsup이 공유)
 │   ├── check-bundle-size.js          ← 공유 정책 기반 번들 크기 측정·게이팅
 │   └── check-tree-shaking.js         ← tree-shaking 검증
 ├── test/
@@ -512,7 +538,7 @@ PR 열기 전 확인:
 | 커맨드 | 설명 |
 |---|---|
 | `/new-component` | 새 서브 컴포넌트 스캐폴딩 (컴포넌트·타입·테스트 파일 생성) |
-| `/check-bundle` | 빌드 후 번들 크기 측정, 20KB 초과 시 실패 (네 아티팩트 전부: index ESM/CJS + headless ESM/CJS) |
+| `/check-bundle` | 빌드 후 번들 크기 측정, 천장 초과 시 실패 (index ESM/CJS 20KB · headless ESM/CJS 22KB) |
 | `/check-a11y` | axe 자동 검사 + ARIA 수동 체크리스트 |
 | `/release` | Changesets 기반 버전 범프·CHANGELOG·npm 배포 가이드 |
 
@@ -761,7 +787,7 @@ audit 결함 카탈로그 기준. 공개 API 변경 없음, 번들 50바이트 �
 □ 접근성 기준을 만족하는가? (axe 통과)
 □ 테스트가 작성됐는가? (커버리지 기준 충족)
 □ JSDoc 주석이 있는가? (공개 API)
-□ 번들에 불필요한 의존성을 추가하지 않았는가? (20KB gzip ceiling)
+□ 번들에 불필요한 의존성을 추가하지 않았는가? (기본 20KB / headless 22KB gzip ceiling)
 □ 내부 구현이 index.ts에 실수로 export되지 않았는가?
 □ changeset 파일을 추가했는가? (공개 API 변경 시 필수)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ pnpm test          # watch mode
 pnpm test:run      # single run (CI)
 pnpm typecheck     # tsc -b
 pnpm lint          # eslint
-pnpm check-bundle  # gzip size check (≤ 20 KB)
+pnpm check-bundle  # gzip size check (default ≤ 20 KB, headless ≤ 22 KB)
 ```
 
 ### Branch Naming
@@ -104,13 +104,13 @@ Before opening a PR, verify:
 - [ ] `pnpm lint` passes
 - [ ] `pnpm test:run` passes
 - [ ] `pnpm build` succeeds
-- [ ] `pnpm check-bundle` — bundle ≤ 20 KB gzip
+- [ ] `pnpm check-bundle` — default entry ≤ 20 KB, headless ≤ 22 KB gzip
 - [ ] Changeset added if public API changed (`pnpm changeset`)
 - [ ] New public APIs have JSDoc comments
 
 ## Bundle Size
 
-The gzip target is **≤ 20 KB** for `@kalyx/react`. Check with:
+The gzip target for `@kalyx/react` is **≤ 20 KB** on the default entry and **≤ 22 KB** on `/headless`, which ships the extra hooks. `scripts/bundle-policy.js` is the single source. Check with:
 
 ```bash
 pnpm build && pnpm check-bundle

--- a/README.ko.md
+++ b/README.ko.md
@@ -105,7 +105,7 @@ API 레퍼런스, 레시피 (Tailwind / shadcn / React Hook Form), 마이그레�
 
 ## 번들
 
-`@kalyx/react` → gzip **약 18.5 KB**. 기본 및 headless ESM/CJS 산출물의 CI 한계는 각각 20 KB입니다.
+`@kalyx/react` → gzip **약 18.5 KB**. CI 한계는 기본 엔트리(ESM+CJS)가 20 KB, 더 큰 headless 엔트리가 별도로 22 KB 입니다.
 
 ## 지원 환경
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Recorded from the [live playground](https://kalyx-docs-site.vercel.app/playgroun
 
 ## Bundle
 
-`@kalyx/react` → **~18.5 KB** gzip. CI gate: ≤ 20 KB for default and headless ESM/CJS artifacts.
+`@kalyx/react` → **~18.5 KB** gzip. CI gate: ≤ 20 KB for the default entry (ESM + CJS); the larger headless entry is gated separately at ≤ 22 KB.
 
 ## Browser support
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@ live on npm and publish hands-off via **npm Trusted Publishing (OIDC)**.
 1. PRs land on `main` with a `.changeset/*.md` entry.
 2. `release.yml` (on every `main` push) first runs the pre-flight gates:
    build → full test run → bundle-size gate (`scripts/check-bundle-size.js`,
-   ceiling 20 KB gzip) → **`scripts/verify-changesets.mjs`**, which fails fast
+   ceiling 20 KB gzip on the default entry, 22 KB on headless) → **`scripts/verify-changesets.mjs`**, which fails fast
    if any changeset mixes ignored packages (`docs`, `@kalyx-example/*`) with
    publishable ones (that mix would abort `changeset publish` midway).
 3. It then runs `changeset version`, opening/updating the

--- a/apps/docs-site/docs/api/react.md
+++ b/apps/docs-site/docs/api/react.md
@@ -212,7 +212,7 @@ non-default backend): `@kalyx/adapter-dayjs`, `@kalyx/adapter-luxon`.
 
 ## Bundle size
 
-Gzipped default-entry artifact: **~18.5 KB** (7 components, CI ceiling 20 KB). The headless ESM and CJS artifacts have their own 20 KB CI gate.
+Gzipped default-entry artifact: **~18.5 KB** (7 components, CI ceiling 20 KB). The headless ESM and CJS artifacts have their own CI gate at 22 KB — that entry ships the same components plus all seven hooks and `DateTimePicker.Presets`, so it is budgeted separately rather than sharing the default entry's number.
 
 That figure measures the artifact with its dependencies external. What your application ships is larger, because the bundler also resolves `@kalyx/core`, `@kalyx/adapter-date-fns`, and `@floating-ui/react` — the repository's consumer harness measures **~24 KB** gzipped. `sideEffects: false` is declared, but that harness does not demonstrate per-picker elimination from the root entry, so importing one picker costs about the same as importing all seven. Measure your production bundle for your exact imports, and see [Troubleshooting → bundle size](../troubleshooting.md#bundle-size-seems-larger-than-expected) for the full reconciliation.
 

--- a/apps/docs-site/docs/troubleshooting.md
+++ b/apps/docs-site/docs/troubleshooting.md
@@ -230,7 +230,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 You will see two different numbers, and both are correct — they measure different things.
 
-**~18.5 KB is the published artifact.** That is what the badge and the CI ceiling track: the gzipped size of `@kalyx/react`'s own `dist/index.js`, with its dependencies left external. It is the number Kalyx controls and gates on (20 KB, enforced across all four artifacts — `index` and `headless`, ESM and CJS).
+**~18.5 KB is the published artifact.** That is what the badge and the CI ceiling track: the gzipped size of `@kalyx/react`'s own `dist/index.js`, with its dependencies left external. It is the number Kalyx controls and gates on: 20 KB for the default entry in both ESM and CJS. The opt-in `headless` entry is gated separately at 22 KB, since it ships the same components plus all seven hooks.
 
 **~24 KB is what a consumer actually ships.** Your bundler resolves the dependencies the artifact only references, so the graph also pulls in `@kalyx/core`, `@kalyx/adapter-date-fns` (and the date-fns functions it uses), and `@floating-ui/react`. Run `pnpm check-tree-shaking` in this repository to see the measured scenarios — currently ~24.0 KB gzipped for a single picker and ~25.0 KB for all seven plus the hooks.
 

--- a/apps/docs-site/i18n/ko/code.json
+++ b/apps/docs-site/i18n/ko/code.json
@@ -60,7 +60,7 @@
     "description": "FeatureGrid: 번들 카드 제목"
   },
   "home.featureGrid.bundle.body": {
-    "message": "7종 picker + hook + date-fns 어댑터 전부 포함. 기본 및 headless 산출물에 각각 20 KB CI 한계를 적용합니다.",
+    "message": "7종 picker + hook + date-fns 어댑터 전부 포함. 기본 엔트리에 20 KB CI 한계를, 더 큰 headless 엔트리에는 별도로 22 KB 한계를 적용합니다.",
     "description": "FeatureGrid: 번들 카드 본문"
   },
   "home.sameJsx.eyebrow": {

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/api/react.md
@@ -207,7 +207,7 @@ Peer 의존성: `react ^19.0.0`, `react-dom ^19.0.0`.
 
 ## 번들 크기
 
-기본 엔트리 산출물은 gzip 기준 **약 18.5 KB**입니다(컴포넌트 7종, CI 한계 20 KB). Headless ESM/CJS 산출물에도 별도의 20 KB CI 게이트가 적용됩니다.
+기본 엔트리 산출물은 gzip 기준 **약 18.5 KB**입니다(컴포넌트 7종, CI 한계 20 KB). Headless ESM/CJS 산출물에는 별도의 22 KB CI 게이트가 적용됩니다 — 이 엔트리는 같은 컴포넌트에 더해 훅 7종 전부와 `DateTimePicker.Presets`까지 싣기 때문에, 기본 엔트리의 수치를 공유하지 않고 따로 예산을 잡습니다.
 
 이 수치는 의존성을 external 로 둔 **산출물** 기준입니다. 애플리케이션이 실제로 배포하는 크기는 더 큽니다 — 번들러가 `@kalyx/core`·`@kalyx/adapter-date-fns`·`@floating-ui/react` 까지 해석하기 때문이며, 이 저장소의 소비자 하네스 실측은 **약 24 KB** gzip 입니다. `sideEffects: false`를 선언하지만 그 하네스는 루트 엔트리에서 picker별 제거를 입증하지 못합니다 — 피커 하나만 import 해도 7종 전부와 비용이 거의 같습니다. 실제 import 조합은 프로덕션 번들에서 직접 측정하시고, 전체 설명은 [트러블슈팅 → 번들 크기](../troubleshooting.md#번들-크기가-예상보다-큽니다)를 참고하세요.
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/troubleshooting.md
@@ -230,7 +230,7 @@ const DISABLED = [{ dayOfWeek: [0, 6] }] as const;
 
 서로 다른 두 숫자를 보게 되는데, 둘 다 맞습니다 — 재는 대상이 다릅니다.
 
-**~18.5 KB 는 배포된 아티팩트입니다.** 배지와 CI 게이트가 추적하는 값으로, 의존성을 external 로 둔 `@kalyx/react` 자체 `dist/index.js` 의 gzip 크기입니다. Kalyx 가 직접 통제하고 게이팅하는 수치입니다(20 KB, 네 아티팩트 전부 — `index`·`headless` × ESM·CJS).
+**~18.5 KB 는 배포된 아티팩트입니다.** 배지와 CI 게이트가 추적하는 값으로, 의존성을 external 로 둔 `@kalyx/react` 자체 `dist/index.js` 의 gzip 크기입니다. Kalyx 가 직접 통제하고 게이팅하는 수치입니다 — 기본 엔트리는 ESM·CJS 모두 20 KB 입니다. 선택적으로 쓰는 `headless` 엔트리는 같은 컴포넌트에 훅 7종까지 싣기 때문에 22 KB 로 따로 게이팅합니다.
 
 **~24 KB 는 소비자가 실제로 배포하는 크기입니다.** 아티팩트가 참조만 하던 의존성을 번들러가 해석하므로, 그래프에 `@kalyx/core`·`@kalyx/adapter-date-fns`(및 거기서 쓰는 date-fns 함수들)·`@floating-ui/react` 가 함께 들어옵니다. 이 저장소에서 `pnpm check-tree-shaking` 을 돌리면 실측 시나리오를 볼 수 있습니다 — 현재 피커 하나 기준 약 24.0 KB gzip, 7종 전부 + 훅 기준 약 25.0 KB 입니다.
 

--- a/apps/docs-site/src/components/FeatureGrid/__tests__/FeatureGrid.test.tsx
+++ b/apps/docs-site/src/components/FeatureGrid/__tests__/FeatureGrid.test.tsx
@@ -25,9 +25,13 @@ describe('<FeatureGrid>', () => {
   it('describes the bundle using the enforced ceiling, not a stale competitor ratio', () => {
     const bundle = FEATURES.find((feature) => feature.id === 'bundle');
 
+    // The headline tracks the default entry — what `import from '@kalyx/react'`
+    // costs — which is the 20 KB gate. The opt-in headless entry has a separate,
+    // larger ceiling and the body must name both rather than implying one number.
     expect(bundle?.titleDefault).toBe('≤20 KB gzipped');
-    expect(bundle?.bodyDefault).toContain('Default and headless artifacts');
     expect(bundle?.bodyDefault).toContain('20 KB CI ceiling');
+    expect(bundle?.bodyDefault).toContain('headless entry has its own at 22 KB');
+    expect(bundle?.bodyDefault).not.toContain('Default and headless artifacts each');
     expect(bundle?.bodyDefault).not.toContain('quarter of react-datepicker');
   });
 

--- a/apps/docs-site/src/components/FeatureGrid/data.ts
+++ b/apps/docs-site/src/components/FeatureGrid/data.ts
@@ -44,6 +44,6 @@ export const FEATURES: readonly Feature[] = [
     titleDefault: '≤20 KB gzipped',
     bodyId: 'home.featureGrid.bundle.body',
     bodyDefault:
-      'All seven pickers + hooks + the date-fns adapter. Default and headless artifacts each have an explicit 20 KB CI ceiling.',
+      'All seven pickers + hooks + the date-fns adapter. The default entry has an explicit 20 KB CI ceiling; the larger headless entry has its own at 22 KB.',
   },
 ] as const;

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -56,6 +56,6 @@ src/
 ## 빌드
 
 ```bash
-pnpm --filter @kalyx/react build     # tsup: ESM + CJS + DTS (번들 목표 ≤20KB — scripts/check-bundle-size.js TARGET_KB 단일 소스)
+pnpm --filter @kalyx/react build     # tsup: ESM + CJS + DTS (번들 목표: index ≤20KB / headless ≤22KB — scripts/bundle-policy.js 단일 소스)
 pnpm --filter @kalyx/react typecheck
 ```

--- a/packages/react/src/components/MonthPicker/Grid.tsx
+++ b/packages/react/src/components/MonthPicker/Grid.tsx
@@ -79,9 +79,15 @@ export function MonthPickerGrid({ classNames, ...props }: MonthPickerGridProps) 
     () =>
       Array.from({ length: 12 }, (_, i) => {
         const monthStart = new Date(Date.UTC(currentYear, i, 1)).toISOString();
-        return isRangeFullyDisabled(monthStart, adapter.endOfMonth(monthStart), disabled, adapter);
+        return isRangeFullyDisabled(
+          monthStart,
+          adapter.addMonths(monthStart, 1),
+          disabled,
+          adapter,
+          displayTimezone,
+        );
       }),
-    [currentYear, disabled, adapter],
+    [currentYear, disabled, adapter, displayTimezone],
   );
 
   const navigateYear = useCallback(

--- a/packages/react/src/components/YearPicker/Grid.tsx
+++ b/packages/react/src/components/YearPicker/Grid.tsx
@@ -78,10 +78,10 @@ export function YearPickerGrid({ classNames, ...props }: YearPickerGridProps) {
       Array.from({ length: 12 }, (_, i) => {
         const year = decadeStart + i;
         const yearStart = new Date(Date.UTC(year, 0, 1)).toISOString();
-        const yearEnd = new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999)).toISOString();
-        return isRangeFullyDisabled(yearStart, yearEnd, disabled, adapter);
+        const nextYearStart = new Date(Date.UTC(year + 1, 0, 1)).toISOString();
+        return isRangeFullyDisabled(yearStart, nextYearStart, disabled, adapter, displayTimezone);
       }),
-    [decadeStart, disabled, adapter],
+    [decadeStart, disabled, adapter, displayTimezone],
   );
 
   const navigateDecade = useCallback(

--- a/packages/react/src/components/_shared/grid-keyboard.test.ts
+++ b/packages/react/src/components/_shared/grid-keyboard.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { civilMidnightFromUtcDay } from '@kalyx/core';
+import { DateFnsAdapter as adapter } from '@kalyx/adapter-date-fns';
+import { isRangeFullyDisabled } from './grid-keyboard.js';
+
+// A month/year cell is "fully disabled" only when a before/after bound excludes
+// every instant in it. The range is half-open: [startInclusive, endExclusive).
+const DEC_2025 = '2025-12-01T00:00:00.000Z';
+const JAN_2026 = '2026-01-01T00:00:00.000Z';
+const FEB_2026 = '2026-02-01T00:00:00.000Z';
+
+describe('isRangeFullyDisabled — UTC semantics (no timezone)', () => {
+  // Locks the path every existing user without `displayTimezone` rides. The
+  // timezone support below is layered on top of this, and must not shift it.
+  it('disables a month whose exclusive end is exactly the bound', () => {
+    expect(isRangeFullyDisabled(DEC_2025, JAN_2026, [{ before: JAN_2026 }], adapter)).toBe(true);
+  });
+
+  it('keeps a month enabled when the bound falls one millisecond inside it', () => {
+    const justInside = '2025-12-31T23:59:59.999Z';
+    expect(isRangeFullyDisabled(DEC_2025, JAN_2026, [{ before: justInside }], adapter)).toBe(false);
+  });
+
+  it('keeps the month containing the bound enabled', () => {
+    expect(
+      isRangeFullyDisabled(JAN_2026, FEB_2026, [{ before: '2026-01-15T00:00:00.000Z' }], adapter),
+    ).toBe(false);
+  });
+
+  it('mirrors the rules for `after`', () => {
+    // February starts after Jan 31, so an `after: Jan 31` bound excludes all of it.
+    expect(
+      isRangeFullyDisabled(
+        FEB_2026,
+        '2026-03-01T00:00:00.000Z',
+        [{ after: '2026-01-31T00:00:00.000Z' }],
+        adapter,
+      ),
+    ).toBe(true);
+    // January itself starts before the bound, so it survives.
+    expect(
+      isRangeFullyDisabled(JAN_2026, FEB_2026, [{ after: '2026-01-31T00:00:00.000Z' }], adapter),
+    ).toBe(false);
+  });
+
+  it('ignores day-granular rules — they never exclude a whole period', () => {
+    expect(
+      isRangeFullyDisabled(
+        DEC_2025,
+        JAN_2026,
+        [{ date: DEC_2025 }, { dayOfWeek: [0, 1, 2, 3, 4, 5, 6] }],
+        adapter,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isRangeFullyDisabled — displayTimezone', () => {
+  // Reproduction of record, from the #193 review. Under a large positive offset
+  // the cell's civil range sits ~14h earlier than its UTC coordinates, so
+  // comparing UTC coordinates against a civil-midnight bound left December 2025
+  // enabled even though every instant in it precedes the bound.
+  it('disables a period that is entirely before the bound in a +14 zone', () => {
+    const zone = 'Pacific/Kiritimati';
+    const bound = civilMidnightFromUtcDay(JAN_2026, zone); // 2025-12-31T10:00:00.000Z
+
+    expect(isRangeFullyDisabled(DEC_2025, JAN_2026, [{ before: bound }], adapter, zone)).toBe(true);
+  });
+
+  it('disables a period that is entirely before the bound in a -11 zone', () => {
+    // The opposite sign shifts the boundary the other way; a fix that only
+    // satisfies the positive case skews this one.
+    const zone = 'Pacific/Niue';
+    const bound = civilMidnightFromUtcDay(JAN_2026, zone);
+
+    expect(isRangeFullyDisabled(DEC_2025, JAN_2026, [{ before: bound }], adapter, zone)).toBe(true);
+  });
+
+  it.each(['Pacific/Kiritimati', 'Pacific/Niue', 'Asia/Seoul', 'America/New_York', 'UTC'])(
+    'keeps the period containing the bound enabled in %s',
+    (zone) => {
+      const bound = civilMidnightFromUtcDay('2025-12-15T00:00:00.000Z', zone);
+      expect(isRangeFullyDisabled(DEC_2025, JAN_2026, [{ before: bound }], adapter, zone)).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each(['Pacific/Kiritimati', 'Pacific/Niue', 'Asia/Seoul', 'America/New_York'])(
+    'does not disable the period immediately after the bound in %s',
+    (zone) => {
+      // January must survive a bound at its own civil start — the bound is
+      // inclusive of the period it opens.
+      const bound = civilMidnightFromUtcDay(JAN_2026, zone);
+      expect(isRangeFullyDisabled(JAN_2026, FEB_2026, [{ before: bound }], adapter, zone)).toBe(
+        false,
+      );
+    },
+  );
+
+  it('mirrors `after` across both offset signs', () => {
+    for (const zone of ['Pacific/Kiritimati', 'Pacific/Niue']) {
+      const bound = civilMidnightFromUtcDay('2026-01-31T00:00:00.000Z', zone);
+      // February is wholly after Jan 31 in that zone.
+      expect(
+        isRangeFullyDisabled(
+          FEB_2026,
+          '2026-03-01T00:00:00.000Z',
+          [{ after: bound }],
+          adapter,
+          zone,
+        ),
+      ).toBe(true);
+      // January contains the bound, so it is not wholly after it.
+      expect(isRangeFullyDisabled(JAN_2026, FEB_2026, [{ after: bound }], adapter, zone)).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/packages/react/src/components/_shared/grid-keyboard.ts
+++ b/packages/react/src/components/_shared/grid-keyboard.ts
@@ -1,24 +1,48 @@
 import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
+import { civilMidnightFromUtcDay } from '@kalyx/core';
 import type { DateAdapter, DisabledRule, ISODateString } from '@kalyx/core';
 import type { Direction } from './rtl.js';
 
 /**
- * A range of dates `[start, end]` is "fully disabled" when every day in it is
- * excluded by a `before` or `after` rule. `date` and `dayOfWeek` rules only
- * disable individual days, so they never disable an entire range.
+ * A half-open range `[startInclusive, endExclusive)` is "fully disabled" when
+ * every instant in it is excluded by a `before` or `after` rule. `date` and
+ * `dayOfWeek` rules only disable individual days, so they never disable an
+ * entire range.
  *
- * Used by `MonthPicker.Grid` and `YearPicker.Grid` to mark a whole month or
- * year unselectable when min/max bounds rule it out.
+ * Used by `MonthPicker.Grid` / `YearPicker.Grid` and the matching headless hooks
+ * to mark a whole month or year unselectable when min/max bounds rule it out —
+ * both for the rendered `isDisabled` flag and for the commit guard, so the two
+ * cannot disagree.
+ *
+ * @param endExclusive - Start of the *next* period, not this period's last
+ *   millisecond.
+ * @param timezone - When set, the range is interpreted as civil days in that
+ *   zone rather than UTC coordinates.
  */
 export function isRangeFullyDisabled(
-  start: ISODateString,
-  end: ISODateString,
+  startInclusive: ISODateString,
+  endExclusive: ISODateString,
   rules: DisabledRule[],
   adapter: DateAdapter,
+  timezone?: string,
 ): boolean {
+  // The range is half-open: [startInclusive, endExclusive). Callers pass the start
+  // of the *next* period as the end rather than its last millisecond, so that the
+  // timezone conversion below is a plain civil-midnight lookup on both ends
+  // instead of day arithmetic on a `23:59:59.999` timestamp.
+  //
+  // With a timezone, the cell covers civil days in *that* zone, so both ends are
+  // mapped to the instants those civil midnights correspond to. Comparing raw UTC
+  // coordinates against a civil-midnight bound is what left a fully out-of-range
+  // month enabled under large positive offsets: in Pacific/Kiritimati (+14) the
+  // civil range sits ~14h earlier than its UTC coordinates suggest.
+  const start = timezone ? civilMidnightFromUtcDay(startInclusive, timezone) : startInclusive;
+  const end = timezone ? civilMidnightFromUtcDay(endExclusive, timezone) : endExclusive;
+
   for (const rule of rules) {
-    if ('before' in rule && adapter.isBefore(end, rule.before)) return true;
+    // Every instant in [start, end) precedes `before` exactly when end <= before.
+    if ('before' in rule && !adapter.isAfter(end, rule.before)) return true;
     if ('after' in rule && adapter.isAfter(start, rule.after)) return true;
   }
   return false;

--- a/packages/react/src/hooks/useMonthPicker.test.tsx
+++ b/packages/react/src/hooks/useMonthPicker.test.tsx
@@ -80,9 +80,13 @@ describe('useMonthPicker', () => {
       useMonthPicker({
         defaultValue: APR_2026,
         onChange,
-        // A single-day rule never disables a whole month, so the grid keeps June
-        // selectable — the commit guard must agree rather than being stricter.
-        disabled: [{ date: '2026-06-10T00:00:00.000Z' }, { dayOfWeek: [0, 6] }],
+        // The rule lands exactly on the coordinate the grid commits for June
+        // (2026-06-01), so `isDateDisabled` would refuse it. A single-day rule
+        // never disables a whole month, so the grid still renders June as
+        // selectable — and the commit guard must agree rather than being
+        // stricter. This is what makes the test discriminate between
+        // `isRangeFullyDisabled` (correct) and `isDateDisabled` (too strict).
+        disabled: [{ date: '2026-06-01T00:00:00.000Z' }, { dayOfWeek: [0, 1, 6] }],
       }),
     );
     act(() => result.current.open());

--- a/packages/react/src/hooks/useMonthPicker.test.tsx
+++ b/packages/react/src/hooks/useMonthPicker.test.tsx
@@ -54,6 +54,46 @@ describe('useMonthPicker', () => {
     expect(result.current.months[3].isDisabled).toBe(false);
   });
 
+  it('refuses to commit a month the grid reports as disabled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useMonthPicker({
+        value: APR_2026,
+        onChange,
+        disabled: [{ before: '2026-04-01T00:00:00.000Z' }],
+      }),
+    );
+    act(() => result.current.open());
+    // March 2026 is entirely before the bound — the grid marks it disabled.
+    expect(result.current.months[2].isDisabled).toBe(true);
+
+    act(() => result.current.selectMonth(result.current.months[2].isoString));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(result.current.value).toBe(APR_2026);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('still commits a month that is only partially disabled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useMonthPicker({
+        defaultValue: APR_2026,
+        onChange,
+        // A single-day rule never disables a whole month, so the grid keeps June
+        // selectable — the commit guard must agree rather than being stricter.
+        disabled: [{ date: '2026-06-10T00:00:00.000Z' }, { dayOfWeek: [0, 6] }],
+      }),
+    );
+    act(() => result.current.open());
+    expect(result.current.months[5].isDisabled).toBe(false);
+
+    act(() => result.current.selectMonth(result.current.months[5].isoString));
+
+    expect(onChange).toHaveBeenCalledWith('2026-06-01T00:00:00.000Z');
+    expect(result.current.value).toBe('2026-06-01T00:00:00.000Z');
+  });
+
   it('toggles open state', () => {
     const { result } = renderHook(() => useMonthPicker());
     act(() => result.current.toggle());

--- a/packages/react/src/hooks/useMonthPicker.test.tsx
+++ b/packages/react/src/hooks/useMonthPicker.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
+import { civilMidnightFromUtcDay } from '@kalyx/core';
 import { useMonthPicker } from './useMonthPicker.js';
 
 const APR_2026 = '2026-04-15T00:00:00.000Z';
@@ -96,6 +97,37 @@ describe('useMonthPicker', () => {
 
     expect(onChange).toHaveBeenCalledWith('2026-06-01T00:00:00.000Z');
     expect(result.current.value).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  // Reproduction of record from the #193 review: under a large positive offset the
+  // cell's civil range sits ~14h earlier than its UTC coordinates, so comparing raw
+  // UTC coordinates against a civil-midnight bound left a fully out-of-range month
+  // enabled — and therefore committable. Asserted for both offset signs because the
+  // negative case passed by accident before the fix.
+  it.each([
+    ['Pacific/Kiritimati', 'a +14 zone'],
+    ['Pacific/Niue', 'a -11 zone'],
+  ])('respects a displayTimezone-aware bound in %s (%s)', (zone) => {
+    const onChange = vi.fn();
+    const bound = civilMidnightFromUtcDay('2026-01-01T00:00:00.000Z', zone);
+    const { result } = renderHook(() =>
+      useMonthPicker({
+        defaultValue: '2026-03-01T00:00:00.000Z',
+        onChange,
+        displayTimezone: zone,
+        disabled: [{ before: bound }],
+      }),
+    );
+    act(() => result.current.previousYear());
+    // December 2025 is entirely before civil Jan 1 in that zone.
+    expect(result.current.months[11].isDisabled).toBe(true);
+
+    act(() => result.current.selectMonth(result.current.months[11].isoString));
+    expect(onChange).not.toHaveBeenCalled();
+
+    // January 2026 opens exactly at the bound, so it must stay selectable.
+    act(() => result.current.nextYear());
+    expect(result.current.months[0].isDisabled).toBe(false);
   });
 
   it('toggles open state', () => {

--- a/packages/react/src/hooks/useMonthPicker.ts
+++ b/packages/react/src/hooks/useMonthPicker.ts
@@ -103,7 +103,8 @@ export function useMonthPicker(options: UseMonthPickerOptions = {}): UseMonthPic
       // as unselectable cannot be committed programmatically either. Deliberately
       // not `isDateDisabled`: a month is disabled only when *fully* excluded, so a
       // day-granular rule must not block the month.
-      if (isRangeFullyDisabled(iso, adapter.endOfMonth(iso), disabled, adapter)) return;
+      if (isRangeFullyDisabled(iso, adapter.addMonths(iso, 1), disabled, adapter, displayTimezone))
+        return;
       const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (!isControlled) setUncontrolledValue(normalized);
       onChange?.(normalized);
@@ -150,13 +151,24 @@ export function useMonthPicker(options: UseMonthPickerOptions = {}): UseMonthPic
           isCurrent: todayYear === viewYear && todayMonth === i,
           isDisabled: isRangeFullyDisabled(
             isoString,
-            adapter.endOfMonth(isoString),
+            adapter.addMonths(isoString, 1),
             disabled,
             adapter,
+            displayTimezone,
           ),
         };
       }),
-    [viewYear, locale, selectedYear, selectedMonth, todayYear, todayMonth, disabled, adapter],
+    [
+      viewYear,
+      locale,
+      selectedYear,
+      selectedMonth,
+      todayYear,
+      todayMonth,
+      disabled,
+      adapter,
+      displayTimezone,
+    ],
   );
 
   return {

--- a/packages/react/src/hooks/useMonthPicker.ts
+++ b/packages/react/src/hooks/useMonthPicker.ts
@@ -99,12 +99,17 @@ export function useMonthPicker(options: UseMonthPickerOptions = {}): UseMonthPic
 
   const selectMonth = useCallback(
     (iso: ISODateString) => {
+      // Same predicate the grid uses for `isDisabled`, so a cell the grid renders
+      // as unselectable cannot be committed programmatically either. Deliberately
+      // not `isDateDisabled`: a month is disabled only when *fully* excluded, so a
+      // day-granular rule must not block the month.
+      if (isRangeFullyDisabled(iso, adapter.endOfMonth(iso), disabled, adapter)) return;
       const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (!isControlled) setUncontrolledValue(normalized);
       onChange?.(normalized);
       setIsOpen(false);
     },
-    [isControlled, onChange, displayTimezone],
+    [isControlled, onChange, displayTimezone, disabled, adapter],
   );
 
   const open = useCallback(() => {

--- a/packages/react/src/hooks/useYearPicker.test.tsx
+++ b/packages/react/src/hooks/useYearPicker.test.tsx
@@ -77,9 +77,13 @@ describe('useYearPicker', () => {
       useYearPicker({
         value: YEAR_2026,
         onChange,
-        // Day-granular rules never disable a whole year, so the grid keeps 2020
-        // selectable — the commit guard must agree rather than being stricter.
-        disabled: [{ date: '2020-06-10T00:00:00.000Z' }, { dayOfWeek: [0, 6] }],
+        // The rule lands exactly on the coordinate the grid commits for 2020
+        // (2020-01-01), so `isDateDisabled` would refuse it. Day-granular rules
+        // never disable a whole year, so the grid still renders 2020 as
+        // selectable — and the commit guard must agree rather than being
+        // stricter. This is what makes the test discriminate between
+        // `isRangeFullyDisabled` (correct) and `isDateDisabled` (too strict).
+        disabled: [{ date: '2020-01-01T00:00:00.000Z' }, { dayOfWeek: [0, 3, 6] }],
       }),
     );
     act(() => result.current.open());

--- a/packages/react/src/hooks/useYearPicker.test.tsx
+++ b/packages/react/src/hooks/useYearPicker.test.tsx
@@ -51,4 +51,43 @@ describe('useYearPicker', () => {
     expect(result.current.years[4].year).toBe(2020);
     expect(result.current.years[4].isDisabled).toBe(false);
   });
+
+  it('refuses to commit a year the grid reports as disabled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useYearPicker({
+        value: YEAR_2026,
+        onChange,
+        disabled: [{ before: '2020-01-01T00:00:00.000Z' }],
+      }),
+    );
+    act(() => result.current.open());
+    expect(result.current.years[3].isDisabled).toBe(true);
+
+    act(() => result.current.selectYear(result.current.years[3].isoString));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(result.current.value).toBe(YEAR_2026);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('still commits a year that is only partially disabled', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useYearPicker({
+        value: YEAR_2026,
+        onChange,
+        // Day-granular rules never disable a whole year, so the grid keeps 2020
+        // selectable — the commit guard must agree rather than being stricter.
+        disabled: [{ date: '2020-06-10T00:00:00.000Z' }, { dayOfWeek: [0, 6] }],
+      }),
+    );
+    act(() => result.current.open());
+    expect(result.current.years[4].isDisabled).toBe(false);
+
+    act(() => result.current.selectYear(result.current.years[4].isoString));
+
+    expect(onChange).toHaveBeenCalledWith(result.current.years[4].isoString);
+    expect(result.current.isOpen).toBe(false);
+  });
 });

--- a/packages/react/src/hooks/useYearPicker.ts
+++ b/packages/react/src/hooks/useYearPicker.ts
@@ -96,10 +96,8 @@ export function useYearPicker(options: UseYearPickerOptions = {}): UseYearPicker
       // as unselectable cannot be committed programmatically either. Deliberately
       // not `isDateDisabled`: a year is disabled only when *fully* excluded, so a
       // day-granular rule must not block the year.
-      const yearEnd = new Date(
-        Date.UTC(adapter.getYear(iso), 11, 31, 23, 59, 59, 999),
-      ).toISOString();
-      if (isRangeFullyDisabled(iso, yearEnd, disabled, adapter)) return;
+      const nextYearStart = new Date(Date.UTC(adapter.getYear(iso) + 1, 0, 1)).toISOString();
+      if (isRangeFullyDisabled(iso, nextYearStart, disabled, adapter, displayTimezone)) return;
       const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (!isControlled) setUncontrolledValue(normalized);
       onChange?.(normalized);
@@ -137,16 +135,22 @@ export function useYearPicker(options: UseYearPickerOptions = {}): UseYearPicker
       Array.from({ length: 12 }, (_, i) => {
         const year = decadeStart + i;
         const isoString = new Date(Date.UTC(year, 0, 1)).toISOString();
-        const yearEnd = new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999)).toISOString();
+        const nextYearStart = new Date(Date.UTC(year + 1, 0, 1)).toISOString();
         return {
           isoString,
           year,
           isSelected: year === selectedYear,
           isCurrent: year === todayYear,
-          isDisabled: isRangeFullyDisabled(isoString, yearEnd, disabled, adapter),
+          isDisabled: isRangeFullyDisabled(
+            isoString,
+            nextYearStart,
+            disabled,
+            adapter,
+            displayTimezone,
+          ),
         };
       }),
-    [decadeStart, selectedYear, todayYear, disabled, adapter],
+    [decadeStart, selectedYear, todayYear, disabled, adapter, displayTimezone],
   );
 
   return {

--- a/packages/react/src/hooks/useYearPicker.ts
+++ b/packages/react/src/hooks/useYearPicker.ts
@@ -92,12 +92,20 @@ export function useYearPicker(options: UseYearPickerOptions = {}): UseYearPicker
 
   const selectYear = useCallback(
     (iso: ISODateString) => {
+      // Same predicate the grid uses for `isDisabled`, so a cell the grid renders
+      // as unselectable cannot be committed programmatically either. Deliberately
+      // not `isDateDisabled`: a year is disabled only when *fully* excluded, so a
+      // day-granular rule must not block the year.
+      const yearEnd = new Date(
+        Date.UTC(adapter.getYear(iso), 11, 31, 23, 59, 59, 999),
+      ).toISOString();
+      if (isRangeFullyDisabled(iso, yearEnd, disabled, adapter)) return;
       const normalized = displayTimezone ? civilMidnightFromUtcDay(iso, displayTimezone) : iso;
       if (!isControlled) setUncontrolledValue(normalized);
       onChange?.(normalized);
       setIsOpen(false);
     },
-    [isControlled, onChange, displayTimezone],
+    [isControlled, onChange, displayTimezone, disabled, adapter],
   );
 
   const open = useCallback(() => {

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -34,9 +34,12 @@ export default defineConfig({
 		const { gzipSync } = await import("zlib");
 		const { readFileSync, writeFileSync } = await import("fs");
 		// Mirror scripts/check-bundle-size.js + .github/workflows/pr-check.yml + release.yml.
-		// Raised from 12 → 13 → 14 → 15 → 16 → 17 → 20 KB across milestones as features landed
-		// (CLAUDE.md §2 records each bump's rationale; 17→20 = timezone/constraint correctness breadth).
-		// Both public entries have explicit absolute budgets. Entry-split additionally
+		// Default entry raised 12 → 13 → 14 → 15 → 16 → 17 → 20 KB across milestones as
+		// features landed (CLAUDE.md §2 records each bump's rationale; 17→20 =
+		// timezone/constraint correctness breadth). The headless entry was split off the
+		// same number and raised to 22 KB in 2026-08 — it ships strictly more code than
+		// index, so an equal ceiling made it bind first on every change. See
+		// scripts/bundle-policy.js for the full rationale. Entry-split additionally
 		// verifies that headless does not include date-fns.
 		const outputs = [
 			["ESM index", "dist/index.js", REACT_GZIP_CEILING_KB],

--- a/scripts/__tests__/bundle-policy.test.mjs
+++ b/scripts/__tests__/bundle-policy.test.mjs
@@ -14,9 +14,16 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../..');
 
 describe('React bundle policy', () => {
-  it('keeps the approved ceiling at 20KB', () => {
+  it('keeps the approved ceilings: 20KB default, 22KB headless', () => {
     expect(REACT_GZIP_CEILING_KB).toBe(20);
-    expect(HEADLESS_REACT_GZIP_CEILING_KB).toBe(20);
+    expect(HEADLESS_REACT_GZIP_CEILING_KB).toBe(22);
+  });
+
+  it('gives the entry that ships more code the larger budget', () => {
+    // headless = index surface + 4 extra hooks + DateTimePicker.Presets, so an
+    // equal ceiling would make it bind first on every change. Guards against a
+    // future edit quietly collapsing the two numbers back together.
+    expect(HEADLESS_REACT_GZIP_CEILING_KB).toBeGreaterThan(REACT_GZIP_CEILING_KB);
   });
 
   it('compares raw bytes at the exact boundary without rounding overages down', () => {

--- a/scripts/bundle-policy.js
+++ b/scripts/bundle-policy.js
@@ -1,5 +1,17 @@
+// The two public entries carry different amounts of code, so they get different
+// budgets. `index` exposes 7 components + 3 hooks; `headless` exposes the same 7
+// components plus all 7 hooks and `DateTimePicker.Presets`. They were originally
+// given the same number, which meant the entry shipping strictly more code had
+// strictly less headroom — index sat ~1.5 KB under the line while headless ran
+// out at under 200 B, so headless became the binding constraint on every change
+// even when index was nowhere near its limit.
+//
+// 2026-08: headless 20 → 22 KB, to give the larger entry headroom proportional
+// to the smaller one rather than a number it inherited by accident. The default
+// entry — what `import from '@kalyx/react'` costs, and the figure quoted publicly
+// — is deliberately unchanged at 20 KB.
 export const REACT_GZIP_CEILING_KB = 20;
-export const HEADLESS_REACT_GZIP_CEILING_KB = 20;
+export const HEADLESS_REACT_GZIP_CEILING_KB = 22;
 
 export function isWithinBudget(gzipBytes, ceilingKB) {
   return gzipBytes <= ceilingKB * 1024;


### PR DESCRIPTION
> **Stacked on #192.** Base is `docs/accuracy-sweep-bundle-a`, not `main` — the doc sweep here builds directly on files that PR changes. Merge #192 first, then this retargets to `main` cleanly.

Correctness batch. One behaviour fix, one ceiling policy change, and a contract decision that turned out to require **no runtime change at all** — for a measured reason.

## The headline finding: the planned fix was not implementable

The plan called for normalizing inbound `value` at Root so that `"2026-01-15T00:00:00.000Z"` — the shape our own docs handed people — would select Jan 15 under any `displayTimezone`. Measured, it can't work:

`civilMidnightFromUtcDay` reads its argument's **UTC** Y/M/D and treats it as a calendar coordinate. That's right where it's used today (`selectDate` feeds it a grid cell) but it is **not idempotent on a value that is already an instant**. Normalizing every inbound `value` makes a controlled component walk backward one day per render in positive-offset zones:

```
Asia/Seoul         selected cell over 4 renders: 2026-01-15 -> 2026-01-14 -> 2026-01-13 -> 2026-01-12
Pacific/Auckland   selected cell over 4 renders: 2026-01-15 -> 2026-01-14 -> 2026-01-13 -> 2026-01-12
America/New_York   selected cell over 4 renders: 2026-01-15 -> 2026-01-15 -> 2026-01-15 -> 2026-01-15
```

The idempotent alternative, `startOfDayInTimezone`, fails the other way: it reads the argument as an instant, so raw `…T00:00:00Z` still lands on the 14th in New_York. **No single transform satisfies both**, because one ISO string cannot say whether it is a coordinate or an instant.

And the more important half: **the current behaviour is correct.** `2026-01-15T00:00:00.000Z` genuinely *is* 7pm Jan 14 in New York, so highlighting the 14th is right. The documentation was wrong, not the code — and #192 already fixed the user-facing pages.

So the contract is fixed at **instants**, and three of the four planned items close with no runtime change:

| Item | Outcome |
| --- | --- |
| ISO-string `value` contract | Contract fixed at instants. `CLAUDE.md` §3 rewritten — it was the last place still teaching the broken pattern, showing `value="2026-01-15T00:00:00.000Z"` next to `displayTimezone="Asia/Seoul"`. |
| `{before}` / `{after}` boundary | No change. Under the instant contract the current behaviour is correct; passing a raw UTC coordinate as a bound is the same user error, documented in #192. |
| `isDateDisabled` self-normalization | No change. It cannot self-normalize for the same reason — it can't tell a coordinate from an instant. Documented instead. |
| Month/Year hook commit guards | **Real fix**, below. |

`CLAUDE.md` §3 records the measurement so this isn't re-litigated.

## The one real behaviour fix

`useMonthPicker.selectMonth` and `useYearPicker.selectYear` computed the grid's `isDisabled` flags and then committed without consulting them, so a cell the grid renders as unselectable could still be committed programmatically and fire `onChange`. Only the `/headless` hooks were exposed — `MonthPicker` / `YearPicker` components are `DatePickerRoot`, which already guards.

**Guarded with `isRangeFullyDisabled`, not `isDateDisabled` as originally proposed.** Both grids mark a month or year disabled only when a bound excludes it *entirely*, so `isDateDisabled` would refuse commits the grid shows as enabled — a single `{ date }` or `{ dayOfWeek }` rule would block the whole month. A commit guard has to use the same predicate as the flag it enforces.

TDD, RED confirmed first. Four tests on the invariant "commit agrees with the grid": two refusing a fully-disabled cell, two still committing a partially-disabled one.

The last commit exists because my first version of those two "still commits" tests **did not test what they claimed**. They used a rule that missed the committed coordinate, so both predicates permitted the commit and the tests passed even against the unguarded code. Rules now land exactly on `2026-06-01` / `2020-01-01`, and discrimination is verified by swapping the guard to `isDateDisabled` and watching them go red.

## Ceiling: headless 20 → 22 KB

The two entries carry different code — `index` is 7 components + 3 hooks, `headless` is the same components plus all 7 hooks and `DateTimePicker.Presets` — but shared one number. The entry shipping strictly more code therefore had strictly *less* headroom: index sat ~1.5 KB under the line while headless ran out at under 200 B, so headless bound every change even when index was nowhere near its limit.

**The default entry stays at 20 KB.** That is what `import from '@kalyx/react'` costs and the figure quoted publicly, so it is deliberately untouched. Rationale recorded in `bundle-policy.js` and the `CLAUDE.md` §2 ladder, matching how every prior bump here is documented, plus a test asserting `headless > index` so the two can't quietly collapse back together.

Raising the ceiling without sweeping the claims would reintroduce exactly the defect class #192 removes, so: FeatureGrid card and its test assertion, ko `code.json`, `api/react.md` + `troubleshooting` (EN+KO), both READMEs, PR template, check-bundle bands, `CLAUDE.md` §2/§4/§10/§15, `packages/react/CLAUDE.md`, CONTRIBUTING, RELEASING, the ci-cd / oss-references / release skills, and a stale `release.yml` comment. Marketing headlines reading "≤20 KB" describe the default entry and stay true. `bundle-diff.mjs` derives its ceilings through `BUNDLES`, so the PR margin comment follows automatically — verified rather than assumed.

## Verification

| Check | Result |
| --- | --- |
| `pnpm test:run` | 918 passed / 52 files |
| Guard tests discriminate | verified by swapping in the wrong predicate → RED, restored → green |
| `pnpm typecheck` · `pnpm lint` | pass |
| `pnpm build` | pass |
| Bundle | 18.45 / 18.56 (≤20) · 19.73 / 19.86 (≤22) |
| `check-doc-code-examples` | 46 examples |
| `pnpm --filter docs-site build` | en + ko, zero broken anchors |
| `verify-entry-split` · `verify-changesets` | pass |

Changeset included (`@kalyx/react` patch) — unlike #192, this changes public behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
