### PR TITLE
docs: stop documenting form submission on pickers that lack it

### DIFF
--- a/apps/docs-site/docs/components/monthpicker.md
+++ b/apps/docs-site/docs/components/monthpicker.md
@@ -197,16 +197,17 @@ function DisabledMonthPicker() {
 For simple forms where you don't need React state:
 
 ```tsx
-<form action="/api/save" method="post">
-  <MonthPicker name="billingMonth" defaultValue="2026-04-01T00:00:00.000Z">
-    <MonthPicker.Input />
-    <MonthPicker.Popover>
-      <MonthPicker.Grid />
-    </MonthPicker.Popover>
-  </MonthPicker>
-  <button type="submit">Save</button>
-</form>
+<MonthPicker defaultValue="2026-04-01T00:00:00.000Z">
+  <MonthPicker.Input />
+  <MonthPicker.Popover>
+    <MonthPicker.Grid />
+  </MonthPicker.Popover>
+</MonthPicker>
 ```
+
+Unlike `DatePicker`, this picker has no native form-submission support: there is
+no `name` prop and nothing renders a hidden input. To submit the value, keep it
+in state via `onChange` and render your own `<input type="hidden">`.
 
 ## Event callbacks
 

--- a/apps/docs-site/docs/components/weekpicker.md
+++ b/apps/docs-site/docs/components/weekpicker.md
@@ -190,17 +190,18 @@ Restrict selectable weeks. Any `DisabledRule` that matches at least one day in a
 ## Uncontrolled
 
 ```tsx
-<form action="/api/save" method="post">
-  <WeekPicker name="sprintWeek" defaultValue={{ start: '2026-04-13T00:00:00.000Z', end: '2026-04-19T00:00:00.000Z' }}>
-    <WeekPicker.Input part="start" />
-    <WeekPicker.Input part="end" />
-    <WeekPicker.Popover>
-      <WeekPicker.Calendar />
-    </WeekPicker.Popover>
-  </WeekPicker>
-  <button type="submit">Save</button>
-</form>
+<WeekPicker defaultValue={{ start: '2026-04-13T00:00:00.000Z', end: '2026-04-19T00:00:00.000Z' }}>
+  <WeekPicker.Input part="start" />
+  <WeekPicker.Input part="end" />
+  <WeekPicker.Popover>
+    <WeekPicker.Calendar />
+  </WeekPicker.Popover>
+</WeekPicker>
 ```
+
+Unlike `DatePicker`, this picker has no native form-submission support: there is
+no `name` prop and nothing renders a hidden input. To submit the value, keep it
+in state via `onChange` and render your own `<input type="hidden">`.
 
 ## Timezone
 

--- a/apps/docs-site/docs/components/yearpicker.md
+++ b/apps/docs-site/docs/components/yearpicker.md
@@ -182,16 +182,17 @@ function DisabledYearPicker() {
 ## Uncontrolled
 
 ```tsx
-<form action="/api/save" method="post">
-  <YearPicker name="taxYear" defaultValue="2026-01-01T00:00:00.000Z">
-    <YearPicker.Input />
-    <YearPicker.Popover>
-      <YearPicker.Grid />
-    </YearPicker.Popover>
-  </YearPicker>
-  <button type="submit">Save</button>
-</form>
+<YearPicker defaultValue="2026-01-01T00:00:00.000Z">
+  <YearPicker.Input />
+  <YearPicker.Popover>
+    <YearPicker.Grid />
+  </YearPicker.Popover>
+</YearPicker>
 ```
+
+Unlike `DatePicker`, this picker has no native form-submission support: there is
+no `name` prop and nothing renders a hidden input. To submit the value, keep it
+in state via `onChange` and render your own `<input type="hidden">`.
 
 ## Event callbacks
 

--- a/apps/docs-site/docs/concepts/ssr.md
+++ b/apps/docs-site/docs/concepts/ssr.md
@@ -76,8 +76,8 @@ In SSR, the initial render has no user interaction yet. Start with either `defau
 
 ```tsx
 {/* Uncontrolled — good for forms */}
-<DatePicker name="checkIn" defaultValue="2026-04-15T00:00:00.000Z">
-  <DatePicker.Input />
+<DatePicker defaultValue="2026-04-15T00:00:00.000Z">
+  <DatePicker.Input name="checkIn" />
 </DatePicker>
 
 {/* Controlled with null — good for optional fields */}

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/monthpicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/monthpicker.md
@@ -107,16 +107,17 @@ Restrict selectable months using the same `DisabledRule` syntax as `DatePicker`.
 For simple forms where you don't need React state:
 
 ```tsx
-<form action="/api/save" method="post">
-  <MonthPicker name="billingMonth" defaultValue="2026-04-01T00:00:00.000Z">
-    <MonthPicker.Input />
-    <MonthPicker.Popover>
-      <MonthPicker.Grid />
-    </MonthPicker.Popover>
-  </MonthPicker>
-  <button type="submit">Save</button>
-</form>
+<MonthPicker defaultValue="2026-04-01T00:00:00.000Z">
+  <MonthPicker.Input />
+  <MonthPicker.Popover>
+    <MonthPicker.Grid />
+  </MonthPicker.Popover>
+</MonthPicker>
 ```
+
+`DatePicker` 와 달리 이 피커는 네이티브 폼 제출을 지원하지 않는다 — `name` prop 이
+없고 hidden input 도 렌더하지 않는다. 값을 제출하려면 `onChange` 로 상태에 담아
+직접 `<input type="hidden">` 을 렌더한다.
 
 ## Event callbacks
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/weekpicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/weekpicker.md
@@ -96,17 +96,18 @@ Restrict selectable weeks. Any `DisabledRule` that matches at least one day in a
 ## Uncontrolled
 
 ```tsx
-<form action="/api/save" method="post">
-  <WeekPicker name="sprintWeek" defaultValue={{ start: '2026-04-13T00:00:00.000Z', end: '2026-04-19T00:00:00.000Z' }}>
-    <WeekPicker.Input part="start" />
-    <WeekPicker.Input part="end" />
-    <WeekPicker.Popover>
-      <WeekPicker.Calendar />
-    </WeekPicker.Popover>
-  </WeekPicker>
-  <button type="submit">Save</button>
-</form>
+<WeekPicker defaultValue={{ start: '2026-04-13T00:00:00.000Z', end: '2026-04-19T00:00:00.000Z' }}>
+  <WeekPicker.Input part="start" />
+  <WeekPicker.Input part="end" />
+  <WeekPicker.Popover>
+    <WeekPicker.Calendar />
+  </WeekPicker.Popover>
+</WeekPicker>
 ```
+
+`DatePicker` 와 달리 이 피커는 네이티브 폼 제출을 지원하지 않는다 — `name` prop 이
+없고 hidden input 도 렌더하지 않는다. 값을 제출하려면 `onChange` 로 상태에 담아
+직접 `<input type="hidden">` 을 렌더한다.
 
 ## Timezone
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/yearpicker.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/components/yearpicker.md
@@ -92,16 +92,17 @@ Restrict selectable years. Rules are evaluated against January 1 of each year.
 ## Uncontrolled
 
 ```tsx
-<form action="/api/save" method="post">
-  <YearPicker name="taxYear" defaultValue="2026-01-01T00:00:00.000Z">
-    <YearPicker.Input />
-    <YearPicker.Popover>
-      <YearPicker.Grid />
-    </YearPicker.Popover>
-  </YearPicker>
-  <button type="submit">Save</button>
-</form>
+<YearPicker defaultValue="2026-01-01T00:00:00.000Z">
+  <YearPicker.Input />
+  <YearPicker.Popover>
+    <YearPicker.Grid />
+  </YearPicker.Popover>
+</YearPicker>
 ```
+
+`DatePicker` 와 달리 이 피커는 네이티브 폼 제출을 지원하지 않는다 — `name` prop 이
+없고 hidden input 도 렌더하지 않는다. 값을 제출하려면 `onChange` 로 상태에 담아
+직접 `<input type="hidden">` 을 렌더한다.
 
 ## Event callbacks
 

--- a/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/ssr.md
+++ b/apps/docs-site/i18n/ko/docusaurus-plugin-content-docs/current/concepts/ssr.md
@@ -76,8 +76,8 @@ SSR 첫 렌더에는 아직 사용자 상호작용이 없습니다. `defaultValu
 
 ```tsx
 {/* 비제어 — 폼에 적합 */}
-<DatePicker name="checkIn" defaultValue="2026-04-15T00:00:00.000Z">
-  <DatePicker.Input />
+<DatePicker defaultValue="2026-04-15T00:00:00.000Z">
+  <DatePicker.Input name="checkIn" />
 </DatePicker>
 
 {/* null 제어 — 선택 필드에 적합 */}

--- a/scripts/check-doc-code-examples.mjs
+++ b/scripts/check-doc-code-examples.mjs
@@ -61,24 +61,15 @@ const EN_ONLY_DOCUMENTS = [
   ['concepts/timezone.md', 'KO fence content has drifted from EN'],
   ['recipes/use-cases.md', 'KO fence content has drifted from EN'],
   ['recipes/tailwind.md', 'KO fence content has drifted from EN'],
+  ['components/monthpicker.md', 'KO has one fewer executable fence'],
+  ['components/yearpicker.md', 'KO has one fewer executable fence'],
 ];
 
 // Not compiled, with the reason each one fails. This list is the difference
 // between "the documentation is verified" and what this script actually proves,
 // so keep it accurate — and prefer fixing an entry to explaining it.
-//
-// Three of these are real defects awaiting a decision rather than checker
-// limitations, and are called out as DEFECT below.
 const UNCHECKED_DOCUMENTS = [
-  // DEFECT: documents `name` on a picker Root for native form submission. Only
-  // `DatePicker.Input` implements that (via a hidden input); MonthPicker,
-  // YearPicker, WeekPicker, RangePicker and DateTimePicker have no
-  // form-submission support at all, so these sections promise a feature that
-  // does not exist. Fixing needs a product call: implement `name` on those
-  // Inputs, or delete the sections.
-  ['components/monthpicker.md', 'DEFECT: `name` on Root — no form-submission support on MonthPicker'],
-  ['components/yearpicker.md', 'DEFECT: `name` on Root — no form-submission support on YearPicker'],
-  ['components/weekpicker.md', 'DEFECT: `name` on Root — no form-submission support on WeekPicker'],
+  ['components/weekpicker.md', 'a fence uses `{/* ... */}` as children, which JSX treats as none'],
   // Anatomy trees render `<DatePicker.Preset />` and `<RangePicker.Preset />`
   // self-closing, but `children` is required on both.
   ['components/datepicker.md', 'anatomy fences self-close components whose `children` is required'],


### PR DESCRIPTION
Resolves the `DEFECT` entries recorded in #200, taking the **delete-the-claim** option rather than implementing `name` on four more Inputs.

## What was wrong

MonthPicker, YearPicker and WeekPicker each documented an uncontrolled example wrapped in `<form action="/api/save">`, with `name` on the Root and a submit button. None of it works:

```
$ grep -rl 'type="hidden"' packages/react/src/components/
packages/react/src/components/DatePicker/Input.tsx
```

`name` is not a prop on those Roots, and nothing renders a field for the value to travel through. RangePicker and DateTimePicker have no support either — `DatePicker.Input` is the only place it exists.

## Only the false part was removed

Deleting each whole `## Uncontrolled` section would have thrown away accurate documentation: uncontrolled mode via `defaultValue` genuinely works. So the examples keep `defaultValue` and lose the `<form>` wrapper, the `name` and the submit button, and each page now says plainly:

> Unlike `DatePicker`, this picker has no native form-submission support: there is no `name` prop and nothing renders a hidden input. To submit the value, keep it in state via `onChange` and render your own `<input type="hidden">`.

`concepts/ssr.md` carried the same shape on `DatePicker`, which **does** support this — there the fix is moving `name` onto `DatePicker.Input`, not removing it.

## Coverage moved as a result

With the invalid props gone, monthpicker and yearpicker compile clean in both locales and move `UNCHECKED_DOCUMENTS` → `EN_ONLY_DOCUMENTS` (their KO pages are one fence behind, so byte-exact parity cannot be enforced yet).

weekpicker stays unchecked, but its reason is corrected from the now-fixed `name` defect to the real remaining cause: a fence using `{/* ... */}` as children, which JSX treats as no children at all. Left alone as a deliberate placeholder.

**112 examples across 15 documents**, up from 97 across 13.

## Verification

- `pnpm check-doc-examples` → `✓ Compiled 112 TypeScript examples across 15 documents (24 pages deliberately unchecked)`. The inventory assertion from #200 enforces that every one of those 24 is still named with a reason.
- `scripts/__tests__/check-doc-code-examples.test.mjs`: 23 pass.
- docs-site builds clean in **en and ko** after `docusaurus clear`.
- No source changes — this is documentation and checker configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)