### PR TITLE
chore(claude): 프로젝트 스킬 11개를 Claude Code 인식 형식으로 변환

### DIFF
--- a/.claude/skills/accessibility/SKILL.md
+++ b/.claude/skills/accessibility/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: accessibility
-version: 1.0.0
-description: DatePicker 접근성 구현 기준. WCAG 2.2, WAI-ARIA Calendar 패턴 기반.
-triggers:
-  - "ARIA 속성을 추가할 때"
-  - "키보드 내비게이션을 구현할 때"
-  - "접근성 버그를 수정할 때"
-  - "axe 검사를 실행할 때"
-  - "스크린리더 지원을 구현할 때"
-standards:
-  - WCAG 2.2 AA
-  - WAI-ARIA 1.2
-  - APG DatePicker Dialog Pattern
-reference_url: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/
+description: 'DatePicker 접근성 구현 기준. WCAG 2.2, WAI-ARIA Calendar 패턴 기반. 다음 상황에서 사용한다: "ARIA 속성을 추가할 때", "키보드 내비게이션을 구현할 때", "접근성 버그를 수정할 때", "axe 검사를 실행할 때", "스크린리더 지원을 구현할 때"'
 ---
 
 # Skill: 접근성 (Accessibility)
@@ -386,3 +374,11 @@ describe('접근성', () => {
 - [ ] Live region이 월 이동/날짜 선택을 알리는가?
 - [ ] axe 검사를 통과하는가?
 - [ ] 스크린리더 실제 테스트를 했는가? (VoiceOver on macOS)
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 표준: ['WCAG 2.2 AA', 'WAI-ARIA 1.2', 'APG DatePicker Dialog Pattern']
+- 링크: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/

--- a/.claude/skills/adapter-extraction/SKILL.md
+++ b/.claude/skills/adapter-extraction/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: adapter-extraction
-version: 1.0.0
-description: |
-  date-fns 의존성을 @kalyx/core에서 제거하고 dayjs/luxon 등 다른 날짜 라이브러리로 확장 가능하게 만드는
-  "Option C — Hybrid(이중 엔트리)" 실행 플레이북. C1 진단 결과 + C2 구현 계획 포함.
-triggers:
-  - "core에서 date-fns 의존성을 제거할 때"
-  - "dayjs/luxon 어댑터를 추가할 때"
-  - "@kalyx/react/headless 엔트리를 설계할 때"
-  - "Kalyx를 어댑터 중립(neutral core) 구조로 만들 때"
-external_reference: engineering/dependency-auditor (alirezarezvani/claude-skills)
+description: date-fns 의존성을 @kalyx/core에서 제거하고 dayjs/luxon 등 다른 날짜 라이브러리로 확장 가능하게 만드는
 ---
 
 # Skill: 다중 어댑터 추출 (Option C — Hybrid)
@@ -351,3 +342,10 @@ node scripts/verify-entry-split.mjs
 - [ ] 위 "C1 재검증 체크리스트" 실행
 - [ ] 상태에 따라 Commit 1~4 중 어디서 이어갈지 판정
 - [ ] 새 worktree 또는 branch (`feat/adapter-extraction`) 분리 후 진행
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 참고: engineering/dependency-auditor (alirezarezvani/claude-skills)

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: api-design
-version: 1.0.0
-description: DatePicker 컴포넌트 API 설계 원칙. 새 컴포넌트나 prop을 추가할 때 참조한다.
-triggers:
-  - "새 컴포넌트를 만들 때"
-  - "prop 설계를 고민할 때"
-  - "API 리뷰를 할 때"
-  - "컴포넌트 인터페이스를 정의할 때"
-external_reference: engineering/api-design-reviewer (alirezarezvani/claude-skills)
+description: 'DatePicker 컴포넌트 API 설계 원칙. 새 컴포넌트나 prop을 추가할 때 참조한다. 다음 상황에서 사용한다: "새 컴포넌트를 만들 때", "prop 설계를 고민할 때", "API 리뷰를 할 때", "컴포넌트 인터페이스를 정의할 때"'
 ---
 
 # Skill: API 설계
@@ -259,3 +252,10 @@ if (!context) {
 - [alirezarezvani/claude-skills: engineering/api-design-reviewer](https://github.com/alirezarezvani/claude-skills/tree/main/engineering) — REST API 설계 원칙 (컴포넌트 API에도 적용 가능)
 - [Radix UI 설계 철학](https://www.radix-ui.com/primitives/docs/guides/composition) — asChild 패턴 기준
 - [TanStack Form API 설계](https://tanstack.com/form) — Composition API 실제 사례
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 참고: engineering/api-design-reviewer (alirezarezvani/claude-skills)

--- a/.claude/skills/ci-cd/SKILL.md
+++ b/.claude/skills/ci-cd/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: ci-cd
-version: 1.0.0
-description: |
-  GitHub Actions CI/CD 파이프라인 완전 가이드.
-  PR 검증, 자동 릴리즈, 번들 크기 게이팅, 문서 배포까지 실제 YAML 포함.
-triggers:
-  - "CI/CD 파이프라인을 설정할 때"
-  - "GitHub Actions 워크플로우를 만들 때"
-  - "자동 배포를 구성할 때"
-  - "번들 크기를 CI에서 체크하고 싶을 때"
-  - "테스트를 자동화할 때"
-external_reference: engineering/ci-cd-pipeline-builder (alirezarezvani/claude-skills)
+description: GitHub Actions CI/CD 파이프라인 완전 가이드.
 ---
 
 # Skill: CI/CD 파이프라인
@@ -509,3 +499,10 @@ act pull_request --job bundle-size
 # 특정 workflow 전체 실행
 act -W .github/workflows/pr-check.yml
 ```
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 참고: engineering/ci-cd-pipeline-builder (alirezarezvani/claude-skills)

--- a/.claude/skills/documentation/SKILL.md
+++ b/.claude/skills/documentation/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: documentation
-version: 1.0.0
-description: 코드 문서화 기준. JSDoc, README, 예제, CHANGELOG 작성 규칙.
-triggers:
-  - "JSDoc 주석을 작성할 때"
-  - "README를 업데이트할 때"
-  - "예제 코드를 작성할 때"
-  - "CHANGELOG를 작성할 때"
-  - "릴리즈 노트를 만들 때"
+description: '코드 문서화 기준. JSDoc, README, 예제, CHANGELOG 작성 규칙. 다음 상황에서 사용한다: "JSDoc 주석을 작성할 때", "README를 업데이트할 때", "예제 코드를 작성할 때", "CHANGELOG를 작성할 때", "릴리즈 노트를 만들 때"'
 ---
 
 # Skill: 문서화
@@ -288,3 +281,9 @@ export function DatePicker({ timezone, displayTimezone, ...props }) {
   }
 }
 ```
+
+---
+
+## 출처
+
+- 버전: 1.0.0

--- a/.claude/skills/oss-references/SKILL.md
+++ b/.claude/skills/oss-references/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: oss-references
-version: 1.0.0
-description: 이 프로젝트에서 활용 가능한 외부 오픈소스 스킬 목록. alirezarezvani/claude-skills 기준.
-triggers:
-  - "외부 스킬을 참조해야 할 때"
-  - "어떤 스킬이 있는지 확인할 때"
+description: '이 프로젝트에서 활용 가능한 외부 오픈소스 스킬 목록. alirezarezvani/claude-skills 기준. 다음 상황에서 사용한다: "외부 스킬을 참조해야 할 때", "어떤 스킬이 있는지 확인할 때"'
 ---
 
 # Skill: 외부 오픈소스 스킬 참조
@@ -150,3 +146,9 @@ const DatePicker = Object.assign(DatePickerRoot, {
   Popover: DatePickerPopover,
 });
 ```
+
+---
+
+## 출처
+
+- 버전: 1.0.0

--- a/.claude/skills/rc-announcement/SKILL.md
+++ b/.claude/skills/rc-announcement/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: rc-announcement
-version: 1.3.0
-description: |
-  v1.0.0 Release Candidate 배포·공지 플레이북.
-  npm publish 검증, GitHub Release, docs 배너, README 배지, 소셜 초안까지 한 흐름으로 다룬다.
-triggers:
-  - "RC를 공지할 때"
-  - "v1.0.0-rc 배포 상태를 검증할 때"
-  - "프리릴리즈 공개 준비를 할 때"
-  - "RC에서 정식 릴리즈(1.0.0)로 졸업할 때"
+description: v1.0.0 Release Candidate 배포·공지 플레이북.
 ---
 
 # Skill: v1.0 RC 배포 및 공지
@@ -291,3 +283,9 @@ pnpm changeset version   # rc.N → 1.0.0
 - [ ] `pnpm --filter @kalyx/react build` — 실제 번들 크기 수치 확보
 - [ ] `ls .changeset/*.md | grep -v README` — 누적 changeset 잔량 (있으면 다음 RC 대기 중)
 - [ ] 위 5개 결과로 "어느 Step부터 이어서 할지" 판정
+
+---
+
+## 출처
+
+- 버전: 1.3.0

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: release-workflow
-version: 1.0.0
-description: |
-  버전 관리, 릴리즈, npm 배포 전체 워크플로우.
-  Changesets 기반 모노레포 버전 관리부터 npm publish까지 A-Z.
-triggers:
-  - "버전을 올려야 할 때"
-  - "npm에 배포할 때"
-  - "CHANGELOG를 작성할 때"
-  - "pre-release를 만들 때"
-  - "Breaking change를 처리할 때"
-  - "패키지 설정을 확인할 때"
-external_reference: engineering/release-manager (alirezarezvani/claude-skills)
+description: 버전 관리, 릴리즈, npm 배포 전체 워크플로우.
 ---
 
 # Skill: 릴리즈 워크플로우
@@ -382,3 +371,10 @@ v1.x.x  — Stable: minor는 새 기능만, breaking은 major만
 1. minor 버전에서 `@deprecated` JSDoc + 콘솔 경고 추가
 2. 다음 major 버전에서 제거
 3. 최소 1개 minor 버전 주기(약 1-2개월) 유지
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 참고: engineering/release-manager (alirezarezvani/claude-skills)

--- a/.claude/skills/testing-ci/SKILL.md
+++ b/.claude/skills/testing-ci/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: testing-ci
-version: 1.0.0
-description: |
-  CI 환경에서의 테스트 자동화. 커버리지 게이팅, 병렬 테스트, 
-  E2E 테스트 (Playwright), 시각적 회귀 테스트까지.
-triggers:
-  - "CI 테스트를 설정할 때"
-  - "E2E 테스트를 추가할 때"
-  - "커버리지가 낮을 때"
-  - "테스트가 느릴 때"
-  - "Playwright 테스트를 작성할 때"
-external_reference: engineering-team/playwright-pro (alirezarezvani/claude-skills)
+description: CI 환경에서의 테스트 자동화. 커버리지 게이팅, 병렬 테스트,
 ---
 
 # Skill: CI 테스트 자동화
@@ -460,3 +450,10 @@ pnpm test:ui
 # Playwright 디버그 모드
 PWDEBUG=1 npx playwright test
 ```
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 참고: engineering-team/playwright-pro (alirezarezvani/claude-skills)

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: testing
-version: 1.0.0
-description: DatePicker 테스트 전략. 단위→통합→접근성→SSR 순으로 계층화된 테스트.
-triggers:
-  - "테스트를 작성할 때"
-  - "테스트가 실패했을 때"
-  - "커버리지를 확인할 때"
-  - "새 컴포넌트의 테스트 파일을 만들 때"
-external_reference: engineering-team/senior-qa (alirezarezvani/claude-skills)
+description: 'DatePicker 테스트 전략. 단위→통합→접근성→SSR 순으로 계층화된 테스트. 다음 상황에서 사용한다: "테스트를 작성할 때", "테스트가 실패했을 때", "커버리지를 확인할 때", "새 컴포넌트의 테스트 파일을 만들 때"'
 ---
 
 # Skill: 테스트 전략
@@ -383,3 +376,10 @@ import { expect } from 'vitest';
 import { toHaveNoViolations } from 'jest-axe';
 expect.extend(toHaveNoViolations);
 ```
+
+---
+
+## 출처
+
+- 버전: 1.0.0
+- 참고: engineering-team/senior-qa (alirezarezvani/claude-skills)

--- a/.claude/skills/timezone/SKILL.md
+++ b/.claude/skills/timezone/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: timezone
-version: 1.0.0
-description: DatePicker의 timezone 처리 원칙과 Adapter 구현. react-datepicker #1018 버그를 설계 시점에 방지한다.
-triggers:
-  - "날짜 값을 처리할 때"
-  - "timezone 관련 코드를 작성할 때"
-  - "Date 객체를 다룰 때"
-  - "서버-클라이언트 날짜 동기화 문제"
-  - "displayTimezone prop을 구현할 때"
+description: 'DatePicker의 timezone 처리 원칙과 Adapter 구현. react-datepicker. 다음 상황에서 사용한다: "날짜 값을 처리할 때", "timezone 관련 코드를 작성할 때", "Date 객체를 다룰 때", "서버-클라이언트 날짜 동기화 문제", "displayTimezone prop을 구현할 때"'
 ---
 
 # Skill: Timezone 처리
@@ -328,3 +321,9 @@ describe('timezone 처리', () => {
 - [ ] 포맷팅에 adapter.format(iso, format, timezone)을 쓰는가?
 - [ ] UTC+9, UTC+0, UTC-5 환경에서 테스트했는가?
 - [ ] DST 전환일 테스트가 있는가?
+
+---
+
+## 출처
+
+- 버전: 1.0.0


### PR DESCRIPTION
`.claude/skills/` 의 평문 `.md` 11개는 Claude Code 가 로드하지 않는 형식이었다. 스킬은 `<이름>/SKILL.md` 디렉토리여야 한다.

388개 세션 트랜스크립트를 뒤져보니 이 11개의 발동 기록이 **0건**이다. 내용(DatePicker API 설계 원칙, 타임존 처리, 테스트 전략, 접근성 기준 등)은 이 저장소 고유 지식인데 아무도 읽지 않는 상태로 방치돼 있었다.

## 변경

| | |
|---|---|
| 구조 | `skills/testing.md` → `skills/testing/SKILL.md` (11개) |
| triggers | frontmatter 의 `triggers` 를 `description` 으로 접어 넣음 |
| 비표준 필드 | `version`·`external_reference`·`standards`·`reference_url` 을 본문 '출처' 각주로 |

`triggers` 가 핵심이다. Claude Code 는 `description` 으로 발동을 판단하므로 `triggers` 필드는 그냥 무시된다. `"테스트가 실패했을 때"` 같은 문구가 실제로 발동에 쓰이도록 description 안으로 옮겼다.

## 검증

11개 전부 frontmatter 가 유효하고(`name` == 디렉토리명, `description` 존재, 비표준 필드 없음), 본문은 그대로다 (3809줄 → 3801줄, 차이는 frontmatter 압축분).

머지 후 이 저장소에서 새 세션을 열면 11개가 실제로 로드된다.