### PR TITLE
docs(core): fix getWeekStartForLocale JSDoc listing ko-KR as Monday-first

### DIFF
--- a/packages/core/src/utils/locale.ts
+++ b/packages/core/src/utils/locale.ts
@@ -102,8 +102,8 @@ const weekStartCache = new Map<string, WeekStartsOn>();
  * Infers the locale's first day of the week as a {@link WeekStartsOn} (0 = Sunday, 1 = Monday).
  *
  * Reads `Intl.Locale(locale).weekInfo.firstDay` (1 = Monday … 7 = Sunday). Since the public
- * `WeekStartsOn` surface is `0 | 1`, Sunday-first locales (firstDay 7, e.g. en-US, ja-JP) map to
- * `0` and every other locale maps to `1` (e.g. ko-KR, en-GB, de-DE). Falls back to `0` when the
+ * `WeekStartsOn` surface is `0 | 1`, Sunday-first locales (firstDay 7, e.g. en-US, ja-JP, ko-KR)
+ * map to `0` and every other locale maps to `1` (e.g. en-GB, de-DE). Falls back to `0` when the
  * runtime lacks `weekInfo` (older engines) or the locale tag is unparseable.
  *
  * @param locale BCP 47 locale string (e.g. "en-US", "ko-KR")


### PR DESCRIPTION
## Summary

The `getWeekStartForLocale` JSDoc in `packages/core/src/utils/locale.ts` listed **ko-KR** as an example of a locale mapping to `1` (Monday-first). This contradicts both the code and the tests: `new Intl.Locale('ko-KR').getWeekInfo().firstDay === 7` (Sunday), so the function returns `0`, and `packages/core/src/__tests__/locale.test.ts` pins `expect(getWeekStartForLocale('ko-KR')).toBe(0)`.

This PR moves ko-KR to the Sunday-first example list and keeps only locales that actually return `1` (en-GB, de-DE) as Monday-first examples. No code logic changes.

## Type

- [x] `docs` — Documentation only

## Changes

- `packages/core/src/utils/locale.ts`: corrected the JSDoc example locales for `getWeekStartForLocale` (comment-only, 2 lines)

## Test plan

- Verified at runtime with Node: `new Intl.Locale('ko-KR').getWeekInfo().firstDay` → `7` (Sunday) → function returns `0`; en-GB/de-DE → `1`
- Existing test `packages/core/src/__tests__/locale.test.ts:99` already asserts `getWeekStartForLocale('ko-KR') === 0`
- Test suite not re-run locally (JSDoc-only change, no dependencies installed in this worktree)

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` succeeds
- [ ] Bundle size checked (`pnpm check-bundle` — default entry ≤ 20 KB, headless ≤ 22 KB gzip)
- [ ] Changeset added (if public API changed) — N/A, comment-only
- [x] New public APIs have JSDoc comments — existing JSDoc corrected
- [ ] Accessibility: axe passes, keyboard navigation works — N/A
- [ ] SSR: no `window`/`document` outside `useEffect` — N/A
- [ ] If the change touches date/time math, `displayTimezone` behavior verified — N/A (comment only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)