### PR TITLE
chore: sentry MCP를 프로젝트 스코프로 이동

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}


### PR DESCRIPTION
전역(user 스코프)에 등록돼 있던 sentry MCP 서버를 이 저장소의 `.mcp.json` 으로 내린다.

## 배경

개인 Claude Code 설정을 정리하면서, 388개 세션의 실제 도구 호출량을 세어보니 sentry MCP 호출 270건이 **전부 이 저장소와 jihoon-blog 작업**이었다. 전역에 두면 sentry 를 쓰지 않는 모든 프로젝트에서도 로드된다.

## 변경

`.mcp.json` 한 파일 추가:

```json
{ "mcpServers": { "sentry": { "type": "http", "url": "https://mcp.sentry.dev/mcp" } } }
```

## 기여자에게 미치는 영향

이 저장소를 여는 사람에게 sentry MCP 서버 승인 프롬프트가 뜬다. 거절해도 빌드·테스트·개발에 아무 영향이 없다 — 로컬 개발 도구 설정일 뿐이며 CI 나 패키지 산출물과는 무관하다.

시크릿은 포함하지 않는다 (OAuth 로 인증).