### PR TITLE
chore(react): depend on core and the date-fns adapter with a caret range

### DIFF
--- a/.changeset/loose-pandas-listen.md
+++ b/.changeset/loose-pandas-listen.md
@@ -1,0 +1,9 @@
+---
+'@kalyx/react': patch
+---
+
+Depend on `@kalyx/core` and `@kalyx/adapter-date-fns` with a caret range instead of an exact pin.
+
+Previously these were declared as `workspace:*`, which pnpm substitutes with the exact sibling version at pack time — `@kalyx/react@1.4.3` shipped `"@kalyx/core": "1.4.2"`. A core-only patch could then only reach you by way of a new `@kalyx/react` release. They are now `workspace:^`, so the published range is `^1.4.2` and a core patch is picked up on your next resolve without waiting for a react release.
+
+This cannot install a core older than the one your `@kalyx/react` was built against: the range is stamped at publish time from the sibling's version, so each react release floors core at whatever it shipped alongside.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,6 +56,45 @@ manual, by an authenticated maintainer. Lessons from the dayjs/luxon launches:
    (GitHub Actions · Repository `jiji-hoon96/kalyx` · Workflow `release.yml` ·
    environment empty) so every later release is hands-off.
 
+## Cross-package dependency ranges
+
+Every published package references its workspace siblings with **`workspace:^`**,
+never `workspace:*`. pnpm substitutes the range at pack time:
+
+| protocol in the repo | what lands in the tarball |
+|---|---|
+| `workspace:^` | `^<sibling's version at publish time>` |
+| `workspace:*` | the exact version, e.g. `1.4.2` |
+
+`workspace:*` is not a tighter version of the same thing — it changes who gets
+patches and when. Measured with `pnpm changeset version` against a core-only
+patch changeset:
+
+- With **`workspace:*`**, `@kalyx/react` is pulled in as a dependent so its
+  pinned range can be rewritten, and `linked: [["@kalyx/core","@kalyx/react"]]`
+  aligns both versions. A core patch therefore always forces a react release,
+  and anyone staying on the older react keeps the old core.
+- With **`workspace:^`**, the existing range already satisfies the new version,
+  so react is not released at all and existing installs pick the core patch up
+  on their next resolve.
+
+The floor cannot go stale: `workspace:^` is never rewritten in the repo, so each
+publish stamps that moment's sibling version. A react release that needs a new
+core API is packed alongside it and declares `^<that core version>`, which makes
+an older core uninstallable with it.
+
+Verify after any change here by unpacking the tarball, not by reading
+`package.json`:
+
+```bash
+cd packages/react && pnpm pack --pack-destination /tmp
+tar -xzOf /tmp/kalyx-react-*.tgz package/package.json | jq .dependencies
+```
+
+Workspace refs in `devDependencies` (e.g. `@kalyx/core`'s dev use of
+`@kalyx/adapter-date-fns`) and in the private `examples/*` and `apps/*` packages
+are never published, so their protocol is immaterial.
+
 ## Open follow-ups
 
 - Backfill the `@kalyx/adapter-date-fns@1.0.0` GitHub Release (the 1.0.0 manual

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,8 +70,8 @@
 	},
 	"dependencies": {
 		"@floating-ui/react": "^0.27.0",
-		"@kalyx/adapter-date-fns": "workspace:*",
-		"@kalyx/core": "workspace:*"
+		"@kalyx/adapter-date-fns": "workspace:^",
+		"@kalyx/core": "workspace:^"
 	},
 	"peerDependencies": {
 		"react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,10 +451,10 @@ importers:
         specifier: ^0.27.0
         version: 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@kalyx/adapter-date-fns':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../adapter-date-fns
       '@kalyx/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       react:
         specifier: ^19.0.0


### PR DESCRIPTION
**C-3** of bundle C (governance). Independent of #197 — no overlapping files.

## The handoff's premise was wrong, and it changes what this PR is

The handoff said core-only patches "aren't delivered to react users." Measured with `pnpm changeset version` against a core-only patch changeset, they are — just by a different route:

| react's protocol | result of a core-only patch changeset |
|---|---|
| `workspace:*` (before) | core 1.4.2→**1.4.4**, react 1.4.3→**1.4.4** — react is pulled in as a dependent so its pinned range can be rewritten, then `linked: [core, react]` aligns the two |
| `workspace:^` (after) | core 1.4.2→**1.4.4**, react stays **1.4.3** — `^1.4.2` already satisfies 1.4.4, so react isn't released |

So this is not a bug fix, it's a trade: patches reach existing installs without a react release, at the cost of core patches no longer being signalled by a react version bump or CHANGELOG entry. Chosen deliberately. The adapters already used `workspace:^` and publish `^1.x`; react was the outlier.

## No stale-floor risk

`workspace:^` is never rewritten inside the repo — pnpm stamps the sibling's version at each pack. A react release that needs a new core API is packed alongside it and declares `^<that core version>`, so an older core cannot be installed with it. Confirmed on a joint core-minor + react-patch probe.

## Verification

Checked the tarball, not `package.json`:

```
$ cd packages/react && pnpm pack
$ tar -xzOf kalyx-react-1.4.3.tgz package/package.json | jq .dependencies
{
  "@floating-ui/react": "^0.27.0",
  "@kalyx/adapter-date-fns": "^1.0.1",
  "@kalyx/core": "^1.4.2"
}
```

Previously `"1.0.1"` / `"1.4.2"` (exact). Also:

- `pnpm changeset version` with the included changeset → **react 1.4.4 alone**; core and all three adapters untouched.
- `pnpm install --frozen-lockfile` passes against the regenerated lockfile (2-line specifier diff).

## Scope

Only published `dependencies` are affected. `@kalyx/core`'s dev use of `@kalyx/adapter-date-fns` and the `workspace:*` refs in `examples/*` and `apps/*` are never published, so their protocol is immaterial and left alone.

The policy and the verification command are written into `RELEASING.md` so the next person doesn't re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)