### PR TITLE
ci(security): run OSV and license scans on every PR

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,11 +13,21 @@ on:
     paths:
       - '**/package.json'
       - 'pnpm-lock.yaml'
+  # No `paths` filter here, unlike the push trigger above: these two jobs are
+  # required status checks on `main`, and required checks are matched by name.
+  # A path-filtered workflow does not report skipped checks — it reports
+  # nothing at all — so any PR that misses the filter (docs, tests, refactors:
+  # most of them) would sit permanently pending. Both jobs finish in well
+  # under two minutes, so running them unconditionally is cheap.
   pull_request:
-    paths:
-      - '**/package.json'
-      - 'pnpm-lock.yaml'
   workflow_dispatch:
+
+# Force-pushes to a PR branch would otherwise stack independent scan runs that
+# all race to completion; the newest head is the only one a required check is
+# evaluated against. Mirrors pr-check.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   actions: read
@@ -31,6 +41,12 @@ jobs:
     # osv.dev vulnerability database — independent of npm's deprecated
     # audit endpoint that `pnpm audit` still calls.
     name: OSV Vulnerability Scan
+    # ⚠️ This is a required status check on `main`, reported under the composed
+    # name `OSV Vulnerability Scan / osv-scan` — the second half is the job id
+    # *inside* the upstream reusable workflow. The @v2.0.0 pin is therefore
+    # load-bearing: bumping it (or the tag moving) can rename the check and
+    # leave every PR permanently pending. Update the ruleset's required
+    # contexts in the same change as any version bump here.
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.0.0
     with:
       scan-args: |-


### PR DESCRIPTION
Prerequisite for **C-2** of bundle C (governance): promoting the two security jobs to required status checks on `main`.

## Why the filter has to go first

`security.yml`'s `pull_request` trigger was filtered to `**/package.json` and `pnpm-lock.yaml`. A path-filtered workflow does not report a *skipped* check — it reports **no check at all**. Promoting either job to required today would leave every PR that misses the filter (docs, tests, refactors — most of them) permanently pending. Measured on the docs-only PR #192: zero security checks reported.

Cost of running them unconditionally, measured on run `31150229455`:

| job | duration |
|---|---|
| License Compatibility | 37s |
| OSV Vulnerability Scan | 27s |

Under two minutes per PR. Rejected alternatives: an always-running shim job that reports skip-as-success (vacuous pass), and leaving it unrequired (a PR reintroducing a CVE passes green).

## This PR is its own test case

It touches no dependency file. If both checks report below with the names `OSV Vulnerability Scan / osv-scan` and `License Compatibility`, the promotion is safe to make.

## Notes for whoever bumps this next

- **The `@v2.0.0` pin on `google/osv-scanner-action` becomes load-bearing.** The check reports as `OSV Vulnerability Scan / osv-scan` — the second half is the job id *inside* the upstream reusable workflow, not ours. If that tag moves or gets bumped and upstream renames the job, every PR goes permanently pending. Update the ruleset's required contexts in the same change as any bump. Noted in-file too.
- **`osv-scanner` (no prefix) must NOT be made required.** That check-run comes from the SARIF upload, not a job, and can be absent when the upload is skipped or permissions differ.
- **New failure surface.** With `fail-on-vuln: true` and no path filter, a newly published advisory against any pinned dependency now blocks *all* PRs, not just dependency-touching ones. That is the intended trade; `osv-scanner.toml`'s ignore list is currently empty, so nothing is masked and nothing expires.
- **Bot release PRs are unaffected and still need `--admin`.** Their workflow runs conclude `action_required` (approval gate), so these checks never self-report there — already true of the existing nine required checks.

## Verification

- `security.yml` parses; triggers are `schedule`, `push`, `pull_request`, `workflow_dispatch`; job names unchanged.
- `main-protection` ruleset `17387277` backed up before any change; admin `bypass_mode: pull_request` remains, so a mis-promotion is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)