### PR TITLE
docs(security): record which published versions lack provenance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,14 @@
 
 ## Supported versions
 
+Fixes ship forward only — they land in a new release of the affected package
+rather than being backported.
+
 | Version | Supported |
 |---------|-----------|
-| 1.0.0-rc.x | Yes |
-| < 1.0.0 | No |
+| Latest published release of each `@kalyx/*` package | Yes |
+| Any earlier `1.x` | Upgrade to the latest `1.x` |
+| `0.x` and `1.0.0-rc.*` pre-releases | No |
 
 ## Reporting a vulnerability
 
@@ -30,7 +34,50 @@ Kalyx is a client-side UI library. The most relevant security concerns are:
 - **Prototype pollution** through date/option objects
 - **Supply chain** vulnerabilities in dependencies (`date-fns`, `@floating-ui/react`)
 
-We run automated dependency audits weekly via GitHub Actions (`security.yml`).
+We run automated dependency audits weekly via GitHub Actions (`security.yml`),
+plus on pull requests. `osv-scanner` reads `pnpm-lock.yaml` and queries osv.dev;
+a licence check refuses anything outside a permissive allowlist.
+
+## Release integrity (provenance)
+
+Releases are published from CI by `release.yml` over **npm Trusted Publishing
+(OIDC)** with no long-lived token, and all five packages set
+`publishConfig.provenance: true`. Those releases carry a signed SLSA provenance
+attestation binding the tarball to the workflow run and commit that produced it.
+
+Verify a version before trusting it:
+
+```bash
+npm audit signatures                       # verifies what your lockfile resolved
+npm view @kalyx/react@1.4.3 dist.attestations
+```
+
+### Versions published without provenance
+
+Six versions predate the current setup and are **not** attested. They were
+uploaded from a maintainer's machine — every package's first publish must be
+manual, because npm can only attach a Trusted Publisher to a package that
+already exists (see `RELEASING.md`). Nothing is wrong with these tarballs as far
+as we know, but their contents cannot be cryptographically traced to a commit,
+so treat them as unverifiable rather than verified:
+
+| Package | Unsigned versions |
+|---|---|
+| `@kalyx/core` | `0.2.0` |
+| `@kalyx/react` | `0.2.0` |
+| `@kalyx/adapter-date-fns` | `1.0.0-rc.1`, `1.0.0` |
+| `@kalyx/adapter-dayjs` | `0.1.0` |
+| `@kalyx/adapter-luxon` | `0.1.0` |
+
+`@kalyx/adapter-dayjs` and `@kalyx/adapter-luxon` have only ever published
+`0.1.0`, so **every currently released version of those two is unsigned.** Their
+next release is signed — the `publishConfig.provenance` flag and the Trusted
+Publisher registration are both already in place. They are not being republished
+to fix this, because reissuing an identical tarball under a new version number
+would be a change to the version history and not to the artifact.
+
+Everything else, including every `1.x` of `@kalyx/core` and `@kalyx/react` and
+`@kalyx/adapter-date-fns@1.0.1`, is attested.
 
 ## Disclosure
 


### PR DESCRIPTION
**C-4** of bundle C (governance). Independent of #197 and #198 — no overlapping files.

The task here was to *record* the provenance gap, not to close it. No code changes, no version bumps.

## The handoff undercounted

It named `adapter-dayjs@0.1.0` and `adapter-luxon@0.1.0`. Surveying every published version of all five packages with `npm view <pkg>@<v> dist.attestations` turns up **six** unsigned versions:

| Package | Unsigned |
|---|---|
| `@kalyx/core` | `0.2.0` |
| `@kalyx/react` | `0.2.0` |
| `@kalyx/adapter-date-fns` | `1.0.0-rc.1`, `1.0.0` |
| `@kalyx/adapter-dayjs` | `0.1.0` |
| `@kalyx/adapter-luxon` | `0.1.0` |

Everything else — every `1.x` of core and react, and `adapter-date-fns@1.0.1` — is attested.

The sharper framing the handoff missed: dayjs and luxon have only ever published `0.1.0`, so **every currently released version of those two packages is unverifiable.** Anyone installing them today gets an unattested tarball. That is worth stating plainly in SECURITY.md rather than in a spec file.

## Not republishing

Both packages already have `publishConfig.provenance: true` and a registered Trusted Publisher, so their next release is signed. Reissuing an identical tarball under a new version number would change the version history, not the artifact — so no forced bump, per the handoff.

## Also fixed

`## Supported versions` still said `1.0.0-rc.x` was the supported line, which has been wrong since 1.0.0 shipped. Replaced with a forward-only policy that doesn't promise backports nobody intends to make.

## Deliberately not claimed

An earlier draft said the OSV and licence jobs are required status checks on `main`. They are not yet — that is #197 plus a ruleset change. The wording here describes only what is true today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)