### PR TITLE
docs(recipes): use the real AmPmToggle classNames keys

### DIFF
--- a/apps/docs-site/docs/recipes/tailwind.md
+++ b/apps/docs-site/docs/recipes/tailwind.md
@@ -225,8 +225,8 @@ function TailwindTime() {
           <TimePicker.AmPmToggle
             classNames={{
               root: 'flex flex-col gap-1',
-              button: 'rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs',
-              buttonSelected: '!bg-indigo-600 !text-white !border-indigo-600',
+              option: 'rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs',
+              optionSelected: '!bg-indigo-600 !text-white !border-indigo-600',
             }}
           />
         </div>
@@ -257,8 +257,8 @@ function TailwindTime() {
     <TimePicker.AmPmToggle
       classNames={{
         root: 'flex flex-col gap-1',
-        button: 'rounded border px-2 py-1 text-xs',
-        buttonSelected: '!bg-indigo-600 !text-white !border-indigo-600',
+        option: 'rounded border px-2 py-1 text-xs',
+        optionSelected: '!bg-indigo-600 !text-white !border-indigo-600',
       }}
     />
   </div>

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/recipes/tailwind.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/recipes/tailwind.md
@@ -114,8 +114,8 @@ import { DatePicker } from '@kalyx/react';
     <TimePicker.AmPmToggle
       classNames={{
         root: 'flex flex-col gap-1',
-        button: 'rounded border px-2 py-1 text-xs',
-        buttonSelected: '!bg-indigo-600 !text-white !border-indigo-600',
+        option: 'rounded border px-2 py-1 text-xs',
+        optionSelected: '!bg-indigo-600 !text-white !border-indigo-600',
       }}
     />
   </div>

--- a/scripts/check-doc-code-examples.mjs
+++ b/scripts/check-doc-code-examples.mjs
@@ -60,6 +60,7 @@ const EN_ONLY_DOCUMENTS = [
   ['concepts/styling.md', 'KO fence content has drifted from EN'],
   ['concepts/timezone.md', 'KO fence content has drifted from EN'],
   ['recipes/use-cases.md', 'KO fence content has drifted from EN'],
+  ['recipes/tailwind.md', 'KO fence content has drifted from EN'],
 ];
 
 // Not compiled, with the reason each one fails. This list is the difference
@@ -78,9 +79,6 @@ const UNCHECKED_DOCUMENTS = [
   ['components/monthpicker.md', 'DEFECT: `name` on Root — no form-submission support on MonthPicker'],
   ['components/yearpicker.md', 'DEFECT: `name` on Root — no form-submission support on YearPicker'],
   ['components/weekpicker.md', 'DEFECT: `name` on Root — no form-submission support on WeekPicker'],
-  // DEFECT: `classNames={{ button: … }}` on TimePicker.AmPmToggle; the real key
-  // set is TimePickerAmPmToggleClassNames, which has no `button`.
-  ['recipes/tailwind.md', 'DEFECT: unknown `button` key in TimePickerAmPmToggleClassNames'],
   // Anatomy trees render `<DatePicker.Preset />` and `<RangePicker.Preset />`
   // self-closing, but `children` is required on both.
   ['components/datepicker.md', 'anatomy fences self-close components whose `children` is required'],


### PR DESCRIPTION
Fixes one of the `DEFECT` entries the expanded doc-example checker recorded in #200.

The Tailwind recipe styled `TimePicker.AmPmToggle` with `button` / `buttonSelected`. `TimePickerAmPmToggleClassNames` has neither — the keys are `root`, `option`, `optionSelected` — so copying the recipe produced a type error and an unstyled AM/PM control.

With the keys corrected the page compiles clean in **both** locales, so it moves out of `UNCHECKED_DOCUMENTS` into `EN_ONLY_DOCUMENTS`: **97 examples across 13 documents**, up from 94 across 12. It cannot join `CHECKED_DOCUMENTS` yet because the KO fences have drifted from EN at fence 2.

## This PR is also the C-2 verification

It touches **no dependency file**, which is exactly the case that reported zero security checks before the `paths` filter was removed. If `OSV Vulnerability Scan / osv-scan` and `License Compatibility` appear below **and are marked required**, the ruleset promotion is confirmed end to end — required checks match on the name string, and that string could only be verified against a real PR.

## Verification

- `pnpm check-doc-examples` → `✓ Compiled 97 TypeScript examples across 13 documents (26 pages deliberately unchecked)`.
- `scripts/__tests__/check-doc-code-examples.test.mjs`: 23 pass.
- The inventory assertion added in #200 keeps the list move honest: tailwind.md is in exactly one list, and dropping it from both would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)