### PR TITLE
fix(security): ignore the unfixable image-size DoS advisories

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,4 +1,33 @@
 # osv-scanner ignore list.
-# (GHSA-h67p-54hq-rp68 removed 2026-08-04: js-yaml transitive is now pinned to
-#  3.15.1 / 4.3.1 via pnpm.overrides, which osv-scanner no longer flags — the
-#  earlier 'no 3.x patch' rationale is obsolete.)
+#
+# Entries here suppress a finding that `fail-on-vuln: true` would otherwise turn
+# into a merge block on every PR. Each one needs a reason and an expiry — an
+# ignore without a date silently becomes permanent.
+
+[[IgnoredVulns]]
+id = "GHSA-5p2g-fcmc-qvqq"
+ignoreUntil = 2026-11-07
+reason = """
+image-size 2.0.2: denial of service via infinite loops in the JXL and HEIF
+parsers (CVE-2025-71329, HIGH). No fixed version exists — OSV reports
+`fixed: []` with `last_affected: 2.0.2`, which is also the latest release on
+npm, so there is nothing to upgrade or override to.
+
+Not reachable by anyone installing Kalyx: `pnpm why image-size --filter
+'@kalyx/*'` returns nothing. It arrives only through
+@docusaurus/mdx-loader in `apps/docs-site`, which is private and never
+published. Exploiting it would mean committing a malformed JXL or HEIF file to
+this repository and waiting for a docs build to hang — a self-inflicted CI
+outage, not exposure for library consumers.
+
+Revisit when image-size ships a fix or Docusaurus moves off it.
+"""
+
+[[IgnoredVulns]]
+id = "GHSA-w3rx-r6r6-pgpr"
+ignoreUntil = 2026-11-07
+reason = """
+image-size 2.0.2: denial of service via an infinite loop in the ICNS parser
+(CVE-2025-71330, HIGH). Same dependency, same reachability and same absence of a
+fix as GHSA-5p2g-fcmc-qvqq above.
+"""


### PR DESCRIPTION
**This unblocks every PR.** Right now `main` is closed: two advisories were published against `image-size@2.0.2` today, and with the OSV job promoted to a required check (C-2) they fail on every pull request regardless of what it changes.

| | |
|---|---|
| CVE-2025-71329 / GHSA-5p2g-fcmc-qvqq | DoS — infinite loops in the JXL and HEIF parsers. HIGH |
| CVE-2025-71330 / GHSA-w3rx-r6r6-pgpr | DoS — infinite loop in the ICNS parser. HIGH |

## There is no version to upgrade to

OSV reports `fixed: []` and `last_affected: 2.0.2` for both, and `2.0.2` is the latest release on npm. Neither a dependency bump nor a `pnpm.overrides` pin can resolve this — the fix does not exist yet.

## It does not reach anyone installing Kalyx

```
$ pnpm why image-size --filter '@kalyx/*'
(no output)
```

It arrives only through `@docusaurus/mdx-loader` in `apps/docs-site`, which is `private: true` and never published. Exploiting it means committing a malformed JXL, HEIF or ICNS file to this repository and hanging our own docs build — a self-inflicted CI outage, not exposure for library consumers. That is what makes an ignore defensible here rather than merely convenient.

## Scoped, not blanket

Ignored **until 2026-11-07** with the full reasoning inline, so it gets revisited when image-size ships a fix or Docusaurus moves off it. The file header now states the rule: an ignore without an expiry silently becomes permanent.

## Note on C-2

This is the first real exercise of the failure surface #197's description called out — *"a newly published advisory against any pinned dependency now blocks all PRs, not just dependency-touching ones."* That is working as intended; it surfaced within hours. The trade is that unfixable advisories in dev-only tooling now need an explicit, dated decision like this one.

It also confirms the promotion end to end: #203 reached `mergeable_state=blocked`, not `pending`, which means the required check matched on `OSV Vulnerability Scan / osv-scan` and genuinely gated the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)